### PR TITLE
[bugfix] Fix builtin accessor and assign operator

### DIFF
--- a/__generator__/builtin.yml
+++ b/__generator__/builtin.yml
@@ -1216,3 +1216,4 @@ uuid.x500:
   reference: "https://developer.fastly.com/reference/vcl/functions/uuid/uuid-x500/"
   on: [RECV, HASH, HIT, MISS, PASS, FETCH, ERROR, DELIVER, LOG]
   return: STRING
+

--- a/__generator__/predefined.yml
+++ b/__generator__/predefined.yml
@@ -2057,5 +2057,6 @@ waf.logged:
   get: BOOL
 
 LF:
+  reference: "https://developer.fastly.com/reference/vcl/types/string/"
   on: [RECV, HASH, HIT, MISS, PASS, FETCH, ERROR, DELIVER, LOG]
   get: STRING

--- a/__generator__/predefined.yml
+++ b/__generator__/predefined.yml
@@ -272,6 +272,7 @@ bereq.method:
   reference: "https://developer.fastly.com/reference/vcl/variables/backend-request/bereq-method/"
   on: [PASS, MISS, FETCH]
   get: STRING
+  set: STRING
 
 bereq.proto:
   reference: "https://developer.fastly.com/reference/vcl/variables/backend-request/bereq-proto/"
@@ -282,11 +283,13 @@ bereq.request:
   reference: "https://developer.fastly.com/reference/vcl/variables/backend-request/bereq-request/"
   on: [PASS, MISS, FETCH]
   get: STRING
+  set: STRING
 
 bereq.url:
   reference: "https://developer.fastly.com/reference/vcl/variables/backend-request/bereq-url/"
   on: [PASS, MISS, FETCH]
   get: STRING
+  set: STRING
 
 bereq.url.basename:
   reference: "https://developer.fastly.com/reference/vcl/variables/backend-request/bereq-url-basename/"
@@ -340,7 +343,7 @@ beresp.grace:
   reference: "https://developer.fastly.com/reference/vcl/variables/backend-response/beresp-grace/"
   on: [FETCH]
   get: RTIME
-  set: BOOL
+  set: RTIME
 
 beresp.gzip:
   reference: "https://developer.fastly.com/reference/vcl/variables/backend-response/beresp-gzip/"
@@ -426,6 +429,7 @@ obj.grace:
   reference: "https://developer.fastly.com/reference/vcl/variables/cache-object/obj-grace/"
   on: [HIT, ERROR, LOG]
   get: RTIME
+  set: RTIME
 
 obj.hits:
   reference: "https://developer.fastly.com/reference/vcl/variables/cache-object/obj-hits/"
@@ -1252,11 +1256,13 @@ resp.response:
   reference: "https://developer.fastly.com/reference/vcl/variables/client-response/resp-response/"
   on: [DELIVER, LOG]
   get: STRING
+  set: STRING
 
 resp.status:
   reference: "https://developer.fastly.com/reference/vcl/variables/client-response/resp-status/"
   on: [DELIVER, LOG]
   get: INTEGER
+  set: INTEGER
 
 time.to_first_byte:
   reference: "https://developer.fastly.com/reference/vcl/variables/client-response/time-to-first-byte/"
@@ -2049,3 +2055,7 @@ waf.logged:
   reference: "https://developer.fastly.com/reference/vcl/subroutines/waf-debug-log/"
   on: [LOG]
   get: BOOL
+
+LF:
+  on: [RECV, HASH, HIT, MISS, PASS, FETCH, ERROR, DELIVER, LOG]
+  get: STRING

--- a/cmd/falco/snippet.go
+++ b/cmd/falco/snippet.go
@@ -41,7 +41,7 @@ func (s *Snippet) Compile(ctx *context.Context) error {
 		return err
 	}
 	l := linter.New()
-	l.Lint(vcl, ctx)
+	l.Lint(vcl, ctx, false)
 	return nil
 }
 

