### PR TITLE
improve type comparison in set/add statement

### DIFF
--- a/linter/errors.go
+++ b/linter/errors.go
@@ -162,21 +162,17 @@ func ErrorCodeRange(m *ast.Meta, code int64) *LintError {
 	}
 }
 
-// FIXME: accept *ast.Meta
-func InvalidTypeOperator(m *ast.Meta, op string, expects ...types.Type) *LintError {
-	es := make([]string, len(expects))
-	for i, v := range expects {
-		es[i] = v.String()
-	}
-
+func InvalidTypeOperator(m *ast.Meta, op string, left, right types.Type) *LintError {
 	return &LintError{
 		Severity: ERROR,
 		Token:    m.Token,
-		Message:  fmt.Sprintf(`could not operand, "%s" operator expects type %s on right expression`, op, strings.Join(es, " or ")),
+		Message: fmt.Sprintf(
+			`invalid operator, "%s" count not use between left %s and %s right types`,
+			op, left, right,
+		),
 	}
 }
 
-// FIXME: accept *ast.Meta
 func InvalidOperator(m *ast.Meta, op string, left types.Type) *LintError {
 	return &LintError{
 		Severity: ERROR,

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -1465,3 +1465,19 @@ sub vcl_recv {
 		}
 	})
 }
+
+// https://github.com/ysugimoto/falco/issues/39
+func TestPassIssue39(t *testing.T) {
+	t.Run("pass", func(t *testing.T) {
+		input := `
+sub vcl_fetch {
+	### FASTLY fetch
+    if (parse_time_delta(beresp.http.Edge-Control:cache-maxage) >= 0) {
+      set beresp.ttl = parse_time_delta(beresp.http.Edge-Control:cache-maxage);
+    }
+    return(deliver);
+}
+`
+		assertNoError(t, input)
+	})
+}

