### PR TITLE
revert regex related linting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/fatih/color v1.12.0
-	github.com/goccy/go-yaml v1.8.9 // indirect
+	github.com/goccy/go-yaml v1.8.9
 	github.com/google/go-cmp v0.5.6
 	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect
 	github.com/k0kubun/pp v2.4.0+incompatible

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -3,7 +3,6 @@ package linter
 import (
 	"fmt"
 	"net"
-	"regexp"
 	"strings"
 
 	"github.com/ysugimoto/falco/ast"
@@ -1195,17 +1194,6 @@ func (l *Linter) lintInfixExpression(exp *ast.InfixExpression, ctx *context.Cont
 			l.Error(InvalidTypeExpression(exp.GetMeta(), left, types.StringType, types.IPType, types.AclType).Match(OPERATOR_CONDITIONAL))
 		} else if !expectType(right, types.StringType, types.IPType, types.AclType) {
 			l.Error(InvalidTypeExpression(exp.GetMeta(), right, types.StringType, types.IPType, types.AclType).Match(OPERATOR_CONDITIONAL))
-		}
-		// And, if right expression is STRING, regex must be valid
-		if v, ok := exp.Right.(*ast.String); ok {
-			if _, err := regexp.Compile(v.Value); err != nil {
-				err := &LintError{
-					Severity: ERROR,
-					Token:    exp.Right.GetMeta().Token,
-					Message:  "regex string is invalid, " + err.Error(),
-				}
-				l.Error(err)
-			}
 		}
 		return types.BoolType
 	case "+":

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -1238,13 +1238,3 @@ sub vcl_recv {
 }`
 	assertNoError(t, input)
 }
-
-func TestRegexExpressionIsInvalid(t *testing.T) {
-	input := `
-sub vcl_recv {
-	#Fastly recv
-	if (req.url ~ "/foo/(.+") {
-	}
-}`
-	assertError(t, input)
-}


### PR DESCRIPTION
My apologies that Varnish regular expression is not compatible for Golang's regexp package.

It causes:

```
if (req.url ~ "^/([^\?]*)?(\?.*)?$") {
...
}
```

Then raises **[ERROR] regex string is invalid, error parsing regexp: invalid or unsupported Perl syntax: (?.**
I assume that VCL regular expression is using Perl syntax but Golang does not have it... so I revert these changes 😢 