### PR TITLE
Implement remote acl

### DIFF
--- a/cmd/falco/runner.go
+++ b/cmd/falco/runner.go
@@ -91,7 +91,6 @@ func NewRunner(mainVcl string, c *Config) (*Runner, error) {
 			} else if err := snippet.Compile(r.context); err != nil {
 				writeln(red, err.Error())
 			}
-			fmt.Printf("%+v\n", r.context.Acls)
 		}()
 	}
 

--- a/cmd/falco/runner.go
+++ b/cmd/falco/runner.go
@@ -91,6 +91,7 @@ func NewRunner(mainVcl string, c *Config) (*Runner, error) {
 			} else if err := snippet.Compile(r.context); err != nil {
 				writeln(red, err.Error())
 			}
+			fmt.Printf("%+v\n", r.context.Acls)
 		}()
 	}
 

--- a/cmd/falco/snippet.go
+++ b/cmd/falco/snippet.go
@@ -81,7 +81,7 @@ func (s *Snippet) Fetch(c _context.Context) error {
 func (s *Snippet) fetchEdgeDictionary(c _context.Context, version int64) ([]string, error) {
 	dicts, err := s.client.ListEdgeDictionaries(c, version)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get latest version %w", err)
+		return nil, fmt.Errorf("Failed to get edge dictionaries for version %w", err)
 	}
 
 	tmpl, err := template.New("table").Parse(tableTemplate)
@@ -103,6 +103,9 @@ func (s *Snippet) fetchEdgeDictionary(c _context.Context, version int64) ([]stri
 // Fetch remote Access Control entries
 func (s *Snippet) fetchAccessControl(c _context.Context, version int64) ([]string, error) {
 	acls, err := s.client.ListAccessControlLists(c, version)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get access control lists for version %w", err)
+	}
 
 	tmpl, err := template.New("acl").Parse(aclTemplate)
 	if err != nil {

--- a/cmd/falco/snippet.go
+++ b/cmd/falco/snippet.go
@@ -24,6 +24,14 @@ table {{ .Name }} {
 }
 `
 
+var aclTemplate = `
+acl {{ .Name }} {
+	{{- range .Entries }}
+	{{ if .Negated }}!{{ end }}"{{ .Ip }}"{{ if .Subnet }}/{{ .Subnet }}{{ end }};{{ if .Comment }}  # {{ .Comment }}{{ end }}
+	{{- end }}
+}
+`
+
 type Snippet struct {
 	client   *remote.FastlyClient
 	snippets []string
@@ -46,24 +54,31 @@ func (s *Snippet) Compile(ctx *context.Context) error {
 }
 
 func (s *Snippet) Fetch(c _context.Context) error {
+	// Fetch latest version
+	version, err := s.client.LatestVersion(c)
+	if err != nil {
+		return fmt.Errorf("Failed to get latest version %w", err)
+	}
 	write(white, "Fetching Edge Dictionaries...")
-	dicts, err := s.fetchEdgeDictionary(c)
+	dicts, err := s.fetchEdgeDictionary(c, version)
 	if err != nil {
 		return err
 	}
 	writeln(white, "Done")
 	s.snippets = append(s.snippets, dicts...)
+
+	write(white, "Fatching Access Control Lists...")
+	acls, err := s.fetchAccessControl(c, version)
+	if err != nil {
+		return err
+	}
+	writeln(white, "Done")
+	s.snippets = append(s.snippets, acls...)
 	return nil
 }
 
 // Fetch remote Edge dictionary items
-func (s *Snippet) fetchEdgeDictionary(c _context.Context) ([]string, error) {
-	// Fetch latest version
-	version, err := s.client.LatestVersion(c)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to get latest version %w", err)
-	}
-
+func (s *Snippet) fetchEdgeDictionary(c _context.Context, version int64) ([]string, error) {
 	dicts, err := s.client.ListEdgeDictionaries(c, version)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get latest version %w", err)
@@ -78,6 +93,26 @@ func (s *Snippet) fetchEdgeDictionary(c _context.Context) ([]string, error) {
 	for _, dict := range dicts {
 		buf := new(bytes.Buffer)
 		if err := tmpl.Execute(buf, dict); err != nil {
+			return nil, fmt.Errorf("Failed to render table template: %w", err)
+		}
+		snippets = append(snippets, buf.String())
+	}
+	return snippets, nil
+}
+
+// Fetch remote Access Control entries
+func (s *Snippet) fetchAccessControl(c _context.Context, version int64) ([]string, error) {
+	acls, err := s.client.ListAccessControlLists(c, version)
+
+	tmpl, err := template.New("acl").Parse(aclTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to compilte acl template: %w", err)
+	}
+
+	var snippets []string
+	for _, a := range acls {
+		buf := new(bytes.Buffer)
+		if err := tmpl.Execute(buf, a); err != nil {
 			return nil, fmt.Errorf("Failed to render table template: %w", err)
 		}
 		snippets = append(snippets, buf.String())

--- a/context/predefined.go
+++ b/context/predefined.go
@@ -15,7 +15,7 @@ func predefinedVariables() Variables {
 				Set:       types.NeverType,
 				Unset:     false,
 				Scopes:    RECV | HASH | HIT | MISS | PASS | FETCH | ERROR | DELIVER | LOG,
-				Reference: "",
+				Reference: "https://developer.fastly.com/reference/vcl/types/string/",
 			},
 		},
 		"backend": &Object{

--- a/remote/client.go
+++ b/remote/client.go
@@ -3,7 +3,6 @@ package remote
 import (
 	"context"
 	"fmt"
-	"io"
 	"sync"
 	"time"
 
@@ -31,8 +30,9 @@ func NewFastlyClient(c *http.Client, serviceId, apiKey string) *FastlyClient {
 	}
 }
 
-func (c *FastlyClient) request(ctx context.Context, method, url string, body io.Reader, v interface{}) error {
-	req, err := http.NewRequestWithContext(ctx, method, fastlyApiBaseUrl+url, body)
+func (c *FastlyClient) request(ctx context.Context, url string, v interface{}) error {
+	// falco always call API with GET request because we DO NOT change any resources
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fastlyApiBaseUrl+url, nil)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -58,7 +58,7 @@ func (c *FastlyClient) LatestVersion(ctx context.Context) (int64, error) {
 
 	endpoint := fmt.Sprintf("/service/%s/version/active", c.serviceId)
 	var v Version
-	if err := c.request(ctx, http.MethodGet, endpoint, nil, &v); err != nil {
+	if err := c.request(ctx, endpoint, &v); err != nil {
 		return 0, errors.WithStack(err)
 	}
 
@@ -68,7 +68,7 @@ func (c *FastlyClient) LatestVersion(ctx context.Context) (int64, error) {
 func (c *FastlyClient) ListEdgeDictionaries(ctx context.Context, version int64) ([]*EdgeDictionary, error) {
 	endpoint := fmt.Sprintf("/service/%s/version/%d/dictionary", c.serviceId, version)
 	var dicts []*EdgeDictionary
-	if err := c.request(ctx, http.MethodGet, endpoint, nil, &dicts); err != nil {
+	if err := c.request(ctx, endpoint, &dicts); err != nil {
 		return nil, errors.WithStack(err)
 	}
 
@@ -105,7 +105,7 @@ func (c *FastlyClient) ListEdgeDictionaries(ctx context.Context, version int64) 
 func (c *FastlyClient) ListEdgeDictionaryItems(ctx context.Context, dictId string) ([]*EdgeDictionaryItem, error) {
 	endpoint := fmt.Sprintf("/service/%s/dictionary/%s/items", c.serviceId, dictId)
 	var items []*EdgeDictionaryItem
-	if err := c.request(ctx, http.MethodGet, endpoint, nil, &items); err != nil {
+	if err := c.request(ctx, endpoint, &items); err != nil {
 		return nil, errors.WithStack(err)
 	}
 
@@ -115,7 +115,7 @@ func (c *FastlyClient) ListEdgeDictionaryItems(ctx context.Context, dictId strin
 func (c *FastlyClient) ListAccessControlLists(ctx context.Context, version int64) ([]*AccessControl, error) {
 	endpoint := fmt.Sprintf("/service/%s/version/%d/acl", c.serviceId, version)
 	var acls []*AccessControl
-	if err := c.request(ctx, http.MethodGet, endpoint, nil, &acls); err != nil {
+	if err := c.request(ctx, endpoint, &acls); err != nil {
 		return nil, errors.WithStack(err)
 	}
 
@@ -152,7 +152,7 @@ func (c *FastlyClient) ListAccessControlLists(ctx context.Context, version int64
 func (c *FastlyClient) ListAccessControlEntries(ctx context.Context, aclId string) ([]*AccessControlEntry, error) {
 	endpoint := fmt.Sprintf("/service/%s/acl/%s/entries", c.serviceId, aclId)
 	var entries []*AccessControlEntry
-	if err := c.request(ctx, http.MethodGet, endpoint, nil, &entries); err != nil {
+	if err := c.request(ctx, endpoint, &entries); err != nil {
 		return nil, errors.WithStack(err)
 	}
 

--- a/remote/entity.go
+++ b/remote/entity.go
@@ -14,3 +14,16 @@ type EdgeDictionaryItem struct {
 	Key   string `json:"item_key"`
 	Value string `json:"item_value"`
 }
+
+type AccessControl struct {
+	Id      string `json:"id"`
+	Name    string `json:"name"`
+	Entries []*AccessControlEntry
+}
+
+type AccessControlEntry struct {
+	Ip      string `json:"ip"`
+	Negated string `json:"negated"`
+	Subnet  *int64 `json:"subnet"`
+	Comment string `json:"comment"`
+}


### PR DESCRIPTION
Fixes #37 

This PR implements a new feature that fetches and compiles [Access Control Lists](https://developer.fastly.com/reference/api/acls/) as a VCL snippet.

The implementation is the same as `Edge Dictionary`.