--- a/linter/operator.go
+++ b/linter/operator.go
@@ -1,0 +1,202 @@
+package linter
+
+import (
+	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/types"
+)
+
+// See expression type comparison table:
+// https://docs.google.com/spreadsheets/d/16xRPugw9ubKA1nXHIc5ysVZKokLLhysI-jAu3qbOFJ8/edit#gid=0
+
+// Lint assignment operator of "="
+func (l *Linter) lintAssignOperator(op *ast.Operator, name string, left, right types.Type, isLiteral bool) {
+	switch left {
+	case types.IntegerType:
+		switch right {
+		// allows both variable and literal
+		case types.IntegerType:
+			return
+		// allows variable only, disallow literal
+		case types.FloatType, types.RTimeType, types.TimeType:
+			if isLiteral {
+				l.Error(InvalidType(op.Meta, name, left, right).Match(OPERATOR_ASSIGNMENT))
+			}
+		// disallow
+		default:
+			l.Error(InvalidType(op.Meta, name, left, right).Match(OPERATOR_ASSIGNMENT))
+		}
+	case types.FloatType:
+		switch right {
+		// allows both variable and literal
+		case types.IntegerType, types.FloatType:
+			return
+		// allows variable only, disallow literal
+		case types.RTimeType, types.TimeType:
+			if isLiteral {
+				l.Error(InvalidType(op.Meta, name, left, right).Match(OPERATOR_ASSIGNMENT))
+			}
+		// disallow
+		default:
+			l.Error(InvalidType(op.Meta, name, left, right).Match(OPERATOR_ASSIGNMENT))
+		}
+	case types.StringType:
+		switch right {
+		// allows both variable and literal
+		case types.StringType, types.BoolType:
+			return
+		// allows variable only, disallow literal
+		case types.IntegerType, types.FloatType, types.RTimeType, types.TimeType, types.IPType:
+			if isLiteral {
+				l.Error(InvalidType(op.Meta, name, left, right).Match(OPERATOR_ASSIGNMENT))
+			}
+		// disallow
+		default:
+			l.Error(InvalidType(op.Meta, name, left, right).Match(OPERATOR_ASSIGNMENT))
+		}
+	case types.RTimeType, types.TimeType:
+		switch right {
+		// allows both variable and literal
+		case types.RTimeType, types.TimeType:
+			return
+		// allows variable only, disallow literal
+		case types.IntegerType, types.FloatType:
+			if isLiteral {
+				l.Error(InvalidType(op.Meta, name, left, right).Match(OPERATOR_ASSIGNMENT))
+			}
+		// disallow
+		default:
+			l.Error(InvalidType(op.Meta, name, left, right).Match(OPERATOR_ASSIGNMENT))
+		}
+	case types.IPType:
+		switch right {
+		// allows both variable and literal
+		case types.StringType, types.IPType:
+			return
+		// disallow
+		default:
+			l.Error(InvalidType(op.Meta, name, left, right).Match(OPERATOR_ASSIGNMENT))
+		}
+	default: // types.BackendType or types.BoolType
+		if left != right {
+			l.Error(InvalidType(op.Meta, name, left, right).Match(OPERATOR_ASSIGNMENT))
+		}
+	}
+}
+
+// Lint addition and subtraction operator of "+=" and "-="
+func (l *Linter) lintAddSubOperator(op *ast.Operator, left, right types.Type, isLiteral bool) {
+	switch left {
+	case types.IntegerType:
+		switch right {
+		// allows both variable and literal
+		case types.IntegerType:
+			return
+		// allows variable only, disallow literal
+		case types.FloatType, types.RTimeType, types.TimeType:
+			if isLiteral {
+				l.Error(InvalidTypeOperator(op.Meta, op.Operator, left, right).Match(OPERATOR_CONDITIONAL))
+			}
+		// disallow
+		default:
+			l.Error(InvalidTypeOperator(op.Meta, op.Operator, left, right).Match(OPERATOR_CONDITIONAL))
+		}
+	case types.FloatType:
+		switch right {
+		// allows both variable and literal
+		case types.IntegerType, types.FloatType:
+			return
+		// allows variable only, disallow literal
+		case types.RTimeType, types.TimeType:
+			if isLiteral {
+				l.Error(InvalidTypeOperator(op.Meta, op.Operator, left, right).Match(OPERATOR_CONDITIONAL))
+			}
+		// disallow
+		default:
+			l.Error(InvalidTypeOperator(op.Meta, op.Operator, left, right).Match(OPERATOR_CONDITIONAL))
+		}
+	case types.RTimeType:
+		switch right {
+		// allows both variable and literal
+		case types.RTimeType:
+			return
+		// allows variable only, disallow literal
+		case types.IntegerType, types.FloatType, types.TimeType:
+			if isLiteral {
+				l.Error(InvalidTypeOperator(op.Meta, op.Operator, left, right).Match(OPERATOR_CONDITIONAL))
+			}
+		// disallow
+		default:
+			l.Error(InvalidTypeOperator(op.Meta, op.Operator, left, right).Match(OPERATOR_CONDITIONAL))
+		}
+	case types.TimeType:
+		switch right {
+		// allows both variable and literal
+		case types.RTimeType:
+			return
+		// allows variable only, disallow literal
+		case types.IntegerType, types.FloatType:
+			if isLiteral {
+				l.Error(InvalidTypeOperator(op.Meta, op.Operator, left, right).Match(OPERATOR_CONDITIONAL))
+			}
+		// disallow
+		default:
+			l.Error(InvalidTypeOperator(op.Meta, op.Operator, left, right).Match(OPERATOR_CONDITIONAL))
+		}
+	default:
+		// disallow other types
+		l.Error(InvalidOperator(op.Meta, op.Operator, left).Match(OPERATOR_CONDITIONAL))
+	}
+}
+
+// Lint arithmetic operator excepts addition and subtraction of "*=", "/=" and "%="
+func (l *Linter) lintArithmeticOpereator(op *ast.Operator, left, right types.Type, isLiteral bool) {
+	switch left {
+	case types.IntegerType:
+		switch right {
+		// allows both variable and literal
+		case types.IntegerType:
+			return
+		// allows variable only, disallow literal
+		case types.FloatType:
+			if isLiteral {
+				l.Error(InvalidTypeOperator(op.Meta, op.Operator, left, right).Match(OPERATOR_CONDITIONAL))
+			}
+		// disallow
+		default:
+			l.Error(InvalidTypeOperator(op.Meta, op.Operator, left, right).Match(OPERATOR_CONDITIONAL))
+		}
+	case types.FloatType, types.RTimeType:
+		switch right {
+		// allows both variable and literal
+		case types.IntegerType, types.FloatType:
+			return
+		// disallow
+		default:
+			l.Error(InvalidTypeOperator(op.Meta, op.Operator, left, right).Match(OPERATOR_CONDITIONAL))
+		}
+	default:
+		l.Error(InvalidOperator(op.Meta, op.Operator, left).Match(OPERATOR_ASSIGNMENT))
+	}
+}
+
+func (l *Linter) lintBitwiseOperator(op *ast.Operator, left, right types.Type) {
+	switch left {
+	case types.IntegerType:
+		if right != types.IntegerType {
+			l.Error(InvalidTypeOperator(op.Meta, op.Operator, left, right).Match(OPERATOR_CONDITIONAL))
+		}
+	default:
+		l.Error(InvalidOperator(op.Meta, op.Operator, left).Match(OPERATOR_CONDITIONAL))
+	}
+}
+
+func (l *Linter) lintLogicalOperator(op *ast.Operator, left, right types.Type) {
+	switch left {
+	case types.BoolType:
+		if right != types.BoolType {
+			l.Error(InvalidTypeOperator(op.Meta, op.Operator, left, right).Match(OPERATOR_CONDITIONAL))
+		}
+	default:
+		l.Error(InvalidOperator(op.Meta, op.Operator, left).Match(OPERATOR_CONDITIONAL))
+	}
+}

