### PR TITLE
fix file not found error and enable to parse vcl extension files

### DIFF
--- a/cmd/falco/runner.go
+++ b/cmd/falco/runner.go
@@ -208,9 +208,13 @@ func (r *Runner) Run() (*RunnerResult, error) {
 }
 
 func (r *Runner) run(vclFile string, isMain bool) ([]*plugin.VCL, error) {
+	fmt.Printf("%q\n", vclFile)
+	if vclFile == "" {
+		return nil, nil
+	}
 	fp, err := os.Open(vclFile)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to open file: %s", vclFile)
+	if err != nil { 
+		return nil, fmt.Errorf("Failed to open file: %s %v", vclFile, err)
 	}
 	defer fp.Close()
 
@@ -239,8 +243,8 @@ func (r *Runner) run(vclFile string, isMain bool) ([]*plugin.VCL, error) {
 		var file string
 		// Find for each include paths
 		for _, p := range r.includePaths {
-			if _, err := os.Stat(filepath.Join(p, include.Module.Value+".vcl")); err == nil {
-				file = filepath.Join(p, include.Module.Value+".vcl")
+			if _, err := os.Stat(filepath.Join(p, include.Module.Value)); err == nil {
+				file = filepath.Join(p, include.Module.Value)
 				break
 			}
 		}


### PR DESCRIPTION
how to build: 
- go build ./cmd/*
- in our cdn repo, go to src/vcl and execute
` (path to this repo main binary)../../../falco/main -I . ./main.vcl >& ../../errors.txt`