### PR TITLE
boilerplate comment is not mandatory

### DIFF
--- a/linter/linter.go
+++ b/linter/linter.go
@@ -491,7 +491,7 @@ func (l *Linter) lintFastlyBoilerPlateMacro(sub *ast.SubroutineDeclaration, phra
 
 	// Macro not found
 	err := &LintError{
-		Severity: ERROR,
+		Severity: WARNING,
 		Token:    sub.GetMeta().Token,
 		Message: fmt.Sprintf(
 			`Subroutine "%s" does not have fastly boilerplate comment "%s" inside definition`, sub.Name.Value, phrase,


### PR DESCRIPTION
https://developer.fastly.com/reference/vcl/subroutines/#concatenation

> Built-in subroutines with the same name are automatically concatenated in the order the compiler encounters them.

There are valid use cases to not include Fastly's code macros if it's intended to be concatenated. Therefore, Severity should be WARNING.