### PR TITLE
Override severity via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Example:
 ```
 
 ### Note:
-Youe VCL will have dependent modules and loaded via `include [module]`. `falco` accept include path from `-I, --include_path` flag and search and load destination module from include path.
+Your VCL will have dependent modules and loaded via `include [module]`. `falco` accept include path from `-I, --include_path` flag and search and load destination module from include path.
 
 ## User defined subroutine
 
@@ -133,7 +133,21 @@ However, we're planning to solve them using Fastly API.
 
 ## Lint error
 
-`falco` has builtin lint rules. see [rules](https://github.com/ysugimoto/falco/blob/main/docs/rules.md) in detail.
+`falco` has builtin lint rules. see [rules](https://github.com/ysugimoto/falco/blob/main/docs/rules.md) in detail. `falco` may report lots of errors and warnings because falco lints strct type checks, disallows implicit type conversions event VCL is fuzzy typed language. 
+
+## Overriding Severity
+
+To avoid them, you can override severity levels by putting configuration file named `.falcorc` on working directory. the configuration file contents format is following:
+
+```yaml
+## /path/to/working/directory/.falcorc
+regex/matched-value-override: IGNORE
+...
+```
+
+Format is simply yaml key-value object. The key is rule name, see [rules.md](https://github.com/ysugimoto/falco/blob/main/docs/rules.md) and value should be one of `IGNORE`, `INFO`, `WARGNING` and `ERROR`, case insensitive.
+
+On above case, the rule of `regex/matched-value-override` reports `INFO` as default, but override to `IGNORE` which does not report it.
 
 ## Error Levels
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ However, we're planning to solve them using Fastly API.
 
 ## Lint error
 
-`falco` has builtin lint rules. see [rules](https://github.com/ysugimoto/falco/blob/main/docs/rules.md) in detail. `falco` may report lots of errors and warnings because falco lints strct type checks, disallows implicit type conversions event VCL is fuzzy typed language. 
+`falco` has builtin lint rules. see [rules](https://github.com/ysugimoto/falco/blob/main/docs/rules.md) in detail. `falco` may report lots of errors and warnings because falco lints with strict type checks, disallows implicit type conversions even VCL is fuzzy typed language. 
 
 ## Overriding Severity
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Typically our deployment flow using custom VCLs is following:
 1. Clone active service and create new version
 2. Delete existing custom VCLs
 3. Upload new VCL files to the Fastly
-4. Activate new sevice version // <= Validate VCLs on the Fastly cloud
+4. Activate new sevice version **<= Validate VCLs on the Fastly cloud**
 
 Above flows take a time, and then if we have some mistakes on VCL e.g. missing semicolon X(, the deployment will fail.
 Additionally, unnecessary service version will be created by our trivial issue.

--- a/linter/errors.go
+++ b/linter/errors.go
@@ -15,6 +15,7 @@ const (
 	WARNING Severity = "Warning"
 	ERROR   Severity = "Error"
 	INFO    Severity = "Info"
+	IGNORE  Severity = "Ignore"
 )
 
 type LintError struct {

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -813,7 +813,7 @@ func (l *Linter) lintIfStatement(stmt *ast.IfStatement, ctx *context.Context) ty
 	// push regex captured variables
 	if err := pushRegexGroupVars(stmt.Condition, ctx); err != nil {
 		err := &LintError{
-			Severity: WARNING,
+			Severity: INFO,
 			Token:    stmt.Condition.GetMeta().Token,
 			Message:  err.Error(),
 		}
@@ -825,7 +825,7 @@ func (l *Linter) lintIfStatement(stmt *ast.IfStatement, ctx *context.Context) ty
 		l.lintIfCondition(a.Condition, ctx)
 		if err := pushRegexGroupVars(a.Condition, ctx); err != nil {
 			err := &LintError{
-				Severity: WARNING,
+				Severity: INFO,
 				Token:    a.Condition.GetMeta().Token,
 				Message:  err.Error(),
 			}

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -641,7 +641,7 @@ sub foo {
 	}
 	set var.S = re.group.1;
 }`
-		assertErrorWithSeverity(t, input, WARNING)
+		assertErrorWithSeverity(t, input, INFO)
 	})
 
 	t.Run("condition type is not expected", func(t *testing.T) {


### PR DESCRIPTION
This PR supports overriding lint error severity from the user configuration file.

The fixed configuration file is `.falcorc`, and should be placed in the current working directory.

The configuration file format is a simple key-value object like YAML:

```yaml
regex/matched-value-override: IGNORE
```

And then falco overrides error severity as specified severity matched its rule.