--- a/linter/operator.go
+++ b/linter/operator.go
@@ -148,7 +148,7 @@ func (l *Linter) lintAddSubOperator(op *ast.Operator, left, right types.Type, is
 	}
 }
 
-// Lint arithmetic operator excepts addition and subtraction of "*=", "/=" and "%="
+// Lint arithmetic operator excepts addition and subtraction. Lint "*=", "/=" and "%=" operator
 func (l *Linter) lintArithmeticOpereator(op *ast.Operator, left, right types.Type, isLiteral bool) {
 	switch left {
 	case types.IntegerType:
@@ -179,6 +179,7 @@ func (l *Linter) lintArithmeticOpereator(op *ast.Operator, left, right types.Typ
 	}
 }
 
+// Lint bitwise related operators "|=", "&=", "^=", "<<=", ">>=", "rol=" and "ror=".
 func (l *Linter) lintBitwiseOperator(op *ast.Operator, left, right types.Type) {
 	switch left {
 	case types.IntegerType:
@@ -190,6 +191,7 @@ func (l *Linter) lintBitwiseOperator(op *ast.Operator, left, right types.Type) {
 	}
 }
 
+// Lint logical operators "||=" and "&&=".
 func (l *Linter) lintLogicalOperator(op *ast.Operator, left, right types.Type) {
 	switch left {
 	case types.BoolType:


### PR DESCRIPTION
Fix #39

This PR fixes #39 of type comparison of set statement between RTIME vs INTEGER.

Additionally, I investigated every primitive type comparison in `set` statement for each operator.
Some operator could accept variable but forbid literal expression, so I summarized in spreadsheet,  see: https://docs.google.com/spreadsheets/d/16xRPugw9ubKA1nXHIc5ysVZKokLLhysI-jAu3qbOFJ8/edit?usp=sharing 
