### PR TITLE
Fixes #42 - Linting `client.geo.city.utf8`

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -518,7 +518,7 @@ func splitName(name string) (string, []string) {
 	var first string
 	var remains []string
 
-	sep := strings.SplitN(name, ".", 3)
+	sep := strings.SplitN(name, ".", 4)
 	if len(sep) == 1 {
 		first = sep[0]
 	} else {

--- a/context/context.go
+++ b/context/context.go
@@ -396,6 +396,13 @@ func (c *Context) Declare(name string, valueType types.Type, m *ast.Meta) error 
 
 	first, remains := splitName(name)
 
+	// declaration syntax for variables is:
+	// declare local var.variableName [type]
+	// which means that they must be prefixed with var.
+	if first != "var" {
+		return fmt.Errorf(`variable "%s" declaration error. Variable be prefixed with 'var.'`, name)
+	}
+
 	obj, ok := c.Variables[first]
 	if !ok {
 		// Newly assign object

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -130,6 +130,9 @@ func TestContextDeclare(t *testing.T) {
 		if err := c.Declare("var.foo", types.StringType, nil); err == nil {
 			t.Errorf("expected error but got nil")
 		}
+		if err := c.Declare("variable.bar", types.StringType, nil); err == nil {
+			t.Errorf("expected error but got nil")
+		}
 	})
 }
 

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -403,6 +403,15 @@ sub foo {
 		assertNoError(t, input)
 	})
 
+	t.Run("pass with deep fastly variable", func(t *testing.T) {
+		input := `
+sub foo {
+	set req.http.Host = client.geo.city.utf8;
+}`
+
+		assertNoError(t, input)
+	})
+
 	t.Run("invalid variable name", func(t *testing.T) {
 		input := `
 sub foo {


### PR DESCRIPTION
As discussed in #42, setting the split depth to 3 causes variables
such as `client.geo.city.utf8` to not be recognized.

Signed-off-by: Sotiris Nanopoulos <sotiris.nanopoulos@reddit.com>