### PR TITLE
Fix parsing infix block comments

### DIFF
--- a/linter/helper.go
+++ b/linter/helper.go
@@ -329,3 +329,14 @@ func getFastlySubroutineScope(name string) string {
 	}
 	return ""
 }
+
+func hasFastlyBoilerPlateMacro(commentText, phrase string) bool {
+	comments := strings.Split(commentText, "\n")
+	for _, c := range comments {
+		c = strings.TrimLeft(c, " */#")
+		if strings.HasPrefix(strings.ToUpper(c), phrase) {
+			return true
+		}
+	}
+	return false
+}

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -479,13 +479,12 @@ func (l *Linter) lintSubRoutineDeclaration(decl *ast.SubroutineDeclaration, ctx 
 
 func (l *Linter) lintFastlyBoilerPlateMacro(sub *ast.SubroutineDeclaration, phrase string) {
 	// visit all statement comments and find "FASTLY [phase]" comment
+	if hasFastlyBoilerPlateMacro(sub.Block.InfixComment(), phrase) {
+		return
+	}
 	for _, stmt := range sub.Block.Statements {
-		comments := strings.Split(stmt.LeadingComment(), "\n")
-		for _, c := range comments {
-			c = strings.TrimLeft(c, " */#")
-			if strings.HasPrefix(strings.ToUpper(c), phrase) {
-				return
-			}
+		if hasFastlyBoilerPlateMacro(stmt.LeadingComment(), phrase) {
+			return
 		}
 	}
 

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -300,6 +300,12 @@ sub vcl_recv {
 	set req.http.Host = "example.com";
 }`
 		assertNoError(t, input)
+
+		input = `
+sub vcl_log {
+	# FASTLY log
+}`
+		assertNoError(t, input)
 	})
 
 	t.Run("invalid subroutine name", func(t *testing.T) {

--- a/parser/statement_parser.go
+++ b/parser/statement_parser.go
@@ -99,6 +99,10 @@ func (p *Parser) parseBlockStatement() (*ast.BlockStatement, error) {
 
 	b.Meta.Trailing = p.trailing()
 	p.nextToken() // point to RIGHT_BRACE
+
+	// RIGHT_BRACE leading comments are block infix comments
+	swapLeadingInfix(p.curToken, b.Meta)
+
 	return b, nil
 }
 


### PR DESCRIPTION
Fixes #12 

Infix comments of block statement is discarded currently, so I changed that parser sets RIGHT_BRACE leading comments as infix comments of block statement like `parseAclDeclaration`.