### PR TITLE
implement unused definition/variable linting

### DIFF
--- a/__generator__/template.go
+++ b/__generator__/template.go
@@ -9,21 +9,6 @@ import (
 	"github.com/ysugimoto/falco/types"
 )
 
-type Variables map[string]*Object
-
-type Object struct {
-	Items map[string]*Object
-	Value *Accessor
-}
-
-type Accessor struct {
-	Get       types.Type
-	Set       types.Type
-	Unset     bool
-	Scopes    int
-	Reference string
-}
-
 func predefinedVariables() Variables {
 	return {{ .Variables }}
 }

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -123,10 +123,10 @@ func TestContextUnset(t *testing.T) {
 func TestContextDeclare(t *testing.T) {
 	t.Run("error when variable is already declared", func(t *testing.T) {
 		c := New()
-		if err := c.Declare("var.foo", types.StringType); err != nil {
+		if err := c.Declare("var.foo", types.StringType, nil); err != nil {
 			t.Errorf("expected nil but got error: %s", err)
 		}
-		if err := c.Declare("var.foo", types.StringType); err == nil {
+		if err := c.Declare("var.foo", types.StringType, nil); err == nil {
 			t.Errorf("expected error but got nil")
 		}
 	})

--- a/context/predefined.go
+++ b/context/predefined.go
@@ -6,21 +6,6 @@ import (
 	"github.com/ysugimoto/falco/types"
 )
 
-type Variables map[string]*Object
-
-type Object struct {
-	Items map[string]*Object
-	Value *Accessor
-}
-
-type Accessor struct {
-	Get       types.Type
-	Set       types.Type
-	Unset     bool
-	Scopes    int
-	Reference string
-}
-
 func predefinedVariables() Variables {
 	return Variables{
 		"backend": &Object{
@@ -1399,7 +1384,7 @@ func predefinedVariables() Variables {
 							Items: map[string]*Object{},
 							Value: &Accessor{
 								Get:       types.StringType,
-								Set:       types.NeverType,
+								Set:       types.StringType,
 								Unset:     false,
 								Scopes:    RECV | ERROR | DELIVER | LOG,
 								Reference: "https://developer.fastly.com/reference/vcl/variables/client-connection/client-socket-congestion-algorithm/",
@@ -1409,7 +1394,7 @@ func predefinedVariables() Variables {
 							Items: map[string]*Object{},
 							Value: &Accessor{
 								Get:       types.IntegerType,
-								Set:       types.NeverType,
+								Set:       types.IntegerType,
 								Unset:     false,
 								Scopes:    RECV | ERROR | FETCH | DELIVER | LOG,
 								Reference: "https://developer.fastly.com/reference/vcl/variables/client-connection/client-socket-cwnd/",

--- a/linter/errors.go
+++ b/linter/errors.go
@@ -282,3 +282,22 @@ func InvalidReturnState(m *ast.Meta, scope, state string, expects ...string) *Li
 		),
 	}
 }
+
+func UnusedDeclaration(m *ast.Meta, name, declType string) *LintError {
+	return &LintError{
+		Severity: WARNING,
+		Token:    m.Token,
+		Message: fmt.Sprintf(
+			`%s "%s" is unused in VCL program`,
+			declType, name,
+		),
+	}
+}
+
+func UnusedVariable(m *ast.Meta, name string) *LintError {
+	return &LintError{
+		Severity: WARNING,
+		Token:    m.Token,
+		Message:  fmt.Sprintf(`variable "%s" is unused`, name),
+	}
+}

--- a/linter/rules.go
+++ b/linter/rules.go
@@ -53,6 +53,8 @@ const (
 	INCLUDE_STATEMENT_MODULE_NOT_FOUND   = "include/module-not-found"
 	INCLUDE_STATEMENT_MODULE_LOAD_FAILED = "include/module-load-failed"
 	REGEX_MATCHED_VALUE_MAY_OVERRIDE     = "regex/matched-value-override"
+	UNUSED_DECLARATION                   = "unused/declaration"
+	UNUSED_VARIABLE                      = "unused/variable"
 )
 
 var references = map[Rule]string{

--- a/types/types.go
+++ b/types/types.go
@@ -74,7 +74,8 @@ type VCLType interface {
 }
 
 type Acl struct {
-	Decl *ast.AclDeclaration
+	Decl   *ast.AclDeclaration
+	IsUsed bool // mark this acl is accessed at least once
 }
 
 func (a *Acl) Type() Type         { return AclType }
@@ -84,6 +85,7 @@ func (a *Acl) String() string     { return a.Decl.String() }
 type Backend struct {
 	BackendDecl  *ast.BackendDeclaration
 	DirectorDecl *ast.DirectorDeclaration
+	IsUsed       bool // mark this backend is accessed at least once
 }
 
 func (b *Backend) Type() Type { return BackendType }
@@ -192,6 +194,7 @@ type Table struct {
 	Name       string
 	ValueType  Type
 	Properties []*ast.TableProperty
+	IsUsed     bool // mark this table is accessed at least once
 }
 
 func (t *Table) Type() Type         { return TableType }
@@ -199,8 +202,9 @@ func (t *Table) Token() token.Token { return t.Decl.GetMeta().Token }
 func (t *Table) String() string     { return t.Decl.String() }
 
 type Subroutine struct {
-	Decl *ast.SubroutineDeclaration
-	Body *ast.BlockStatement
+	Decl   *ast.SubroutineDeclaration
+	Body   *ast.BlockStatement
+	IsUsed bool // mark this subroutine is called at least once
 }
 
 func (s *Subroutine) Type() Type         { return SubroutineType }


### PR DESCRIPTION
This PR adds more linter rules of:

1. lint global definitions (table, acl, backend, subroutine) are unused (rule: `UNUSED_DEFINITION`)
2. lint local variables are unused (rule: `UNUSED_VARIABLE`)

The above rules raise `WARNING` severity error because it's ok to work, so the rule is just used to optimize the user's VCL.

And, linting unused things should do only once in the linting process, therefore I divided expose a method of `Lint()` and the internal lining method of `lint()` with keeping backward compatibility.

