### PR TITLE
[bugfix] single argument should accept in randomstr function

### DIFF
--- a/__generator__/builtin.yml
+++ b/__generator__/builtin.yml
@@ -793,6 +793,7 @@ randomstr:
   reference: "https://developer.fastly.com/reference/vcl/functions/randomness/randomstr/"
   on: [RECV, HASH, HIT, MISS, PASS, FETCH, ERROR, DELIVER, LOG]
   arguments:
+    - [INTEGER]
     - [INTEGER, STRING]
   return: STRING
 

--- a/context/builtin.go
+++ b/context/builtin.go
@@ -1190,6 +1190,7 @@ func builtinFunctions() Functions {
 			Value: &BuiltinFunction{
 				Return: types.StringType,
 				Arguments: [][]types.Type{
+					[]types.Type{types.IntegerType},
 					[]types.Type{types.IntegerType, types.StringType},
 				},
 				Scopes:    RECV | HASH | HIT | MISS | PASS | FETCH | ERROR | DELIVER | LOG,

--- a/context/predefined.go
+++ b/context/predefined.go
@@ -1399,7 +1399,7 @@ func predefinedVariables() Variables {
 							Items: map[string]*Object{},
 							Value: &Accessor{
 								Get:       types.StringType,
-								Set:       types.NeverType,
+								Set:       types.StringType,
 								Unset:     false,
 								Scopes:    RECV | ERROR | DELIVER | LOG,
 								Reference: "https://developer.fastly.com/reference/vcl/variables/client-connection/client-socket-congestion-algorithm/",
@@ -1409,7 +1409,7 @@ func predefinedVariables() Variables {
 							Items: map[string]*Object{},
 							Value: &Accessor{
 								Get:       types.IntegerType,
-								Set:       types.NeverType,
+								Set:       types.IntegerType,
 								Unset:     false,
 								Scopes:    RECV | ERROR | FETCH | DELIVER | LOG,
 								Reference: "https://developer.fastly.com/reference/vcl/variables/client-connection/client-socket-cwnd/",


### PR DESCRIPTION
fixes #33

The [Fastly doc](https://developer.fastly.com/reference/vcl/functions/randomness/randomstr/) says `randomstr` function spec is:

```
STRING randomstr(INTEGER len [, STRING characters])
```

The second argument is optional so we need to be valid even if a single argument is supplied.