### PR TITLE
fix: nested block syntax could parse/lint

### DIFF
--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -1186,3 +1186,27 @@ sub foo {
 		assertNoError(t, input)
 	})
 }
+
+func TestBlockSyntaxInsideBlockStatement(t *testing.T) {
+	input := `
+sub vcl_recv {
+	#Fastly recv
+	{
+		log "vcl_recv";
+	}
+}`
+	assertNoError(t, input)
+}
+
+func TestBlockSyntaxInsideBlockStatementmultiply(t *testing.T) {
+	input := `
+sub vcl_recv {
+	#Fastly recv
+	{
+		{
+			log "vcl_recv";
+		}
+	}
+}`
+	assertNoError(t, input)
+}

--- a/parser/statement_parser.go
+++ b/parser/statement_parser.go
@@ -59,6 +59,17 @@ func (p *Parser) parseBlockStatement() (*ast.BlockStatement, error) {
 
 		p.nextToken() // point to statement
 		switch p.curToken.Token.Type {
+		// https://github.com/ysugimoto/falco/issues/17
+		// VCL accepts block syntax:
+		// ```
+		// sub vcl_recv {
+		//   {
+		//      log "recv";
+		//   }
+		// }
+		// ```
+		case token.LEFT_BRACE:
+			stmt, err = p.parseBlockStatement()
 		case token.SET:
 			stmt, err = p.parseSetStatement()
 		case token.UNSET:

--- a/parser/statement_parser_test.go
+++ b/parser/statement_parser_test.go
@@ -1222,3 +1222,98 @@ sub vcl_recv {
 	}
 	assert(t, vcl, expect)
 }
+
+func TestBlockSyntaxInsideBlockStatement(t *testing.T) {
+	t.Run("nested block", func(t *testing.T) {
+		input := `
+sub vcl_recv {
+	{
+		log "vcl_recv";
+	}
+}`
+
+		expect := &ast.VCL{
+			Statements: []ast.Statement{
+				&ast.SubroutineDeclaration{
+					Meta: ast.New(T, 0),
+					Name: &ast.Ident{
+						Meta:  ast.New(T, 0),
+						Value: "vcl_recv",
+					},
+					Block: &ast.BlockStatement{
+						Meta: ast.New(T, 1),
+						Statements: []ast.Statement{
+							&ast.BlockStatement{
+								Meta: ast.New(T, 2),
+								Statements: []ast.Statement{
+									&ast.LogStatement{
+										Meta: ast.New(T, 2),
+										Value: &ast.String{
+											Meta:  ast.New(T, 2),
+											Value: "vcl_recv",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		vcl, err := New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Errorf("%+v", err)
+		}
+		assert(t, vcl, expect)
+	})
+
+	t.Run("nested two blocks", func(t *testing.T) {
+		input := `
+sub vcl_recv {
+	{
+		{
+			log "vcl_recv";
+		}
+	}
+}`
+
+		expect := &ast.VCL{
+			Statements: []ast.Statement{
+				&ast.SubroutineDeclaration{
+					Meta: ast.New(T, 0),
+					Name: &ast.Ident{
+						Meta:  ast.New(T, 0),
+						Value: "vcl_recv",
+					},
+					Block: &ast.BlockStatement{
+						Meta: ast.New(T, 1),
+						Statements: []ast.Statement{
+							&ast.BlockStatement{
+								Meta: ast.New(T, 2),
+								Statements: []ast.Statement{
+									&ast.BlockStatement{
+										Meta: ast.New(T, 3),
+										Statements: []ast.Statement{
+											&ast.LogStatement{
+												Meta: ast.New(T, 3),
+												Value: &ast.String{
+													Meta:  ast.New(T, 3),
+													Value: "vcl_recv",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		vcl, err := New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Errorf("%+v", err)
+		}
+		assert(t, vcl, expect)
+	})
+}


### PR DESCRIPTION
Fixes #17

The parser should parse the nested `LEFT_BRACE` token as a block statement like the following:

```
sub foo {
  {
    log "hello";
  }
}
```