--- a/context/context.go
+++ b/context/context.go
@@ -235,6 +235,24 @@ func (c *Context) AddDirector(name string, director *types.Director) error {
 		},
 	}
 
+	// And, director target backend identifilers should be marked as used
+	for _, d := range director.Decl.Properties {
+		bo, ok := d.(*ast.DirectorBackendObject)
+		if !ok {
+			continue
+		}
+		for _, v := range bo.Values {
+			if v.Key.Value != "backend" {
+				continue
+			}
+			if ident, ok := v.Value.(*ast.Ident); ok {
+				if b, ok := c.Backends[ident.Value]; ok {
+					b.IsUsed = true
+				}
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -3,6 +3,7 @@ package context
 import (
 	"testing"
 
+	"github.com/ysugimoto/falco/ast"
 	"github.com/ysugimoto/falco/types"
 )
 
@@ -174,7 +175,11 @@ func TestDynamicVariableExist(t *testing.T) {
 		if _, err := c.Get("director.example.healthy"); err == nil {
 			t.Errorf("expected error but got nil")
 		}
-		c.AddDirector("example", &types.Director{})
+		c.AddDirector("example", &types.Director{
+			Decl: &ast.DirectorDeclaration{
+				Properties: []ast.Expression{},
+			},
+		})
 		if v, err := c.Get("director.example.healthy"); err != nil {
 			t.Errorf("expected nil but got error: %s", err)
 		} else if v != types.BoolType {

--- a/context/identifilers.go
+++ b/context/identifilers.go
@@ -38,5 +38,12 @@ func builtinIdentifiers() map[string]struct{} {
 		"standard":  {},
 		"url":       {},
 		"url_nopad": {},
+
+		// use for setcookie.get_value_by_name argument of ID
+		"req":    {},
+		"bereq":  {},
+		"obj":    {},
+		"beresp": {},
+		"resp":   {},
 	}
 }

--- a/context/predefined.go
+++ b/context/predefined.go
@@ -8,6 +8,16 @@ import (
 
 func predefinedVariables() Variables {
 	return Variables{
+		"LF": &Object{
+			Items: map[string]*Object{},
+			Value: &Accessor{
+				Get:       types.StringType,
+				Set:       types.NeverType,
+				Unset:     false,
+				Scopes:    RECV | HASH | HIT | MISS | PASS | FETCH | ERROR | DELIVER | LOG,
+				Reference: "",
+			},
+		},
 		"backend": &Object{
 			Items: map[string]*Object{
 				"conn": &Object{
@@ -410,7 +420,7 @@ func predefinedVariables() Variables {
 					Items: map[string]*Object{},
 					Value: &Accessor{
 						Get:       types.StringType,
-						Set:       types.NeverType,
+						Set:       types.StringType,
 						Unset:     false,
 						Scopes:    PASS | MISS | FETCH,
 						Reference: "https://developer.fastly.com/reference/vcl/variables/backend-request/bereq-method/",
@@ -430,7 +440,7 @@ func predefinedVariables() Variables {
 					Items: map[string]*Object{},
 					Value: &Accessor{
 						Get:       types.StringType,
-						Set:       types.NeverType,
+						Set:       types.StringType,
 						Unset:     false,
 						Scopes:    PASS | MISS | FETCH,
 						Reference: "https://developer.fastly.com/reference/vcl/variables/backend-request/bereq-request/",
@@ -491,7 +501,7 @@ func predefinedVariables() Variables {
 					},
 					Value: &Accessor{
 						Get:       types.StringType,
-						Set:       types.NeverType,
+						Set:       types.StringType,
 						Unset:     false,
 						Scopes:    PASS | MISS | FETCH,
 						Reference: "https://developer.fastly.com/reference/vcl/variables/backend-request/bereq-url/",
@@ -609,7 +619,7 @@ func predefinedVariables() Variables {
 					Items: map[string]*Object{},
 					Value: &Accessor{
 						Get:       types.RTimeType,
-						Set:       types.BoolType,
+						Set:       types.RTimeType,
 						Unset:     false,
 						Scopes:    FETCH,
 						Reference: "https://developer.fastly.com/reference/vcl/variables/backend-response/beresp-grace/",
@@ -2466,7 +2476,7 @@ func predefinedVariables() Variables {
 					Items: map[string]*Object{},
 					Value: &Accessor{
 						Get:       types.RTimeType,
-						Set:       types.NeverType,
+						Set:       types.RTimeType,
 						Unset:     false,
 						Scopes:    HIT | ERROR | LOG,
 						Reference: "https://developer.fastly.com/reference/vcl/variables/cache-object/obj-grace/",
@@ -3341,7 +3351,7 @@ func predefinedVariables() Variables {
 					Items: map[string]*Object{},
 					Value: &Accessor{
 						Get:       types.StringType,
-						Set:       types.NeverType,
+						Set:       types.StringType,
 						Unset:     false,
 						Scopes:    DELIVER | LOG,
 						Reference: "https://developer.fastly.com/reference/vcl/variables/client-response/resp-response/",
@@ -3382,7 +3392,7 @@ func predefinedVariables() Variables {
 					Items: map[string]*Object{},
 					Value: &Accessor{
 						Get:       types.IntegerType,
-						Set:       types.NeverType,
+						Set:       types.IntegerType,
 						Unset:     false,
 						Scopes:    DELIVER | LOG,
 						Reference: "https://developer.fastly.com/reference/vcl/variables/client-response/resp-status/",

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -1289,7 +1289,7 @@ sub bar {
 		}
 
 		l := New()
-		l.Lint(vcl, context.New())
+		l.Lint(vcl, context.New(), true)
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
 		}
@@ -1305,7 +1305,7 @@ acl foo {}
 		}
 
 		l := New()
-		l.Lint(vcl, context.New())
+		l.Lint(vcl, context.New(), true)
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
 		}
@@ -1327,7 +1327,7 @@ sub bar {
 		}
 
 		l := New()
-		l.Lint(vcl, context.New())
+		l.Lint(vcl, context.New(), true)
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
 		}
@@ -1343,7 +1343,7 @@ table foo {}
 		}
 
 		l := New()
-		l.Lint(vcl, context.New())
+		l.Lint(vcl, context.New(), true)
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
 		}
@@ -1365,7 +1365,7 @@ sub vcl_recl {
 		}
 
 		l := New()
-		l.Lint(vcl, context.New())
+		l.Lint(vcl, context.New(), true)
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
 		}
@@ -1381,7 +1381,7 @@ backend foo {}
 		}
 
 		l := New()
-		l.Lint(vcl, context.New())
+		l.Lint(vcl, context.New(), true)
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
 		}
@@ -1403,7 +1403,7 @@ sub vcl_recl {
 		}
 
 		l := New()
-		l.Lint(vcl, context.New())
+		l.Lint(vcl, context.New(), true)
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
 		}
@@ -1419,7 +1419,7 @@ sub foo {}
 		}
 
 		l := New()
-		l.Lint(vcl, context.New())
+		l.Lint(vcl, context.New(), true)
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
 		}
@@ -1440,7 +1440,7 @@ sub vcl_recv {
 		}
 
 		l := New()
-		l.Lint(vcl, context.New())
+		l.Lint(vcl, context.New(), true)
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
 		}
@@ -1459,7 +1459,7 @@ sub vcl_recv {
 		}
 
 		l := New()
-		l.Lint(vcl, context.New())
+		l.Lint(vcl, context.New(), true)
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
 		}


### PR DESCRIPTION
This PR fixes some of bugs:

### some predefined variables should be settable

Some predefined variables should be able to use in `set` and `add` statements. This PR modifies as settable:

- `bereq.method`
- `bereq.request`
- `beresp.grace`
- `resp.status`
- `resp.response`

And add `LF` predefined variable (probably undocumented)

### Fix wrong display code in line included VCL error

On lint error of `unused/declaration` rule, `falco` prints line of main vcl. This PR fixes actual code lines.