### PR TITLE
support alpine and M1 Mac

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,5 +29,6 @@ jobs:
           files: |
             dist/falco-linux-amd64
             dist/falco-darwin-amd64
+            dist/falco-darwin-arm64
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test: generate
 	go list ./... | xargs go test
 
 linux:
-	GOOS=linux GOARCH=amd64 go build \
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build \
 			 -ldflags "-X main.version=$(BUILD_VERSION)" \
 			 -o dist/falco-linux-amd64 ./cmd/falco
 
@@ -17,6 +17,9 @@ darwin:
 	GOOS=darwin GOARCH=amd64 go build \
 			 -ldflags "-X main.version=$(BUILD_VERSION)" \
 			 -o dist/falco-darwin-amd64 ./cmd/falco
+	GOOS=darwin GOARCH=arm64 go build \
+			 -ldflags "-X main.version=$(BUILD_VERSION)" \
+			 -o dist/falco-darwin-arm64 ./cmd/falco
 
 lint:
 	golangci-lint run


### PR DESCRIPTION
`falco` is occasionally used on CI, which runs in `alpine` so we need to be able to run on it, also M1 Mac of arm64.
This PR supports them by adding `CGO_ENABLED=0` build option for linux.