### PR TITLE
Implement vcl snippet

### DIFF
--- a/__fixture__/fixture.vcl
+++ b/__fixture__/fixture.vcl
@@ -1,0 +1,3 @@
+sub some_recv {
+  set req.http.Fixture = "1";
+}

--- a/__fixture__/statement-fixture.vcl
+++ b/__fixture__/statement-fixture.vcl
@@ -1,0 +1,1 @@
+set req.http.Fixture = "1";

--- a/cli/resolver.go
+++ b/cli/resolver.go
@@ -204,7 +204,6 @@ func (r *Resolver) resolveSubroutine(decl *ast.SubroutineDeclaration) error {
 
 	scope := getFastlySubroutineScope(decl.Name.Value)
 	if scope != "" {
-		// pp.Println(decl.Block.InfixComment())
 		// if "FASTLY [phase]" macro found in subroutine root, prepend snippet
 		if hasFastlyBoilerPlateMacro(decl.Block.InfixComment(), "FASTLY "+scope) {
 			ss, err := r.findSnippetsByPhase(remote.SnippetType(scope))

--- a/cli/resolver.go
+++ b/cli/resolver.go
@@ -1,0 +1,277 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"path/filepath"
+
+	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/lexer"
+	"github.com/ysugimoto/falco/parser"
+	"github.com/ysugimoto/falco/remote"
+)
+
+type Resolver struct {
+	includePaths []string
+	snippets     []*remote.VCLSnippet
+}
+
+func newResolver() *Resolver {
+	return &Resolver{}
+}
+
+func (r *Resolver) addIncludePaths(ps ...string) {
+	r.includePaths = append(r.includePaths, ps...)
+}
+
+func (r *Resolver) addSnippets(snip ...*remote.VCLSnippet) {
+	r.snippets = append(r.snippets, snip...)
+}
+
+func (r *Resolver) FormatError(m *ast.Meta, err error) error {
+	// Bad logic, but temporary OK :(
+	if strings.Contains(err.Error(), "Caused at") {
+		return err
+	}
+
+	return fmt.Errorf(
+		"%s\nCaused at %s, line: %d, position: %d",
+		err, m.Token.File, m.Token.Line, m.Token.Position,
+	)
+}
+
+func (r *Resolver) Resolve(s []ast.Statement, phase remote.SnippetType) ([]ast.Statement, error) {
+	var resolved []ast.Statement
+
+	for i := range s {
+		switch t := s[i].(type) {
+		// Following statement/declaration could have "include" statement in sub block
+		case *ast.IncludeStatement:
+			var founds []ast.Statement
+			var err error
+
+			// If module name starts with "snippet::", find from VCL snippets managed in Fastly.
+			if strings.HasPrefix(t.Module.Value, "snippet::") {
+				founds, err = r.findSnippets(strings.TrimPrefix(t.Module.Value, "snippet::"), phase)
+			} else {
+				founds, err = r.findFile(t.Module.Value, phase)
+			}
+			if err != nil {
+				return nil, r.FormatError(t.GetMeta(), err)
+			}
+			resolved = append(resolved, founds...)
+		case *ast.IfStatement:
+			if err := r.resolveIfStatement(t, phase); err != nil {
+				return nil, r.FormatError(t.GetMeta(), err)
+			}
+			resolved = append(resolved, t)
+		case *ast.SubroutineDeclaration:
+			if err := r.resolveSubroutine(t); err != nil {
+				return nil, r.FormatError(t.GetMeta(), err)
+			}
+			resolved = append(resolved, t)
+		default:
+			resolved = append(resolved, t)
+		}
+	}
+
+	return resolved, nil
+}
+
+func (r *Resolver) findSnippets(modName string, phase remote.SnippetType) ([]ast.Statement, error) {
+	var statements []ast.Statement
+
+	for _, snip := range r.snippets {
+		if snip.Name != modName {
+			continue
+		}
+
+		ss, err := r.parseStatements(
+			parser.New(lexer.NewFromString(*snip.Content, lexer.WithFile("snippet::"+modName))),
+			phase,
+		)
+		if err != nil {
+			return nil, err
+		}
+		statements = append(statements, ss...)
+	}
+
+	return statements, nil
+}
+
+func (r *Resolver) findSnippetsByPhase(phase remote.SnippetType) ([]ast.Statement, error) {
+	var statements []ast.Statement
+
+	for _, snip := range r.snippets {
+		if snip.Type != phase {
+			continue
+		}
+
+		ss, err := r.parseStatements(
+			parser.New(lexer.NewFromString(*snip.Content, lexer.WithFile("snippet::"+snip.Name))),
+			phase,
+		)
+		if err != nil {
+			return nil, err
+		}
+		statements = append(statements, ss...)
+	}
+
+	return statements, nil
+}
+
+func (r *Resolver) findFile(modName string, phase remote.SnippetType) ([]ast.Statement, error) {
+	var file string
+
+	// Find for each include paths
+	for _, ip := range r.includePaths {
+		if _, err := os.Stat(filepath.Join(ip, modName+".vcl")); err == nil {
+			file = filepath.Join(ip, modName+".vcl")
+			break
+		}
+	}
+
+	if file == "" {
+		return nil, fmt.Errorf("Could not find module file: %s.vcl in include paths", modName)
+	}
+
+	fp, err := os.Open(file)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to open file: %s.vcl: %w", modName, err)
+	}
+	defer fp.Close()
+
+	return r.parseStatements(parser.New(lexer.New(fp, lexer.WithFile(file))), phase)
+}
+
+func (r *Resolver) parseStatements(p *parser.Parser, phase remote.SnippetType) ([]ast.Statement, error) {
+	var ss []ast.Statement
+	var err error
+
+	if phase == remote.SnippetTypeInit {
+		if vcl, err := p.ParseVCL(); err != nil {
+			return nil, err
+		} else {
+			ss = vcl.Statements
+		}
+	} else {
+		ss, err = p.ParseStatement()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	ss, err = r.Resolve(ss, phase)
+	if err != nil {
+		return nil, err
+	}
+	return ss, nil
+}
+
+func (r *Resolver) resolveIfStatement(stmt *ast.IfStatement, phase remote.SnippetType) error {
+	var err error
+
+	// Resolve consequence
+	stmt.Consequence.Statements, err = r.Resolve(stmt.Consequence.Statements, phase)
+	if err != nil {
+		return err
+	}
+
+	// Resolve another (else if)
+	for i, alt := range stmt.Another {
+		alt.Consequence.Statements, err = r.Resolve(alt.Consequence.Statements, phase)
+		if err != nil {
+			return err
+		}
+		stmt.Another[i] = alt
+	}
+
+	// Resolve alternative
+	if stmt.Alternative != nil {
+		stmt.Alternative.Statements, err = r.Resolve(stmt.Alternative.Statements, phase)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *Resolver) resolveSubroutine(decl *ast.SubroutineDeclaration) error {
+	var err error
+
+	scope := getFastlySubroutineScope(decl.Name.Value)
+	if scope != "" {
+		// pp.Println(decl.Block.InfixComment())
+		// if "FASTLY [phase]" macro found in subroutine root, prepend snippet
+		if hasFastlyBoilerPlateMacro(decl.Block.InfixComment(), "FASTLY "+scope) {
+			ss, err := r.findSnippetsByPhase(remote.SnippetType(scope))
+			if err != nil {
+				return nil
+			}
+			decl.Block.Statements = append(ss, decl.Block.Statements...)
+		}
+
+		var statements []ast.Statement
+		// Macro found in some statements, prepend before its statement
+		for _, stmt := range decl.Block.Statements {
+			if !hasFastlyBoilerPlateMacro(stmt.LeadingComment(), "FASTLY "+scope) {
+				statements = append(statements, stmt)
+				continue
+			}
+			ss, err := r.findSnippetsByPhase(remote.SnippetType(scope))
+			if err != nil {
+				return nil
+			}
+			statements = append(statements, ss...)
+			statements = append(statements, stmt)
+		}
+		decl.Block.Statements = statements
+	}
+
+	// Resolve subroutine inside statements
+	decl.Block.Statements, err = r.Resolve(decl.Block.Statements, remote.SnippetType(scope))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// TODO: duplicate with linter:getFastlySubroutineScope, should integrate as utility (@ysugimoto)
+func getFastlySubroutineScope(name string) string {
+	switch name {
+	case "vcl_recv":
+		return "recv"
+	case "vcl_hash":
+		return "hash"
+	case "vcl_hit":
+		return "hit"
+	case "vcl_miss":
+		return "miss"
+	case "vcl_pass":
+		return "pass"
+	case "vcl_fetch":
+		return "fetch"
+	case "vcl_error":
+		return "error"
+	case "vcl_deliver":
+		return "deliver"
+	case "vcl_log":
+		return "log"
+	}
+	return ""
+}
+
+// TODO: duplicate with linter:hasFastlyBoilerPlateMacro, should integrate as utility (@ysugimoto)
+func hasFastlyBoilerPlateMacro(commentText, phrase string) bool {
+	comments := strings.Split(commentText, "\n")
+	for _, c := range comments {
+		c = strings.TrimLeft(c, " */#")
+		if strings.HasPrefix(strings.ToUpper(c), strings.ToUpper(phrase)) {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/resolver_test.go
+++ b/cli/resolver_test.go
@@ -1,0 +1,359 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/lexer"
+	"github.com/ysugimoto/falco/parser"
+	"github.com/ysugimoto/falco/remote"
+	"github.com/ysugimoto/falco/token"
+)
+
+var T = token.Token{}
+
+func assert(t *testing.T, actual, expect interface{}) {
+
+	if diff := cmp.Diff(expect, actual,
+		// Meta structs ignores Token info
+		cmpopts.IgnoreFields(ast.Comment{}, "Token"),
+		cmpopts.IgnoreFields(ast.Meta{}, "Token"),
+		cmpopts.IgnoreFields(ast.Operator{}),
+
+		// VCL type struct ignores Meta info
+		cmpopts.IgnoreFields(ast.Ident{}),
+		cmpopts.IgnoreFields(ast.Boolean{}),
+		cmpopts.IgnoreFields(ast.Integer{}),
+		cmpopts.IgnoreFields(ast.IP{}),
+		cmpopts.IgnoreFields(ast.String{}),
+		cmpopts.IgnoreFields(ast.Float{}),
+		cmpopts.IgnoreFields(ast.RTime{}),
+
+		cmpopts.IgnoreFields(ast.AclDeclaration{}),
+		cmpopts.IgnoreFields(ast.AclCidr{}),
+		cmpopts.IgnoreFields(ast.BackendDeclaration{}),
+		cmpopts.IgnoreFields(ast.BackendProperty{}),
+		cmpopts.IgnoreFields(ast.BackendProbeObject{}),
+		cmpopts.IgnoreFields(ast.ImportStatement{}),
+		cmpopts.IgnoreFields(ast.IncludeStatement{}),
+		cmpopts.IgnoreFields(ast.DirectorDeclaration{}),
+		cmpopts.IgnoreFields(ast.DirectorProperty{}),
+		cmpopts.IgnoreFields(ast.DirectorBackendObject{}),
+		cmpopts.IgnoreFields(ast.TableDeclaration{}),
+		cmpopts.IgnoreFields(ast.TableProperty{}),
+		cmpopts.IgnoreFields(ast.SubroutineDeclaration{}),
+		cmpopts.IgnoreFields(ast.DeclareStatement{}),
+		cmpopts.IgnoreFields(ast.BlockStatement{}),
+		cmpopts.IgnoreFields(ast.SetStatement{}),
+		cmpopts.IgnoreFields(ast.InfixExpression{}),
+		cmpopts.IgnoreFields(ast.PrefixExpression{}),
+		cmpopts.IgnoreFields(ast.GroupedExpression{}),
+		cmpopts.IgnoreFields(ast.IfStatement{}, "AlternativeComments"),
+		cmpopts.IgnoreFields(ast.UnsetStatement{}),
+		cmpopts.IgnoreFields(ast.AddStatement{}),
+		cmpopts.IgnoreFields(ast.CallStatement{}),
+		cmpopts.IgnoreFields(ast.ErrorStatement{}),
+		cmpopts.IgnoreFields(ast.LogStatement{}),
+		cmpopts.IgnoreFields(ast.ReturnStatement{}),
+		cmpopts.IgnoreFields(ast.SyntheticStatement{}),
+		cmpopts.IgnoreFields(ast.SyntheticBase64Statement{}),
+		cmpopts.IgnoreFields(ast.IfExpression{}),
+		cmpopts.IgnoreFields(ast.FunctionCallExpression{}),
+		cmpopts.IgnoreFields(ast.RestartStatement{}),
+		cmpopts.IgnoreFields(ast.EsiStatement{}),
+	); diff != "" {
+		t.Errorf("Assertion error: diff=%s", diff)
+	}
+}
+
+func comments(c ...string) ast.Comments {
+	cs := ast.Comments{}
+	for i := range c {
+		cs = append(cs, &ast.Comment{
+			Value: c[i],
+		})
+	}
+	return cs
+}
+
+func TestFileResolver(t *testing.T) {
+	t.Run("resolve in root", func(t *testing.T) {
+		input := `
+include "fixture";
+`
+		vcl, err := parser.New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		r := newResolver()
+		r.addIncludePaths("../__fixture__")
+		stmt, err := r.Resolve(vcl.Statements, remote.SnippetTypeInit)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expect := []ast.Statement{
+			&ast.SubroutineDeclaration{
+				Meta: ast.New(T, 0),
+				Name: &ast.Ident{
+					Meta:  ast.New(T, 0),
+					Value: "some_recv",
+				},
+				Block: &ast.BlockStatement{
+					Meta: ast.New(T, 1),
+					Statements: []ast.Statement{
+						&ast.SetStatement{
+							Meta: ast.New(T, 1),
+							Ident: &ast.Ident{
+								Meta:  ast.New(T, 1),
+								Value: "req.http.Fixture",
+							},
+							Operator: &ast.Operator{
+								Meta:     ast.New(T, 1),
+								Operator: "=",
+							},
+							Value: &ast.String{
+								Meta:  ast.New(T, 1),
+								Value: "1",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		assert(t, stmt, expect)
+	})
+
+	t.Run("resolve in statement", func(t *testing.T) {
+		input := `
+sub vcl_recv {
+	include "statement-fixture";
+}
+`
+		vcl, err := parser.New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		r := newResolver()
+		r.addIncludePaths("../__fixture__")
+		stmt, err := r.Resolve(vcl.Statements, remote.SnippetTypeInit)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expect := []ast.Statement{
+			&ast.SubroutineDeclaration{
+				Meta: ast.New(T, 0),
+				Name: &ast.Ident{
+					Meta:  ast.New(T, 0),
+					Value: "vcl_recv",
+				},
+				Block: &ast.BlockStatement{
+					Meta: ast.New(T, 1),
+					Statements: []ast.Statement{
+						&ast.SetStatement{
+							Meta: ast.New(T, 0),
+							Ident: &ast.Ident{
+								Meta:  ast.New(T, 0),
+								Value: "req.http.Fixture",
+							},
+							Operator: &ast.Operator{
+								Meta:     ast.New(T, 0),
+								Operator: "=",
+							},
+							Value: &ast.String{
+								Meta:  ast.New(T, 0),
+								Value: "1",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		assert(t, stmt, expect)
+	})
+}
+
+func TestSnippetResolver(t *testing.T) {
+	t.Run("resolve in root", func(t *testing.T) {
+		input := `
+include "snippet::root";
+`
+		vcl, err := parser.New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		r := newResolver()
+		c := `
+sub some_recv {
+	set req.http.Fixture = "1";
+}`
+		r.addSnippets(&remote.VCLSnippet{
+			Name:    "root",
+			Content: &c,
+		})
+		stmt, err := r.Resolve(vcl.Statements, remote.SnippetTypeInit)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expect := []ast.Statement{
+			&ast.SubroutineDeclaration{
+				Meta: ast.New(T, 0),
+				Name: &ast.Ident{
+					Meta:  ast.New(T, 0),
+					Value: "some_recv",
+				},
+				Block: &ast.BlockStatement{
+					Meta: ast.New(T, 1),
+					Statements: []ast.Statement{
+						&ast.SetStatement{
+							Meta: ast.New(T, 1),
+							Ident: &ast.Ident{
+								Meta:  ast.New(T, 1),
+								Value: "req.http.Fixture",
+							},
+							Operator: &ast.Operator{
+								Meta:     ast.New(T, 1),
+								Operator: "=",
+							},
+							Value: &ast.String{
+								Meta:  ast.New(T, 1),
+								Value: "1",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		assert(t, stmt, expect)
+	})
+
+	t.Run("resolve in statement", func(t *testing.T) {
+		input := `
+sub vcl_recv {
+	include "snippet::stmt";
+}
+`
+		vcl, err := parser.New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		r := newResolver()
+		c := `
+set req.http.Fixture = "1";
+`
+		r.addSnippets(&remote.VCLSnippet{
+			Name:    "stmt",
+			Content: &c,
+		})
+		stmt, err := r.Resolve(vcl.Statements, remote.SnippetTypeInit)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expect := []ast.Statement{
+			&ast.SubroutineDeclaration{
+				Meta: ast.New(T, 0),
+				Name: &ast.Ident{
+					Meta:  ast.New(T, 0),
+					Value: "vcl_recv",
+				},
+				Block: &ast.BlockStatement{
+					Meta: ast.New(T, 1, ast.Comments{}),
+					Statements: []ast.Statement{
+						&ast.SetStatement{
+							Meta: ast.New(T, 0),
+							Ident: &ast.Ident{
+								Meta:  ast.New(T, 0),
+								Value: "req.http.Fixture",
+							},
+							Operator: &ast.Operator{
+								Meta:     ast.New(T, 0),
+								Operator: "=",
+							},
+							Value: &ast.String{
+								Meta:  ast.New(T, 0),
+								Value: "1",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		assert(t, stmt, expect)
+	})
+
+	t.Run("resolve in statement macro", func(t *testing.T) {
+		input := `
+sub vcl_recv {
+	#FASTLY recv
+}
+`
+		vcl, err := parser.New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		r := newResolver()
+		c := `
+set req.http.Fixture = "1";
+`
+		r.addSnippets(&remote.VCLSnippet{
+			Name:    "stmt",
+			Content: &c,
+			Type:    remote.SnippetTypeRecv,
+		})
+		r.addSnippets(&remote.VCLSnippet{
+			Name:    "stmt2",
+			Content: &c,
+			Type:    remote.SnippetTypeFetch,
+		})
+		stmt, err := r.Resolve(vcl.Statements, remote.SnippetTypeInit)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expect := []ast.Statement{
+			&ast.SubroutineDeclaration{
+				Meta: ast.New(T, 0),
+				Name: &ast.Ident{
+					Meta:  ast.New(T, 0),
+					Value: "vcl_recv",
+				},
+				Block: &ast.BlockStatement{
+					Meta: ast.New(T, 1, comments(), comments(), comments("#FASTLY recv")),
+					Statements: []ast.Statement{
+						&ast.SetStatement{
+							Meta: ast.New(T, 0),
+							Ident: &ast.Ident{
+								Meta:  ast.New(T, 0),
+								Value: "req.http.Fixture",
+							},
+							Operator: &ast.Operator{
+								Meta:     ast.New(T, 0),
+								Operator: "=",
+							},
+							Value: &ast.String{
+								Meta:  ast.New(T, 0),
+								Value: "1",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		assert(t, stmt, expect)
+	})
+}

--- a/cli/runner.go
+++ b/cli/runner.go
@@ -42,7 +42,6 @@ type RunnerResult struct {
 
 type Runner struct {
 	transformers []*Transformer
-	includePaths []string
 	mainVclFile  string
 	overrides    map[string]linter.Severity
 	resolver     *Resolver

--- a/cli/runner.go
+++ b/cli/runner.go
@@ -239,35 +239,9 @@ func (r *Runner) run(vclFile string) ([]*plugin.VCL, error) {
 		return nil, err
 	}
 
-	var vcls []*plugin.VCL
-	// // Lint dependent VCLs before execute main VCL
-	// for _, stmt := range vcl.Statements {
-	// 	include, ok := stmt.(*ast.IncludeStatement)
-	// 	if !ok {
-	// 		continue
-	// 	}
-
-	// 	var file string
-	// 	// Find for each include paths
-	// 	for _, p := range r.includePaths {
-	// 		if _, err := os.Stat(filepath.Join(p, include.Module.Value+".vcl")); err == nil {
-	// 			file = filepath.Join(p, include.Module.Value+".vcl")
-	// 			break
-	// 		}
-	// 	}
-
-	// 	subVcl, err := r.run(file)
-	// 	if err != nil {
-	// 		return nil, err
-	// 	}
-	// 	vcls = append(vcls, subVcl...)
-	// }
-
-	// Append main to the last of proceeds VCLs
-	vcls = append(vcls, &plugin.VCL{
-		File: vclFile,
-		AST:  vcl,
-	})
+	vcls := []*plugin.VCL{
+		{File: vclFile, AST: vcl},
+	}
 
 	lt := linter.New()
 	lt.Lint(vcl, r.context)

--- a/cli/snippet.go
+++ b/cli/snippet.go
@@ -80,7 +80,7 @@ func (s *Snippet) fetchEdgeDictionary(ctx context.Context, version int64) ([]str
 
 // Fetch remote VCL snippets
 func (s *Snippet) fetchVCLSnippets(ctx context.Context, version int64) ([]*remote.VCLSnippet, error) {
-	snippets, err := s.client.ListVCLSnippets(ctx)
+	snippets, err := s.client.ListVCLSnippets(ctx, version)
 	if err != nil {
 		return nil, err
 	}

--- a/context/predefined.go
+++ b/context/predefined.go
@@ -1399,7 +1399,7 @@ func predefinedVariables() Variables {
 							Items: map[string]*Object{},
 							Value: &Accessor{
 								Get:       types.StringType,
-								Set:       types.NeverType,
+								Set:       types.StringType,
 								Unset:     false,
 								Scopes:    RECV | ERROR | DELIVER | LOG,
 								Reference: "https://developer.fastly.com/reference/vcl/variables/client-connection/client-socket-congestion-algorithm/",
@@ -1409,7 +1409,7 @@ func predefinedVariables() Variables {
 							Items: map[string]*Object{},
 							Value: &Accessor{
 								Get:       types.IntegerType,
-								Set:       types.NeverType,
+								Set:       types.IntegerType,
 								Unset:     false,
 								Scopes:    RECV | ERROR | FETCH | DELIVER | LOG,
 								Reference: "https://developer.fastly.com/reference/vcl/variables/client-connection/client-socket-cwnd/",

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -52,7 +52,10 @@ Currently not supported.
 
 ### VCL snippets
 
-Currently not supported.
+Prefetch [VCL dynamic snippets](https://docs.fastly.com/en/guides/using-dynamic-vcl-snippets) and [VCL regular snippets](https://docs.fastly.com/en/guides/using-regular-vcl-snippets) from Fastly and parse them to embed in your VCL:
+
+- embed VCLs that correspond to `include` statement like `include "snippet::<snipppet_name>"
+- Find Fastly's macro (e.g. `#FASTLY recv`) and embed VCLs that correspond type
 
 ### Access control lists
 

--- a/examples/_feature_default.vcl
+++ b/examples/_feature_default.vcl
@@ -1,0 +1,1 @@
+set req.http.Included = "1";

--- a/examples/default05.vcl
+++ b/examples/default05.vcl
@@ -19,11 +19,13 @@ backend httpbin_org {
     .timeout = 5s;
     .initial = 1;
     .expected_response = 200;
-    .interval = 10s # missing semicolon X(
+    .interval = 10s;
   }
 }
 
 sub vcl_recv {
+
+  include "_feature_default";
 
   #Fastly recv
   set req.backend = httpbin_org;

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -32,8 +32,8 @@ func New(r io.Reader, opts ...OptionFunc) *Lexer {
 	return l
 }
 
-func NewFromString(input string) *Lexer {
-	return New(strings.NewReader(input))
+func NewFromString(input string, opts ...OptionFunc) *Lexer {
+	return New(strings.NewReader(input), opts...)
 }
 
 func (l *Lexer) readChar() {

--- a/parser/declaration_parser.go
+++ b/parser/declaration_parser.go
@@ -435,7 +435,7 @@ func (p *Parser) parseSubroutineDeclaration() (*ast.SubroutineDeclaration, error
 	swapLeadingTrailing(p.curToken, s.Name.Meta)
 
 	var err error
-	if s.Block, err = p.parseBlockStatement(); err != nil {
+	if s.Block, err = p.ParseBlockStatement(); err != nil {
 		return nil, errors.WithStack(err)
 	}
 	// After block statement is parsed, cusor should point RIGHT_BRACE, end of block statement

--- a/parser/declaration_parser.go
+++ b/parser/declaration_parser.go
@@ -435,7 +435,7 @@ func (p *Parser) parseSubroutineDeclaration() (*ast.SubroutineDeclaration, error
 	swapLeadingTrailing(p.curToken, s.Name.Meta)
 
 	var err error
-	if s.Block, err = p.ParseBlockStatement(); err != nil {
+	if s.Block, err = p.parseBlockStatement(); err != nil {
 		return nil, errors.WithStack(err)
 	}
 	// After block statement is parsed, cusor should point RIGHT_BRACE, end of block statement

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -178,8 +178,8 @@ func (p *Parser) ParseVCL() (*ast.VCL, error) {
 // include "module"; // <- valid, read and parse as ParseVCL()
 // ...
 // sub foo_recv {
-//   include "snippet::some_module"; // valid, need parse as ParseStatement()
-//   include "statement-module";     // valid, need parse as ParseStatement()
+//   include "snippet::some_module"; // valid, need to parse by ParseStatement()
+//   include "statement-module";     // valid, need to parse by ParseStatement()
 // }
 func (p *Parser) ParseStatement() ([]ast.Statement, error) {
 	var statements []ast.Statement

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -171,7 +171,7 @@ func (p *Parser) ParseVCL() (*ast.VCL, error) {
 
 // ParseStatement parses included VCL.
 // In "include" statement, process read partial an VCL (file or snippet, regular or dynamic),
-// but the partial VCL may not be used in root VCL, can be unsed inside subroutine.
+// but the partial VCL may not be used in root VCL, can be used inside subroutine.
 // Then we need to parse them as inline statement, e.g:
 //
 // #main.vcl

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -159,3 +159,52 @@ sub vcl_recv {
 	}
 	assert(t, vcl, expect)
 }
+
+func TestParseStatement(t *testing.T) {
+	input := `
+set req.http.BlockStatement = "yes";
+set req.http.Foo = "bar";
+restart;
+`
+	expect := []ast.Statement{
+		&ast.SetStatement{
+			Meta: ast.New(T, 0),
+			Ident: &ast.Ident{
+				Meta:  ast.New(T, 0),
+				Value: "req.http.BlockStatement",
+			},
+			Operator: &ast.Operator{
+				Meta:     ast.New(T, 0),
+				Operator: "=",
+			},
+			Value: &ast.String{
+				Meta:  ast.New(T, 0),
+				Value: "yes",
+			},
+		},
+		&ast.SetStatement{
+			Meta: ast.New(T, 0),
+			Ident: &ast.Ident{
+				Meta:  ast.New(T, 0),
+				Value: "req.http.Foo",
+			},
+			Operator: &ast.Operator{
+				Meta:     ast.New(T, 0),
+				Operator: "=",
+			},
+			Value: &ast.String{
+				Meta:  ast.New(T, 0),
+				Value: "bar",
+			},
+		},
+		&ast.RestartStatement{
+			Meta: ast.New(T, 0),
+		},
+	}
+
+	vcl, err := New(lexer.NewFromString(input)).ParseStatement()
+	if err != nil {
+		t.Errorf("%+v", err)
+	}
+	assert(t, vcl, expect)
+}

--- a/parser/statement_parser.go
+++ b/parser/statement_parser.go
@@ -44,7 +44,7 @@ func (p *Parser) parseIncludeStatement() (ast.Statement, error) {
 	return i, nil
 }
 
-func (p *Parser) parseBlockStatement() (*ast.BlockStatement, error) {
+func (p *Parser) ParseBlockStatement() (*ast.BlockStatement, error) {
 	// Note: block statement is used for declaration/statement inside like subroutine, if, elseif, else
 	// on start this statement, current token must point start of LEFT_BRACE
 	// and after on end this statement, current token must poinrt end of RIGHT_BRACE
@@ -69,7 +69,7 @@ func (p *Parser) parseBlockStatement() (*ast.BlockStatement, error) {
 		// }
 		// ```
 		case token.LEFT_BRACE:
-			stmt, err = p.parseBlockStatement()
+			stmt, err = p.ParseBlockStatement()
 		case token.SET:
 			stmt, err = p.parseSetStatement()
 		case token.UNSET:
@@ -474,7 +474,7 @@ func (p *Parser) parseIfStatement() (*ast.IfStatement, error) {
 	}
 
 	// parse Consequence block
-	stmt.Consequence, err = p.parseBlockStatement()
+	stmt.Consequence, err = p.ParseBlockStatement()
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -501,7 +501,7 @@ func (p *Parser) parseIfStatement() (*ast.IfStatement, error) {
 			if !p.expectPeek(token.LEFT_BRACE) {
 				return nil, errors.WithStack(UnexpectedToken(p.peekToken, "LEFT_BRACE"))
 			}
-			stmt.Alternative, err = p.parseBlockStatement()
+			stmt.Alternative, err = p.ParseBlockStatement()
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
@@ -550,7 +550,7 @@ func (p *Parser) parseAnotherIfStatement() (*ast.IfStatement, error) {
 	}
 
 	// parse Consequence block
-	stmt.Consequence, err = p.parseBlockStatement()
+	stmt.Consequence, err = p.ParseBlockStatement()
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/parser/statement_parser.go
+++ b/parser/statement_parser.go
@@ -44,7 +44,7 @@ func (p *Parser) parseIncludeStatement() (ast.Statement, error) {
 	return i, nil
 }
 
-func (p *Parser) ParseBlockStatement() (*ast.BlockStatement, error) {
+func (p *Parser) parseBlockStatement() (*ast.BlockStatement, error) {
 	// Note: block statement is used for declaration/statement inside like subroutine, if, elseif, else
 	// on start this statement, current token must point start of LEFT_BRACE
 	// and after on end this statement, current token must poinrt end of RIGHT_BRACE
@@ -69,7 +69,7 @@ func (p *Parser) ParseBlockStatement() (*ast.BlockStatement, error) {
 		// }
 		// ```
 		case token.LEFT_BRACE:
-			stmt, err = p.ParseBlockStatement()
+			stmt, err = p.parseBlockStatement()
 		case token.SET:
 			stmt, err = p.parseSetStatement()
 		case token.UNSET:
@@ -84,6 +84,8 @@ func (p *Parser) ParseBlockStatement() (*ast.BlockStatement, error) {
 			stmt, err = p.parseDeclareStatement()
 		case token.ERROR:
 			stmt, err = p.parseErrorStatement()
+		case token.INCLUDE:
+			stmt, err = p.parseIncludeStatement()
 		case token.ESI:
 			stmt, err = p.parseEsiStatement()
 		case token.LOG:
@@ -474,7 +476,7 @@ func (p *Parser) parseIfStatement() (*ast.IfStatement, error) {
 	}
 
 	// parse Consequence block
-	stmt.Consequence, err = p.ParseBlockStatement()
+	stmt.Consequence, err = p.parseBlockStatement()
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -501,7 +503,7 @@ func (p *Parser) parseIfStatement() (*ast.IfStatement, error) {
 			if !p.expectPeek(token.LEFT_BRACE) {
 				return nil, errors.WithStack(UnexpectedToken(p.peekToken, "LEFT_BRACE"))
 			}
-			stmt.Alternative, err = p.ParseBlockStatement()
+			stmt.Alternative, err = p.parseBlockStatement()
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
@@ -550,7 +552,7 @@ func (p *Parser) parseAnotherIfStatement() (*ast.IfStatement, error) {
 	}
 
 	// parse Consequence block
-	stmt.Consequence, err = p.ParseBlockStatement()
+	stmt.Consequence, err = p.parseBlockStatement()
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/remote/client.go
+++ b/remote/client.go
@@ -118,8 +118,8 @@ func (c *FastlyClient) ListVCLSnippets(ctx context.Context, version int64) ([]*V
 		return nil, errors.WithStack(err)
 	}
 
-	// Dynamic snippet context is null ont this API response,
-	// so we need to call additional API to get snippet content.
+	// Dynamic snippet context is null on this API response,
+	// We need to call additional API to get snippet content.
 	for i := range snippets {
 		if snippets[i].Dynamic == "0" {
 			continue

--- a/remote/client.go
+++ b/remote/client.go
@@ -3,7 +3,6 @@ package remote
 import (
 	"context"
 	"fmt"
-	"io"
 	"sync"
 	"time"
 
@@ -31,8 +30,8 @@ func NewFastlyClient(c *http.Client, serviceId, apiKey string) *FastlyClient {
 	}
 }
 
-func (c *FastlyClient) request(ctx context.Context, method, url string, body io.Reader, v interface{}) error {
-	req, err := http.NewRequestWithContext(ctx, method, fastlyApiBaseUrl+url, body)
+func (c *FastlyClient) request(ctx context.Context, url string, v interface{}) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fastlyApiBaseUrl+url, nil)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -58,7 +57,7 @@ func (c *FastlyClient) LatestVersion(ctx context.Context) (int64, error) {
 
 	endpoint := fmt.Sprintf("/service/%s/version/active", c.serviceId)
 	var v Version
-	if err := c.request(ctx, http.MethodGet, endpoint, nil, &v); err != nil {
+	if err := c.request(ctx, endpoint, &v); err != nil {
 		return 0, errors.WithStack(err)
 	}
 
@@ -68,7 +67,7 @@ func (c *FastlyClient) LatestVersion(ctx context.Context) (int64, error) {
 func (c *FastlyClient) ListEdgeDictionaries(ctx context.Context, version int64) ([]*EdgeDictionary, error) {
 	endpoint := fmt.Sprintf("/service/%s/version/%d/dictionary", c.serviceId, version)
 	var dicts []*EdgeDictionary
-	if err := c.request(ctx, http.MethodGet, endpoint, nil, &dicts); err != nil {
+	if err := c.request(ctx, endpoint, &dicts); err != nil {
 		return nil, errors.WithStack(err)
 	}
 
@@ -105,22 +104,17 @@ func (c *FastlyClient) ListEdgeDictionaries(ctx context.Context, version int64) 
 func (c *FastlyClient) ListEdgeDictionaryItems(ctx context.Context, dictId string) ([]*EdgeDictionaryItem, error) {
 	endpoint := fmt.Sprintf("/service/%s/dictionary/%s/items", c.serviceId, dictId)
 	var items []*EdgeDictionaryItem
-	if err := c.request(ctx, http.MethodGet, endpoint, nil, &items); err != nil {
+	if err := c.request(ctx, endpoint, &items); err != nil {
 		return nil, errors.WithStack(err)
 	}
 
 	return items, nil
 }
 
-func (c *FastlyClient) ListVCLSnippets(ctx context.Context) ([]*VCLSnippet, error) {
-	version, err := c.LatestVersion(ctx)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
+func (c *FastlyClient) ListVCLSnippets(ctx context.Context, version int64) ([]*VCLSnippet, error) {
 	endpoint := fmt.Sprintf("/service/%s/version/%d/snippet", c.serviceId, version)
 	var snippets []*VCLSnippet
-	if err := c.request(ctx, http.MethodGet, endpoint, nil, &snippets); err != nil {
+	if err := c.request(ctx, endpoint, &snippets); err != nil {
 		return nil, errors.WithStack(err)
 	}
 
@@ -145,7 +139,7 @@ func (c *FastlyClient) GetDynamicSnippetContent(ctx context.Context, snippetId s
 	var snippet struct {
 		Content string `json:"content"`
 	}
-	if err := c.request(ctx, http.MethodGet, endpoint, nil, &snippet); err != nil {
+	if err := c.request(ctx, endpoint, &snippet); err != nil {
 		return nil, errors.WithStack(err)
 	}
 

--- a/remote/entity.go
+++ b/remote/entity.go
@@ -14,3 +14,27 @@ type EdgeDictionaryItem struct {
 	Key   string `json:"item_key"`
 	Value string `json:"item_value"`
 }
+
+type SnippetType string
+
+const (
+	SnippetTypeInit    SnippetType = "init"
+	SnippetTypeRecv    SnippetType = "recv"
+	SnippetTypeHit     SnippetType = "hit"
+	SnippetTypeMiss    SnippetType = "miss"
+	SnippetTypePass    SnippetType = "pass"
+	SnippetTypeFetch   SnippetType = "fetch"
+	SnippetTypeError   SnippetType = "error"
+	SnippetTypeDeliver SnippetType = "deliver"
+	SnippetTypeLog     SnippetType = "log"
+	SnippetTypeHash    SnippetType = "hash"
+	SnippetTypeNone    SnippetType = "none"
+)
+
+type VCLSnippet struct {
+	Id      string      `json:"id"`
+	Dynamic string      `json:"dynamic"`
+	Type    SnippetType `json:"type"`
+	Content *string     `json:"content"`
+	Name    string      `json:"name"`
+}


### PR DESCRIPTION
This PR supports parsing/linting VCL snippets managed in Fastly.

I'm guessing VCL snippets behavior in Faslty activate phase:

1. Extract macros of "#FASTLY xxx" with VCL snippets corresponds to phase (`recv`, `init`, etc...)
2. resolve `include "snippet::<snippet_name>"` statement with registered snippets (regular or dynamic)
3. Build integrated VCL file

Therefore, I modified the CLI process:

1. Factory **all** VCL snippets if `remote` flag is provided
2.  Parse main VCL file
3. Visit AST recursively, find `include` statement and resolve it (include from a local file or fetched VCL snippets)
4. Extract macro, find `#FASTLY xxx` comments and embed snippets that correspond to the exact phase
5. Integrate to single VCL file (as main VCL), and lint it

I marked `TODO` comment due to duplicated declaration in other packages, but I'll solve in another PR.