### PR TITLE
fix add statement linter

### DIFF
--- a/linter/errors.go
+++ b/linter/errors.go
@@ -73,9 +73,11 @@ func InvalidValue(m *ast.Meta, tt, val string) *LintError {
 	}
 }
 
+// InvalidType raises ERROR due to strict type assertion failed.
+// Actually, it cause compile error for that VCL.
 func InvalidType(m *ast.Meta, name string, expect, actual types.Type) *LintError {
 	return &LintError{
-		Severity: WARNING,
+		Severity: ERROR,
 		Token:    m.Token,
 		Message:  fmt.Sprintf("%s wants type %s but assign %s", name, expect.String(), actual.String()),
 	}

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -3,6 +3,7 @@ package linter
 import (
 	"fmt"
 	"net"
+	"regexp"
 	"strings"
 
 	"github.com/ysugimoto/falco/ast"
@@ -1194,6 +1195,17 @@ func (l *Linter) lintInfixExpression(exp *ast.InfixExpression, ctx *context.Cont
 			l.Error(InvalidTypeExpression(exp.GetMeta(), left, types.StringType, types.IPType, types.AclType).Match(OPERATOR_CONDITIONAL))
 		} else if !expectType(right, types.StringType, types.IPType, types.AclType) {
 			l.Error(InvalidTypeExpression(exp.GetMeta(), right, types.StringType, types.IPType, types.AclType).Match(OPERATOR_CONDITIONAL))
+		}
+		// And, if right expression is STRING, regex must be valid
+		if v, ok := exp.Right.(*ast.String); ok {
+			if _, err := regexp.Compile(v.Value); err != nil {
+				err := &LintError{
+					Severity: ERROR,
+					Token:    exp.Right.GetMeta().Token,
+					Message:  "regex string is invalid, " + err.Error(),
+				}
+				l.Error(err)
+			}
 		}
 		return types.BoolType
 	case "+":

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -899,6 +899,7 @@ func (l *Linter) lintAddStatement(stmt *ast.AddStatement, ctx *context.Context) 
 		!strings.Contains(stmt.Ident.Value, "beresp.http.") &&
 		!strings.Contains(stmt.Ident.Value, "obj.http.") &&
 		!strings.Contains(stmt.Ident.Value, "resp.http.") {
+
 		err := &LintError{
 			Severity: ERROR,
 			Token:    stmt.Ident.GetMeta().Token,

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -892,6 +892,21 @@ func (l *Linter) lintAddStatement(stmt *ast.AddStatement, ctx *context.Context) 
 		l.Error(InvalidName(stmt.Ident.GetMeta(), stmt.Ident.Value, "add").Match(ADD_STATEMENT_SYNTAX))
 	}
 
+	// Add statement could use only for HTTP headers.
+	// https://developer.fastly.com/reference/vcl/statements/add/
+	if !strings.Contains(stmt.Ident.Value, "req.http.") &&
+		!strings.Contains(stmt.Ident.Value, "bereq.http.") &&
+		!strings.Contains(stmt.Ident.Value, "beresp.http.") &&
+		!strings.Contains(stmt.Ident.Value, "obj.http.") &&
+		!strings.Contains(stmt.Ident.Value, "resp.http.") {
+		err := &LintError{
+			Severity: ERROR,
+			Token:    stmt.Ident.GetMeta().Token,
+			Message:  "Add statement could not use for " + stmt.Ident.Value,
+		}
+		l.Error(err.Match(ADD_STATEMENT_SYNTAX))
+	}
+
 	left, err := ctx.Get(stmt.Ident.Value)
 	if err != nil {
 		l.Error(&LintError{

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -504,6 +504,15 @@ sub foo {
 		assertError(t, input)
 	})
 
+	t.Run("only can use for HTTP headers", func(t *testing.T) {
+		input := `
+sub foo {
+	declare local var.FOO STRING;
+	add var.FOO = "bar";
+}`
+
+		assertError(t, input)
+	})
 }
 
 func TestLintCallStatement(t *testing.T) {

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -1238,3 +1238,13 @@ sub vcl_recv {
 }`
 	assertNoError(t, input)
 }
+
+func TestRegexExpressionIsInvalid(t *testing.T) {
+	input := `
+sub vcl_recv {
+	#Fastly recv
+	if (req.url ~ "/foo/(.+") {
+	}
+}`
+	assertError(t, input)
+}


### PR DESCRIPTION
This PR has a couple of changes:

1. Change severity from `WARNING` to `ERROR` when type is different between left and right on `=` operator in `set` statement
2. Raise `ERROR` when `add` statement is used not for HTTP headers (refers [add statement](https://developer.fastly.com/reference/vcl/statements/add/)
3. Check validity of regex string inside if expression