### PR TITLE
fix: prevent to die linter on return statement

### DIFF
--- a/linter/linter.go
+++ b/linter/linter.go
@@ -1009,6 +1009,11 @@ func (l *Linter) lintReturnStatement(stmt *ast.ReturnStatement, ctx *context.Con
 		expects = append(expects, "deliver")
 	}
 
+	// return statement may not have arguments, then stop linting
+	if stmt.Ident == nil {
+		return types.NeverType
+	}
+
 	if !expectState(stmt.Ident.Value, expects...) {
 		l.Error(InvalidReturnState(
 			stmt.Ident.GetMeta(), context.ScopeString(ctx.Mode()), stmt.Ident.Value, expects...,

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -1186,3 +1186,22 @@ sub foo {
 		assertNoError(t, input)
 	})
 }
+
+func TestReturnStatement(t *testing.T) {
+	t.Run("pass: without argument", func(t *testing.T) {
+		input := `
+sub foo {
+	return;
+}`
+		assertNoError(t, input)
+	})
+
+	t.Run("pass: with argument", func(t *testing.T) {
+		input := `
+sub vcl_recv {
+	#Fastly recv
+	return (pass);
+}`
+		assertNoError(t, input)
+	})
+}


### PR DESCRIPTION
Fixes #16 

Linter dies unexpectedly when the return statement does not have an argument like:

```
sub vcl_recv {
  return;
}
```

To prevent this, stop linting when the return statement ident is nil.