### PR TITLE
use context.Set() for set statement linter

### DIFF
--- a/context/context_test.go
+++ b/context/context_test.go
@@ -9,7 +9,7 @@ import (
 func TestContextSet(t *testing.T) {
 	t.Run("Error on undefined variable", func(t *testing.T) {
 		c := New()
-		err := c.Set("foo.bar", &types.String{Value: "example"})
+		_, err := c.Set("foo.bar")
 		if err == nil {
 			t.Errorf("expected error but got nil")
 		}
@@ -18,7 +18,7 @@ func TestContextSet(t *testing.T) {
 	t.Run("Error on invalid scope", func(t *testing.T) {
 		c := New()
 		c.Scope(RECV)
-		err := c.Set("beresp.http.X-Forwarded-Host", &types.String{Value: "example.com"})
+		_, err := c.Set("beresp.http.X-Forwarded-Host")
 		if err == nil {
 			t.Errorf("expected error but got nil")
 		}
@@ -27,25 +27,26 @@ func TestContextSet(t *testing.T) {
 	t.Run("Error on set to read-only variable", func(t *testing.T) {
 		c := New()
 		c.Scope(RECV)
-		err := c.Set("backend.conn.is_tls", &types.Bool{Value: true})
+		_, err := c.Set("backend.conn.is_tls")
 		if err == nil {
 			t.Errorf("expected error but got nil")
 		}
 	})
 
-	t.Run("Error on set to invalid type", func(t *testing.T) {
+	t.Run("Can return right variable type", func(t *testing.T) {
 		c := New()
 		c.Scope(RECV)
-		err := c.Set("req.backend", &types.Bool{Value: true})
-		if err == nil {
-			t.Errorf("expected error but got nil")
+		expectedType := types.BackendType
+		variableType, _ := c.Set("req.backend")
+		if variableType != expectedType {
+			t.Errorf("expected %s but got %s", expectedType, variableType)
 		}
 	})
 
 	t.Run("Able to set to {NAME} variables", func(t *testing.T) {
 		c := New()
 		c.Scope(RECV)
-		err := c.Set("req.http.X-Forwarded-Host", &types.String{Value: "example.com"})
+		_, err := c.Set("req.http.X-Forwarded-Host")
 		if err != nil {
 			t.Errorf("expected nil but got error: %s", err)
 		}
@@ -144,7 +145,7 @@ func TestContextGetSet(t *testing.T) {
 	t.Run("Case insensitive", func(t *testing.T) {
 		c := New()
 		c.Scope(RECV)
-		err := c.Set("req.http.X-Forwarded-Host", &types.String{Value: "example.com"})
+		_, err := c.Set("req.http.X-Forwarded-Host")
 		if err != nil {
 			t.Errorf("expected nil but got error: %s", err)
 		}

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -549,7 +549,7 @@ func (l *Linter) lintSetStatement(stmt *ast.SetStatement, ctx *context.Context) 
 		l.Error(InvalidName(stmt.Ident.GetMeta(), stmt.Ident.Value, "set").Match(SET_STATEMENT_SYNTAX))
 	}
 
-	left, err := ctx.Get(stmt.Ident.Value)
+	left, err := ctx.Set(stmt.Ident.Value)
 	if err != nil {
 		err := &LintError{
 			Severity: ERROR,


### PR DESCRIPTION
`context.Get()` shouldn't be used in `lintSetStatement` as that will skip nesesarry validations in `context.Set()`.


```
sub vcl_fetch {
  set beresp.proto = "http";
  set beresp.saintmode = 10s;
}
```

### expected

For instance, the above example should throw an error for `set beresp.proto` as it's a read-only variable. And there should be no errors for `set beresp.saintmode = 10s;`.

```
% ./falco foo.vcl
🔥 [ERROR] variable "beresp.proto" is read-only
document: https://developer.fastly.com/reference/vcl/variables/backend-response/beresp-proto/
in /path/to/foo.vcl at line 2, position 7
 1|sub vcl_fetch {
 2|  set beresp.proto = "http";
         ^^^^^^^^^^^^
 3|  set beresp.saintmode = 10s;

🔥 [ERROR] beresp.proto wants type NULL but assign STRING
in /path/to/foo.vcl at line 2, position 22
 1|sub vcl_fetch {
 2|  set beresp.proto = "http";
                        ^^^^^^
 3|  set beresp.saintmode = 10s;

🔥 2 errors, ❗️ 1 warnings, 🔈 0 infos.
```

### actual

```
 $ ./falco foo.vcl
🔥 [ERROR] variable "beresp.saintmode" could not read
document: https://developer.fastly.com/reference/vcl/variables/backend-response/beresp-saintmode/
in /path/to/foo.vcl at line 2, position 7
 6|  set beresp.proto = "http";
 7|  set beresp.saintmode = 10s;
         ^^^^^^^^^^^^^^^^
 8|}

🔥 [ERROR] beresp.saintmode wants type NULL but assign RTIME
in /path/to/foo.vcl at line 2, position 26
 6|  set beresp.proto = "http";
 7|  set beresp.saintmode = 10s;
                            ^^^
 8|}

🔥 2 errors, ❗️ 1 warnings, 🔈 0 infos.
```