### PR TITLE
Support edge dictionary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 # vendor/
 falco
 dist/*
+playground

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Flags:
     -I, --include_path : Add include path
     -t, --transformer  : Specify transformer
     -h, --help         : Show this help
+    -r, --remote       : Communicate with Fastly API
     -V, --version      : Display build version
     -v,                : Verbose warning lint result
     -vv,               : Verbose all lint result
@@ -124,15 +125,23 @@ Following table describes annotation name and recognizing scope:
 
 ## Fastly related features
 
-Currently, we don't support snippets which are managed in Fastly:
+`falco` supports to communicate with Fastly API. To enable it, you need following settings:
 
-- Edge Dictionary
+1. Apply `-r, --remote` flag in command. falco will communicate with Fastly API if this flag is supplied.
+2. Fastly API requires target _ServiceID_ and _APIKey_ to call, therefore, you need to specify them via environment varialbes named `FASTLY_SERVICE_ID` and `FASTLY_API_KEY`. falco will use these values automatically.
+
+Note: this feature is experimental so environment variable name is fixed.
+
+### Edge Dictionary
+
+`falco` can fetch [Edge Dictionary](https://docs.fastly.com/en/guides/about-edge-dictionaries) from Fastly and pre-parse.
+
+
+Currently, other snippets are not supported:
+
 - VCL Snippets
 - Log definitions
 - Etc
-
-Above snippets will be injected to your VCL top or extracting `FASTLY XXX` macro, but this tool aims to run locally, not communicating with Fastly service.
-However, we're planning to solve them using the Fastly API.
 
 ## Lint error
 

--- a/README.md
+++ b/README.md
@@ -125,23 +125,7 @@ Following table describes annotation name and recognizing scope:
 
 ## Fastly related features
 
-`falco` supports to communicate with Fastly API. To enable it, you need following settings:
-
-1. Apply `-r, --remote` flag in command. falco will communicate with Fastly API if this flag is supplied.
-2. Fastly API requires target _ServiceID_ and _APIKey_ to call, therefore, you need to specify them via environment varialbes named `FASTLY_SERVICE_ID` and `FASTLY_API_KEY`. falco will use these values automatically.
-
-Note: this feature is experimental so environment variable name is fixed.
-
-### Edge Dictionary
-
-`falco` can fetch [Edge Dictionary](https://docs.fastly.com/en/guides/about-edge-dictionaries) from Fastly and pre-parse.
-
-
-Currently, other snippets are not supported:
-
-- VCL Snippets
-- Log definitions
-- Etc
+Partially supports fetching Fastly managed VCL snippets. See [remote.md](https://github.com/ysugimoto/falco/blob/master/docs/remote.md) in detail.
 
 ## Lint error
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -43,6 +43,7 @@ type Config struct {
 	V            bool
 	VV           bool
 	Version      bool
+	Remote       bool
 }
 
 func write(c *color.Color, format string, args ...interface{}) {
@@ -65,9 +66,10 @@ Flags:
     -I, --include_path : Add include path
     -t, --transformer  : Specify transformer
     -h, --help         : Show this help
+    -r, --remote       : Communicate with Fastly API
     -V, --version      : Display build version
-    -v,                : Verbose warning lint result
-    -vv,               : Varbose all lint result
+    -v                 : Verbose warning lint result
+    -vv                : Varbose all lint result
 
 Example:
     falco -I . -vv /path/to/vcl/main.vcl
@@ -90,6 +92,8 @@ func main() {
 	fs.BoolVar(&c.VV, "vv", false, "Verbose info")
 	fs.BoolVar(&c.Version, "V", false, "Print Version")
 	fs.BoolVar(&c.Version, "version", false, "Print Version")
+	fs.BoolVar(&c.Remote, "r", false, "Use Remote")
+	fs.BoolVar(&c.Remote, "remote", false, "Use Remote")
 
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		if err == flag.ErrHelp {

--- a/cli/runner.go
+++ b/cli/runner.go
@@ -65,23 +65,23 @@ func NewRunner(mainVcl string, c *Config) (*Runner, error) {
 
 	if c.Remote {
 		writeln(cyan, "Remote option supplied. Fetch snippets from Fastly.")
-		// If remote flag is pfovided, fetch predefined data from Fastly.
+		// If remote flag is provided, fetch predefined data from Fastly.
 		// Currently, we only support Edge Dictionary.
 		//
-		// We communiate Fastly API with service id and api key,
+		// We communicate Fastly API with service id and api key,
 		// lookup fixed environment variable, FASTLY_SERVICE_ID and FASTLY_API_KEY
-		// So user need to set them with "-r" argument.
+		// So user needs to set them with "-r" argument.
 		serviceId := os.Getenv("FASTLY_SERVICE_ID")
 		apiKey := os.Getenv("FASTLY_API_KEY")
 		if serviceId == "" || apiKey == "" {
 			return nil, errors.New("Both FASTLY_SERVICE_ID and FASTLY_API_KEY environment variables must be specified")
 		}
 		snippet := NewSnippet(serviceId, apiKey)
+		// Remote communication is optional so we keep processing even if remote communication is failed
 		if err := snippet.Fetch(); err != nil {
-			return nil, err
-		}
-		if err := snippet.Compile(r.context); err != nil {
-			return nil, err
+			writeln(red, err.Error())
+		} else if err := snippet.Compile(r.context); err != nil {
+			writeln(red, err.Error())
 		}
 	}
 

--- a/cli/snippet.go
+++ b/cli/snippet.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	_context "context"
 	"fmt"
 	"strings"
 
@@ -44,9 +45,9 @@ func (s *Snippet) Compile(ctx *context.Context) error {
 	return nil
 }
 
-func (s *Snippet) Fetch() error {
+func (s *Snippet) Fetch(c _context.Context) error {
 	write(white, "Fetching Edge Dictionaries...")
-	dicts, err := s.fetchEdgeDictionary()
+	dicts, err := s.fetchEdgeDictionary(c)
 	if err != nil {
 		return err
 	}
@@ -56,14 +57,14 @@ func (s *Snippet) Fetch() error {
 }
 
 // Fetch remote Edge dictionary items
-func (s *Snippet) fetchEdgeDictionary() ([]string, error) {
+func (s *Snippet) fetchEdgeDictionary(c _context.Context) ([]string, error) {
 	// Fetch latest version
-	version, err := s.client.LatestVersion()
+	version, err := s.client.LatestVersion(c)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get latest version %w", err)
 	}
 
-	dicts, err := s.client.ListEdgeDictionaries(version)
+	dicts, err := s.client.ListEdgeDictionaries(c, version)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get latest version %w", err)
 	}

--- a/cli/snippet.go
+++ b/cli/snippet.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"net/http"
+	"text/template"
+
+	"github.com/ysugimoto/falco/context"
+	"github.com/ysugimoto/falco/lexer"
+	"github.com/ysugimoto/falco/linter"
+	"github.com/ysugimoto/falco/parser"
+	"github.com/ysugimoto/falco/remote"
+)
+
+var tableTemplate = `
+table {{ .Name }} {
+	{{- range .Items }}
+	"{{ .Key }}": "{{ .Value }}",
+	{{- end }}
+}
+`
+
+type Snippet struct {
+	client   *remote.FastlyClient
+	snippets []string
+}
+
+func NewSnippet(serviceId, apiKey string) *Snippet {
+	return &Snippet{
+		client: remote.NewFastlyClient(http.DefaultClient, serviceId, apiKey),
+	}
+}
+
+func (s *Snippet) Compile(ctx *context.Context) error {
+	vcl, err := parser.New(lexer.NewFromString(strings.Join(s.snippets, "\n"))).ParseVCL()
+	if err != nil {
+		return err
+	}
+	l := linter.New()
+	l.Lint(vcl, ctx)
+	return nil
+}
+
+func (s *Snippet) Fetch() error {
+	write(white, "Fetching Edge Dictionaries...")
+	dicts, err := s.fetchEdgeDictionary()
+	if err != nil {
+		return err
+	}
+	writeln(white, "Done")
+	s.snippets = append(s.snippets, dicts...)
+	return nil
+}
+
+// Fetch remote Edge dictionary items
+func (s *Snippet) fetchEdgeDictionary() ([]string, error) {
+	// Fetch latest version
+	version, err := s.client.LatestVersion()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get latest version %w", err)
+	}
+
+	dicts, err := s.client.ListEdgeDictionaries(version)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get latest version %w", err)
+	}
+
+	tmpl, err := template.New("table").Parse(tableTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to compilte table template: %w", err)
+	}
+
+	var snippets []string
+	for _, dict := range dicts {
+		buf := new(bytes.Buffer)
+		if err := tmpl.Execute(buf, dict); err != nil {
+			return nil, fmt.Errorf("Failed to render table template: %w", err)
+		}
+		snippets = append(snippets, buf.String())
+	}
+	return snippets, nil
+}

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -1,0 +1,59 @@
+# Use Fastly managed snippets
+
+`falco` aims to run locally, but probably vcl has dependency of Fastly managed VCL -- Edge Dictionary, VCL snippets --- and linter may cause error if these are not specified,
+
+In order to use them, falco provides remote option which prefetch Fastly managed VCL and do parse and lint.
+
+## Prefetching managed VCL
+
+### Provide remote flag in CLI
+
+By supplying `-r, --remote` flag in command, falco communicates to Fastly API and retrieve VCL snippets.
+
+For example:
+
+```shell
+falco -r -v /path/to/example.vcl
+```
+
+### Environment variables
+
+Fastly API requires `API key` to authenticate, and `Service ID` to distinguish service, therefore you need to specift these values in your environment variable.
+The environment varialbe name is fixed:
+
+| variable name     | usage |
+|:------------------|:----  |
+| FASTLY_SERVICE_ID | Service ID |
+| FASTLY_API_KEY    | API Key, yo can create via [Personal API Tokens](https://manage.fastly.com/account/personal/tokens) |
+
+**Note: We recommend the Fastly API Key has `global:read` scope. falco only just call _read_ related API.**
+
+
+### Edge Dictionary
+
+Prefetch [Edge Dictionary](https://docs.fastly.com/en/guides/about-edge-dictionaries) from Fastly and parse as `Table`.
+Note that Edge Dictionary always treats as `STRING` type in VCL:
+
+If you defined Edge Dictionary named `my_dictionary`, falco deals with as table:
+
+```
+table my_dictionary STRING {
+  "[item_key01": "[item_value01]",
+  "[item_key02": "[item_value02]",
+  ...
+}
+```
+
+You can access `my_dictionary` table in your custom VCL.
+
+### Logging
+
+Currently not supported.
+
+### VCL snippets
+
+Currently not supported.
+
+### Access control lists
+
+Currently not supported.

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -24,7 +24,7 @@ The environment varialbe name is fixed:
 | variable name     | usage |
 |:------------------|:----  |
 | FASTLY_SERVICE_ID | Service ID |
-| FASTLY_API_KEY    | API Key, yo can create via [Personal API Tokens](https://manage.fastly.com/account/personal/tokens) |
+| FASTLY_API_KEY    | API Key, you can create via [Personal API Tokens](https://manage.fastly.com/account/personal/tokens) |
 
 **Note: We recommend the Fastly API Key has `global:read` scope. falco only just call _read_ related API.**
 

--- a/remote/client.go
+++ b/remote/client.go
@@ -52,8 +52,8 @@ func (c *FastlyClient) request(ctx context.Context, method, url string, body io.
 	return nil
 }
 
-func (c *FastlyClient) LatestVersion() (int64, error) {
-	ctx, timeout := context.WithTimeout(context.Background(), 5*time.Second)
+func (c *FastlyClient) LatestVersion(ctx context.Context) (int64, error) {
+	ctx, timeout := context.WithTimeout(ctx, 5*time.Second)
 	defer timeout()
 
 	endpoint := fmt.Sprintf("/service/%s/version/active", c.serviceId)
@@ -65,10 +65,7 @@ func (c *FastlyClient) LatestVersion() (int64, error) {
 	return v.Number, nil
 }
 
-func (c *FastlyClient) ListEdgeDictionaries(version int64) ([]*EdgeDictionary, error) {
-	ctx, timeout := context.WithTimeout(context.Background(), 5*time.Second)
-	defer timeout()
-
+func (c *FastlyClient) ListEdgeDictionaries(ctx context.Context, version int64) ([]*EdgeDictionary, error) {
 	endpoint := fmt.Sprintf("/service/%s/version/%d/dictionary", c.serviceId, version)
 	var dicts []*EdgeDictionary
 	if err := c.request(ctx, http.MethodGet, endpoint, nil, &dicts); err != nil {
@@ -83,7 +80,7 @@ func (c *FastlyClient) ListEdgeDictionaries(version int64) ([]*EdgeDictionary, e
 		go func(d *EdgeDictionary) {
 			defer wg.Done()
 			var err error
-			if d.Items, err = c.ListEdgeDictionaryItems(d.Id); err != nil {
+			if d.Items, err = c.ListEdgeDictionaryItems(ctx, d.Id); err != nil {
 				once.Do(func() {
 					errch <- err
 				})
@@ -105,10 +102,7 @@ func (c *FastlyClient) ListEdgeDictionaries(version int64) ([]*EdgeDictionary, e
 	}
 }
 
-func (c *FastlyClient) ListEdgeDictionaryItems(dictId string) ([]*EdgeDictionaryItem, error) {
-	ctx, timeout := context.WithTimeout(context.Background(), 5*time.Second)
-	defer timeout()
-
+func (c *FastlyClient) ListEdgeDictionaryItems(ctx context.Context, dictId string) ([]*EdgeDictionaryItem, error) {
 	endpoint := fmt.Sprintf("/service/%s/dictionary/%s/items", c.serviceId, dictId)
 	var items []*EdgeDictionaryItem
 	if err := c.request(ctx, http.MethodGet, endpoint, nil, &items); err != nil {

--- a/remote/client.go
+++ b/remote/client.go
@@ -56,13 +56,12 @@ func (c *FastlyClient) LatestVersion() (int64, error) {
 	ctx, timeout := context.WithTimeout(context.Background(), 5*time.Second)
 	defer timeout()
 
-	endpoint := fmt.Sprintf("/service/%s/version", c.serviceId)
-	var vs []Version
-	if err := c.request(ctx, http.MethodGet, endpoint, nil, &vs); err != nil {
+	endpoint := fmt.Sprintf("/service/%s/version/active", c.serviceId)
+	var v Version
+	if err := c.request(ctx, http.MethodGet, endpoint, nil, &v); err != nil {
 		return 0, errors.WithStack(err)
 	}
 
-	v := vs[len(vs)-1]
 	return v.Number, nil
 }
 

--- a/remote/client.go
+++ b/remote/client.go
@@ -1,0 +1,120 @@
+package remote
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"encoding/json"
+	"net/http"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	fastlyApiBaseUrl = "https://api.fastly.com"
+)
+
+type FastlyClient struct {
+	serviceId string
+	apiKey    string
+	client    *http.Client
+}
+
+func NewFastlyClient(c *http.Client, serviceId, apiKey string) *FastlyClient {
+	return &FastlyClient{
+		serviceId: serviceId,
+		apiKey:    apiKey,
+		client:    c,
+	}
+}
+
+func (c *FastlyClient) request(ctx context.Context, method, url string, body io.Reader, v interface{}) error {
+	req, err := http.NewRequestWithContext(ctx, method, fastlyApiBaseUrl+url, body)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	req.Header.Set("Fastly-Key", c.apiKey)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return errors.WithStack(err)
+	} else if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("API respond not 200 code: %d", resp.StatusCode)
+	}
+	defer resp.Body.Close()
+	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+func (c *FastlyClient) LatestVersion() (int64, error) {
+	ctx, timeout := context.WithTimeout(context.Background(), 5*time.Second)
+	defer timeout()
+
+	endpoint := fmt.Sprintf("/service/%s/version", c.serviceId)
+	var vs []Version
+	if err := c.request(ctx, http.MethodGet, endpoint, nil, &vs); err != nil {
+		return 0, errors.WithStack(err)
+	}
+
+	v := vs[len(vs)-1]
+	return v.Number, nil
+}
+
+func (c *FastlyClient) ListEdgeDictionaries(version int64) ([]*EdgeDictionary, error) {
+	ctx, timeout := context.WithTimeout(context.Background(), 5*time.Second)
+	defer timeout()
+
+	endpoint := fmt.Sprintf("/service/%s/version/%d/dictionary", c.serviceId, version)
+	var dicts []*EdgeDictionary
+	if err := c.request(ctx, http.MethodGet, endpoint, nil, &dicts); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	var wg sync.WaitGroup
+	var once sync.Once
+	errch := make(chan error)
+	for _, d := range dicts {
+		wg.Add(1)
+		go func(d *EdgeDictionary) {
+			defer wg.Done()
+			var err error
+			if d.Items, err = c.ListEdgeDictionaryItems(d.Id); err != nil {
+				once.Do(func() {
+					errch <- err
+				})
+			}
+		}(d)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return dicts, nil
+	case err := <-errch:
+		return nil, err
+	}
+}
+
+func (c *FastlyClient) ListEdgeDictionaryItems(dictId string) ([]*EdgeDictionaryItem, error) {
+	ctx, timeout := context.WithTimeout(context.Background(), 5*time.Second)
+	defer timeout()
+
+	endpoint := fmt.Sprintf("/service/%s/dictionary/%s/items", c.serviceId, dictId)
+	var items []*EdgeDictionaryItem
+	if err := c.request(ctx, http.MethodGet, endpoint, nil, &items); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return items, nil
+}

--- a/remote/client_test.go
+++ b/remote/client_test.go
@@ -1,0 +1,139 @@
+package remote
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"io/ioutil"
+	"net/http"
+)
+
+type TestRoundTripper struct {
+	StatusCode int
+	Body       string
+}
+
+func (t *TestRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	if r.Header.Get("Fastly-Key") == "" {
+		return nil, errors.New("Fastly-Key header is required")
+	}
+
+	return &http.Response{
+		StatusCode: t.StatusCode,
+		Body:       ioutil.NopCloser(strings.NewReader(t.Body)),
+	}, nil
+}
+
+func TestListVerions(t *testing.T) {
+	c := NewFastlyClient(&http.Client{
+		Transport: &TestRoundTripper{
+			StatusCode: 200,
+			Body: `
+[
+  {
+	"created_at": "2020-04-09T18:14:30.000Z",
+	"updated_at": "2020-04-09T18:15:30.000Z",
+	"deleted_at": null,
+	"active": true,
+	"comment": "",
+	"deployed": true,
+	"locked": false,
+	"number": 1,
+	"staging": false,
+	"testing": false,
+	"service_id": "SU1Z0isxPaozGVKXdv0eY"
+  }
+]`,
+		},
+	}, "dummy", "dummy")
+
+	version, err := c.LatestVersion()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		t.FailNow()
+	}
+	if version != 1 {
+		t.Errorf("Version assertion error, expects=1 but got=%d", version)
+		t.FailNow()
+	}
+}
+
+func TestListDictionaries(t *testing.T) {
+	c := NewFastlyClient(&http.Client{
+		Transport: &TestRoundTripper{
+			StatusCode: 200,
+			Body: `
+[
+  {
+	"created_at": "2020-04-29T22:16:23.000Z",
+	"deleted_at": null,
+	"id": "3vjTN8v1O7nOAY7aNDGOL",
+	"name": "my_dictionary",
+	"service_id": "SU1Z0isxPaozGVKXdv0eY",
+	"updated_at": "2020-04-29T22:16:23.000Z",
+	"version": 1,
+	"write_only": false
+  }
+]`,
+		},
+	}, "dummy", "dummy")
+
+	dicts, err := c.ListEdgeDictionaries(10)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		t.FailNow()
+	}
+	if len(dicts) != 1 {
+		t.Errorf("dictionaries should have 1 but got %d", len(dicts))
+		t.FailNow()
+	}
+	d := dicts[0]
+	if d.Id != "3vjTN8v1O7nOAY7aNDGOL" {
+		t.Errorf("dict id assertion error, expects=3vjTN8v1O7nOAY7aNDGOL but got=%s", d.Id)
+		t.FailNow()
+	}
+	if d.Name != "my_dictionary" {
+		t.Errorf("dict name assertion error, expects=my_dictionary but got=%s", d.Name)
+		t.FailNow()
+	}
+}
+
+func TestListDictionaryItems(t *testing.T) {
+	c := NewFastlyClient(&http.Client{
+		Transport: &TestRoundTripper{
+			StatusCode: 200,
+			Body: `
+[
+  {
+	"dictionary_id": "3vjTN8v1O7nOAY7aNDGOL",
+	"service_id": "SU1Z0isxPaozGVKXdv0eY",
+	"item_key": "some_key",
+	"item_value": "some_value",
+	"created_at": "2020-04-21T18:14:32.000Z",
+	"deleted_at": null,
+	"updated_at": "2020-04-21T18:14:32.000Z"
+  }
+]`,
+		},
+	}, "dummy", "dummy")
+
+	items, err := c.ListEdgeDictionaryItems("3vjTN8v1O7nOAY7aNDGOL")
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		t.FailNow()
+	}
+	if len(items) != 1 {
+		t.Errorf("dictionaries should have 1 items but got %d", len(items))
+		t.FailNow()
+	}
+	i := items[0]
+	if i.Key != "some_key" {
+		t.Errorf("item key assertion error, expects=some_key but got=%s", i.Key)
+		t.FailNow()
+	}
+	if i.Value != "some_value" {
+		t.Errorf("item value assertion error, expects=some_value but got=%s", i.Value)
+		t.FailNow()
+	}
+}

--- a/remote/client_test.go
+++ b/remote/client_test.go
@@ -25,13 +25,12 @@ func (t *TestRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	}, nil
 }
 
-func TestListVerions(t *testing.T) {
+func TestLatestVersion(t *testing.T) {
 	c := NewFastlyClient(&http.Client{
 		Transport: &TestRoundTripper{
 			StatusCode: 200,
 			Body: `
-[
-  {
+{
 	"created_at": "2020-04-09T18:14:30.000Z",
 	"updated_at": "2020-04-09T18:15:30.000Z",
 	"deleted_at": null,
@@ -43,8 +42,7 @@ func TestListVerions(t *testing.T) {
 	"staging": false,
 	"testing": false,
 	"service_id": "SU1Z0isxPaozGVKXdv0eY"
-  }
-]`,
+}`,
 		},
 	}, "dummy", "dummy")
 

--- a/remote/client_test.go
+++ b/remote/client_test.go
@@ -1,6 +1,7 @@
 package remote
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -46,7 +47,7 @@ func TestLatestVersion(t *testing.T) {
 		},
 	}, "dummy", "dummy")
 
-	version, err := c.LatestVersion()
+	version, err := c.LatestVersion(context.Background())
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 		t.FailNow()
@@ -77,7 +78,7 @@ func TestListDictionaries(t *testing.T) {
 		},
 	}, "dummy", "dummy")
 
-	dicts, err := c.ListEdgeDictionaries(10)
+	dicts, err := c.ListEdgeDictionaries(context.Background(), 10)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 		t.FailNow()
@@ -116,7 +117,7 @@ func TestListDictionaryItems(t *testing.T) {
 		},
 	}, "dummy", "dummy")
 
-	items, err := c.ListEdgeDictionaryItems("3vjTN8v1O7nOAY7aNDGOL")
+	items, err := c.ListEdgeDictionaryItems(context.Background(), "3vjTN8v1O7nOAY7aNDGOL")
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 		t.FailNow()

--- a/remote/entity.go
+++ b/remote/entity.go
@@ -1,0 +1,16 @@
+package remote
+
+type Version struct {
+	Number int64 `json:"number"`
+}
+
+type EdgeDictionary struct {
+	Id    string `json:"id"`
+	Name  string `json:"name"`
+	Items []*EdgeDictionaryItem
+}
+
+type EdgeDictionaryItem struct {
+	Key   string `json:"item_key"`
+	Value string `json:"item_value"`
+}


### PR DESCRIPTION
This is **Experimental** feature that runs with Edge Dictionary.

Before start parsing, falco calls Fastly API and retrieves Edge Dictionaries on the latest version in destination service.
To run with this, the user needs:

1. Apply `-r, --remote` flag in the command
2. Set environment variables named `FASTLY_SERVICE_ID` and `FASTLY_API_KEY` to call Fastly API

For example:

```
export FASTLY_SERVIE_ID=xxxxxxxx
export FASTLY_API_KEY=yyyyyyy
falco -v -r /path/to/vcl/default.vcl
```

Then falco fetches Edge Dictionary via Fastly API and predefined as `TABLE`:

```
table [dict_name] {
  "[dict_item_key]": "[dict_item_value]",
  ...
}
```

The Edge Dictionary always treats values type as STRING.

