### PR TITLE
allow subroutine hoisting

### DIFF
--- a/linter/errors.go
+++ b/linter/errors.go
@@ -110,7 +110,7 @@ func UndefinedSubroutine(m *ast.Meta, name string) *LintError {
 	return &LintError{
 		Severity: ERROR,
 		Token:    m.Token,
-		Message:  fmt.Sprintf("Subroutine %s is not defined. If you have this subroutine, please define before call it", name),
+		Message:  fmt.Sprintf("Subroutine %s is not defined. Did you forget to include of typo its name?", name),
 	}
 }
 

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -115,23 +115,26 @@ func (l *Linter) lint(node ast.Node, ctx *context.Context) types.Type {
 	// Root program
 	case *ast.VCL:
 		return l.lintVCL(t, ctx)
-	// Statements
+
+	// Declarations
 	case *ast.AclDeclaration:
 		return l.lintAclDeclaration(t, ctx)
 	case *ast.BackendDeclaration:
 		return l.lintBackendDeclaration(t, ctx)
-	case *ast.ImportStatement:
-		return l.lintImportStatement(t, ctx)
-	case *ast.IncludeStatement:
-		return l.lintIncludeStatement(t, ctx)
 	case *ast.DirectorDeclaration:
 		return l.lintDirectorDeclaration(t, ctx)
 	case *ast.TableDeclaration:
 		return l.lintTableDeclaration(t, ctx)
 	case *ast.SubroutineDeclaration:
 		return l.lintSubRoutineDeclaration(t, ctx)
+
+	// Statements
 	case *ast.BlockStatement:
 		return l.lintBlockStatement(t, ctx)
+	case *ast.ImportStatement:
+		return l.lintImportStatement(t, ctx)
+	case *ast.IncludeStatement:
+		return l.lintIncludeStatement(t, ctx)
 	case *ast.DeclareStatement:
 		return l.lintDeclareStatement(t, ctx)
 	case *ast.SetStatement:
@@ -193,17 +196,104 @@ func (l *Linter) lint(node ast.Node, ctx *context.Context) types.Type {
 }
 
 func (l *Linter) lintVCL(vcl *ast.VCL, ctx *context.Context) types.Type {
-	for _, stmt := range vcl.Statements {
-		l.lint(stmt, ctx)
+	// https://github.com/ysugimoto/falco/issues/50
+	// To support subroutine hoisting, add root statements to context firstly and lint each statements after that.
+	statements := l.factoryRootStatements(vcl, ctx)
+
+	// Lint each statement/declaration logics
+	for _, s := range statements {
+		l.lint(s, ctx)
 	}
+
 	return types.NeverType
 }
 
-func (l *Linter) lintAclDeclaration(decl *ast.AclDeclaration, ctx *context.Context) types.Type {
-	acl := &types.Acl{
-		Decl: decl,
-	}
+func (l *Linter) factoryRootStatements(vcl *ast.VCL, ctx *context.Context) []ast.Statement {
+	var statements []ast.Statement
+	for _, stmt := range vcl.Statements {
+		switch t := stmt.(type) {
+		case *ast.AclDeclaration:
+			if err := ctx.AddAcl(t.Name.Value, &types.Acl{Decl: t}); err != nil {
+				e := &LintError{
+					Severity: ERROR,
+					Token:    t.Name.GetMeta().Token,
+					Message:  err.Error(),
+				}
+				l.Error(e.Match(ACL_DUPLICATED))
+			}
+			statements = append(statements, stmt)
+		case *ast.BackendDeclaration:
+			if err := ctx.AddBackend(t.Name.Value, &types.Backend{BackendDecl: t}); err != nil {
+				e := &LintError{
+					Severity: ERROR,
+					Token:    t.Name.GetMeta().Token,
+					Message:  err.Error(),
+				}
+				l.Error(e.Match(BACKEND_DUPLICATED))
+			}
+			statements = append(statements, stmt)
+		case *ast.ImportStatement:
+			continue
+		case *ast.IncludeStatement:
+			continue
+		case *ast.DirectorDeclaration:
+			if err := ctx.AddDirector(t.Name.Value, &types.Director{Decl: t}); err != nil {
+				e := &LintError{
+					Severity: ERROR,
+					Token:    t.Name.GetMeta().Token,
+					Message:  err.Error(),
+				}
+				l.Error(e.Match(DIRECTOR_DUPLICATED))
+			}
+			statements = append(statements, stmt)
+		case *ast.TableDeclaration:
+			table := &types.Table{
+				Decl:       t,
+				Name:       t.Name.Value,
+				Properties: t.Properties,
+			}
 
+			// Define table value type
+			if t.ValueType == nil {
+				table.ValueType = types.StringType // default as STRING (e.g. Edge Dictionary)
+			} else {
+				v, ok := ValueTypeMap[t.ValueType.Value]
+				if !ok {
+					l.Error(UndefinedTableType(
+						t.ValueType.GetMeta(), t.Name.Value, t.ValueType.Value,
+					).Match(TABLE_TYPE_VARIATION))
+				} else {
+					table.ValueType = v
+				}
+			}
+
+			if err := ctx.AddTable(t.Name.Value, table); err != nil {
+				e := &LintError{
+					Severity: ERROR,
+					Token:    t.Name.GetMeta().Token,
+					Message:  err.Error(),
+				}
+				l.Error(e.Match(TABLE_DUPLICATED))
+			}
+			statements = append(statements, stmt)
+		case *ast.SubroutineDeclaration:
+			if err := ctx.AddSubroutine(t.Name.Value, &types.Subroutine{Decl: t, Body: t.Block}); err != nil {
+				e := &LintError{
+					Severity: ERROR,
+					Token:    t.Name.GetMeta().Token,
+					Message:  err.Error(),
+				}
+				l.Error(e.Match(SUBROUTINE_DUPLICATED))
+			}
+			statements = append(statements, stmt)
+		default:
+			l.Error(fmt.Errorf("Unexpected statement declaration found: %s", t.String()))
+		}
+	}
+	return statements
+}
+
+func (l *Linter) lintAclDeclaration(decl *ast.AclDeclaration, ctx *context.Context) types.Type {
 	// validate ACL name
 	if !isValidName(decl.Name.Value) {
 		l.Error(InvalidName(decl.Name.GetMeta(), decl.Name.Value, "acl").Match(ACL_SYNTAX))
@@ -228,23 +318,10 @@ func (l *Linter) lintAclDeclaration(decl *ast.AclDeclaration, ctx *context.Conte
 		}
 	}
 
-	if err := ctx.AddAcl(decl.Name.Value, acl); err != nil {
-		e := &LintError{
-			Severity: ERROR,
-			Token:    decl.Name.GetMeta().Token,
-			Message:  err.Error(),
-		}
-		l.Error(e.Match(ACL_DUPLICATED))
-	}
-
 	return types.NeverType
 }
 
 func (l *Linter) lintBackendDeclaration(decl *ast.BackendDeclaration, ctx *context.Context) types.Type {
-	backend := &types.Backend{
-		BackendDecl: decl,
-	}
-
 	// lint BACKEND name
 	if !isValidName(decl.Name.Value) {
 		l.Error(InvalidName(decl.Name.GetMeta(), decl.Name.Value, "backend").Match(BACKEND_SYNTAX))
@@ -253,15 +330,6 @@ func (l *Linter) lintBackendDeclaration(decl *ast.BackendDeclaration, ctx *conte
 	// lint property definitions
 	for i := range decl.Properties {
 		l.lintBackendProperty(decl.Properties[i], ctx)
-	}
-
-	if err := ctx.AddBackend(decl.Name.Value, backend); err != nil {
-		e := &LintError{
-			Severity: ERROR,
-			Token:    decl.Name.GetMeta().Token,
-			Message:  err.Error(),
-		}
-		l.Error(e.Match(BACKEND_DUPLICATED))
 	}
 
 	return types.NeverType
@@ -317,10 +385,6 @@ func (l *Linter) lintIncludeStatement(stmt *ast.IncludeStatement, ctx *context.C
 }
 
 func (l *Linter) lintDirectorDeclaration(decl *ast.DirectorDeclaration, ctx *context.Context) types.Type {
-	director := &types.Director{
-		Decl: decl,
-	}
-
 	// validate director name
 	if !isValidName(decl.Name.Value) {
 		l.Error(InvalidName(decl.Name.GetMeta(), decl.Name.Value, "director").Match(DIRECTOR_SYNTAX))
@@ -328,14 +392,6 @@ func (l *Linter) lintDirectorDeclaration(decl *ast.DirectorDeclaration, ctx *con
 
 	l.lintDirectorProperty(decl, ctx)
 
-	if err := ctx.AddDirector(decl.Name.Value, director); err != nil {
-		e := &LintError{
-			Severity: ERROR,
-			Token:    decl.Name.GetMeta().Token,
-			Message:  err.Error(),
-		}
-		l.Error(e.Match(DIRECTOR_DUPLICATED))
-	}
 	return types.NeverType
 }
 
@@ -435,29 +491,9 @@ func (l *Linter) lintDirectorProperty(decl *ast.DirectorDeclaration, ctx *contex
 }
 
 func (l *Linter) lintTableDeclaration(decl *ast.TableDeclaration, ctx *context.Context) types.Type {
-	table := &types.Table{
-		Decl:       decl,
-		Name:       decl.Name.Value,
-		Properties: decl.Properties,
-	}
-
 	// validate table name
 	if !isValidName(decl.Name.Value) {
 		l.Error(InvalidName(decl.Name.GetMeta(), decl.Name.Value, "table").Match(TABLE_SYNTAX))
-	}
-
-	// validate table type specification
-	if decl.ValueType == nil {
-		table.ValueType = types.StringType
-	} else {
-		v, ok := ValueTypeMap[decl.ValueType.Value]
-		if !ok {
-			l.Error(UndefinedTableType(
-				decl.ValueType.GetMeta(), decl.Name.Value, decl.ValueType.Value,
-			).Match(TABLE_TYPE_VARIATION))
-		} else {
-			table.ValueType = v
-		}
 	}
 
 	// Table item is limited under 1000 by default
@@ -467,23 +503,22 @@ func (l *Linter) lintTableDeclaration(decl *ast.TableDeclaration, ctx *context.C
 		err := &LintError{
 			Severity: WARNING,
 			Token:    decl.Name.GetMeta().Token,
-			Message:  fmt.Sprintf(`table "%s" items are limited under 1000`, table.Name),
+			Message:  fmt.Sprintf(`table "%s" items are limited under 1000`, decl.Name.Value),
 		}
 		l.Error(err.Match(TABLE_ITEM_LIMITATION))
 	}
 
-	// validate table property
-	for _, p := range decl.Properties {
-		l.lintTableProperty(p, table.ValueType, ctx)
+	// table value type
+	var valueType types.Type
+	if decl.ValueType == nil {
+		valueType = types.StringType
+	} else if v, ok := ValueTypeMap[decl.ValueType.Value]; ok {
+		valueType = v
 	}
 
-	if err := ctx.AddTable(decl.Name.Value, table); err != nil {
-		err := &LintError{
-			Severity: ERROR,
-			Token:    decl.Name.GetMeta().Token,
-			Message:  err.Error(),
-		}
-		l.Error(err.Match(TABLE_DUPLICATED))
+	// validate table property
+	for _, p := range decl.Properties {
+		l.lintTableProperty(p, valueType, ctx)
 	}
 
 	return types.NeverType
@@ -518,23 +553,9 @@ func (l *Linter) lintTableProperty(prop *ast.TableProperty, tableType types.Type
 }
 
 func (l *Linter) lintSubRoutineDeclaration(decl *ast.SubroutineDeclaration, ctx *context.Context) types.Type {
-	subroutine := &types.Subroutine{
-		Decl: decl,
-		Body: decl.Block,
-	}
-
 	// validate subroutine name
 	if !isValidName(decl.Name.Value) {
 		l.Error(InvalidName(decl.Name.GetMeta(), decl.Name.Value, "sub").Match(SUBROUTINE_SYNTAX))
-	}
-
-	if err := ctx.AddSubroutine(decl.Name.Value, subroutine); err != nil {
-		err := &LintError{
-			Severity: ERROR,
-			Token:    decl.Name.GetMeta().Token,
-			Message:  err.Error(),
-		}
-		l.Error(err.Match(SUBROUTINE_DUPLICATED))
 	}
 
 	cc := ctx.Scope(getSubroutineCallScope(decl))

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -117,8 +117,9 @@ func (l *Linter) lint(node ast.Node, ctx *context.Context) types.Type {
 		return l.lintVCL(t, ctx)
 
 	// Declarations
+	// Note: root declaration has already added in linter context.
 	case *ast.AclDeclaration:
-		return l.lintAclDeclaration(t, ctx)
+		return l.lintAclDeclaration(t)
 	case *ast.BackendDeclaration:
 		return l.lintBackendDeclaration(t, ctx)
 	case *ast.DirectorDeclaration:
@@ -293,7 +294,7 @@ func (l *Linter) factoryRootStatements(vcl *ast.VCL, ctx *context.Context) []ast
 	return statements
 }
 
-func (l *Linter) lintAclDeclaration(decl *ast.AclDeclaration, ctx *context.Context) types.Type {
+func (l *Linter) lintAclDeclaration(decl *ast.AclDeclaration) types.Type {
 	// validate ACL name
 	if !isValidName(decl.Name.Value) {
 		l.Error(InvalidName(decl.Name.GetMeta(), decl.Name.Value, "acl").Match(ACL_SYNTAX))

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -1490,3 +1490,20 @@ sub vcl_fetch {
 		assertNoError(t, input)
 	})
 }
+
+func TestSubroutineHoisting(t *testing.T) {
+	t.Run("pass", func(t *testing.T) {
+		input := `
+sub vcl_recv {
+	### FASTLY recv
+	call hoisted_subroutine;
+	return(lookup);
+}
+
+sub hoisted_subroutine {
+	set req.http.X-Subrountine-Hoisted = "yes";
+}
+`
+		assertNoError(t, input)
+	})
+}


### PR DESCRIPTION
Fixes #50 

This PR implements supporting subroutine hoisting.
Pass the linting call subroutine even if it is declared after its declaration:

```vcl
sub vcl_recv {
   ...
   call custom_recv;
   ...
}

sub custom_recv {
   ...
}

## pass the linter!
```