### PR TITLE
fix linting problems

### DIFF
--- a/cmd/falco/resolver.go
+++ b/cmd/falco/resolver.go
@@ -160,7 +160,7 @@ func NewStdinResolvers() ([]Resolver, error) {
 		return resolvers, nil
 	case err := <-errChan:
 		return nil, errors.New(fmt.Sprintf("Failed to read from stdin: %s", err.Error()))
-	case <-time.After(time.Second):
+	case <-time.After(10 * time.Second):
 		return nil, errors.New(("Failed to read from stdin: timed out"))
 	}
 }

--- a/cmd/falco/terraform.go
+++ b/cmd/falco/terraform.go
@@ -9,6 +9,7 @@ import (
 const (
 	fastlyTerraformProviderName = "registry.terraform.io/fastly/fastly"
 	fastlyVCLServiceType        = "fastly_service_vcl"
+	fastlyVCLServiceTypeV1      = "fastly_service_v1"
 )
 
 // Terraform planned input struct
@@ -97,5 +98,5 @@ func unmarshalTerraformPlannedInput(buf []byte) ([]*FastlyService, error) {
 
 func isFastlyVCLServiceResource(r *TerraformPlannedResource) bool {
 	return r.ProviderName == fastlyTerraformProviderName &&
-		r.Type == fastlyVCLServiceType
+		(r.Type == fastlyVCLServiceType || r.Type == fastlyVCLServiceTypeV1)
 }

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -355,7 +355,7 @@ sub baz {
 	set var.item1 = "1";
 	set var.item2 = 1;
 	set var.item3 = 1.0;
-	set var.item4 = std.ip("192.168.0.1", "192.168.0,2");
+	set var.item4 = std.ip("192.168.0.1", "192.168.0.2");
 	set var.item5 = always;
 	set var.item6 = foo;
 	set var.item7 = bar;

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -343,7 +343,7 @@ func TestLintDeclareStatement(t *testing.T) {
 		input := `
 acl foo {}
 backend bar {}
-sub bax {
+sub baz {
 	declare local var.item1 STRING;
 	declare local var.item2 INTEGER;
 	declare local var.item3 FLOAT;
@@ -355,7 +355,7 @@ sub bax {
 	set var.item1 = "1";
 	set var.item2 = 1;
 	set var.item3 = 1.0;
-	set var.item4 = std.ip("192.168.0.1", "192.168.2");
+	set var.item4 = std.ip("192.168.0.1", "192.168.0,2");
 	set var.item5 = always;
 	set var.item6 = foo;
 	set var.item7 = bar;

--- a/parser/declaration_parser.go
+++ b/parser/declaration_parser.go
@@ -368,6 +368,8 @@ func (p *Parser) parseTableProperty() (*ast.TableProperty, error) {
 	p.nextToken() // point to table value token
 
 	switch p.curToken.Token.Type {
+	case token.IDENT:
+		prop.Value = p.parseIdent()
 	case token.STRING:
 		prop.Value = p.parseString()
 	case token.ACL, token.BACKEND:


### PR DESCRIPTION
This PR fixes some linting problems:

- Tweak multiple service linting for terraform
  - extend stdin timeout, `terraform show -json` might be a few seconds to putout them
- Support legacy Fastly Provider service definition of `fastly_service_v1`
- Fix ident parse for table property value
- If some declaration access in table property, it should be marked as used