### PR TITLE
implement stat command

### DIFF
--- a/cmd/falco/main.go
+++ b/cmd/falco/main.go
@@ -223,7 +223,10 @@ func runStats(runner *Runner, printJson bool) {
 	if printJson {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
-		enc.Encode(stats)
+		if err := enc.Encode(stats); err != nil {
+			writeln(red, err.Error())
+			os.Exit(1)
+		}
 		return
 	}
 

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -73,6 +73,10 @@ func (l *Lexer) GetLine(n int) (string, bool) {
 	return l.stack[n-1], true
 }
 
+func (l *Lexer) LineCount() int {
+	return l.line - 1
+}
+
 func (l *Lexer) PeekToken() token.Token {
 	t := l.NextToken()
 	// peek token stack works FIFO queue

--- a/parser/statement_parser.go
+++ b/parser/statement_parser.go
@@ -147,7 +147,7 @@ func (p *Parser) parseSetStatement() (*ast.SetStatement, error) {
 	stmt.Value = exp
 
 	if !p.peekTokenIs(token.SEMICOLON) {
-		return nil, errors.WithStack(MissingSemicolon(p.peekToken))
+		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
 	stmt.Meta.Trailing = p.trailing()
 	p.nextToken() // point to SEMICOLON


### PR DESCRIPTION
This PR implements `stats` subcommand to see a target VCL statistics.

### Syntax

```shell
falco stats [vcl file]
```

### Result

<img width="749" alt="スクリーンショット 2022-03-31 20 13 36" src="https://user-images.githubusercontent.com/1000401/161042717-cdefd118-df8a-4526-a30e-3f3d59881d1d.png">

The `stats` command factories all target VCLs and display statistics from parsed context.

Additionary, stats command accepts `-json` option to output pretty JSON format.

<img width="816" alt="スクリーンショット 2022-03-31 20 16 08" src="https://user-images.githubusercontent.com/1000401/161043150-07811ac8-125f-4c8c-ad2b-ebb0278adee2.png">

