### PR TITLE
Support linting multiple services

### DIFF
--- a/cmd/falco/main.go
+++ b/cmd/falco/main.go
@@ -133,7 +133,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	// falco could lint multiple services so resolver should be an slice
+	// falco could lint multiple services so resolver should be a slice
 	var resolvers []Resolver
 	switch fs.Arg(0) {
 	case subcommandTerraform:


### PR DESCRIPTION
Fixes #51 

This PR enables to lint multiple services.
Usually multiple service listings is used for terraform planned result.