### PR TITLE
Adds support for `min_tls_version`/`max_tls_version` in backend object

### DIFF
--- a/examples/default01.vcl
+++ b/examples/default01.vcl
@@ -11,6 +11,8 @@ backend httpbin_org {
   .ssl_sni_hostname = "httpbin.org";
   .ssl_cert_hostname = "httpbin.org";
   .ssl_check_cert = always;
+  .min_tls_version = "1.2";
+  .max_tls_version = "1.2";
   .probe = {
     .request = "GET /status/200 HTTP/1.1" "Host: httpbin.org" "Connection: close";
     .dummy = true;

--- a/examples/default02.vcl
+++ b/examples/default02.vcl
@@ -11,6 +11,8 @@ backend httpbin_org {
   .ssl_sni_hostname = "httpbin.org";
   .ssl_cert_hostname = "httpbin.org";
   .ssl_check_cert = always;
+  .min_tls_version = "1.2";
+  .max_tls_version = "1.2";
   .probe = {
     .request = "GET /status/200 HTTP/1.1" "Host: httpbin.org" "Connection: close";
     .dummy = true;

--- a/examples/default03.vcl
+++ b/examples/default03.vcl
@@ -11,6 +11,8 @@ backend httpbin_org {
   .ssl_sni_hostname = "httpbin.org";
   .ssl_cert_hostname = "httpbin.org";
   .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+  .max_tls_version = "1.2";
   .probe = {
     .request = "GET /status/200 HTTP/1.1" "Host: httpbin.org" "Connection: close";
     .dummy = true;

--- a/examples/default03.vcl
+++ b/examples/default03.vcl
@@ -11,7 +11,7 @@ backend httpbin_org {
   .ssl_sni_hostname = "httpbin.org";
   .ssl_cert_hostname = "httpbin.org";
   .ssl_check_cert = always;
-    .min_tls_version = "1.2";
+  .min_tls_version = "1.2";
   .max_tls_version = "1.2";
   .probe = {
     .request = "GET /status/200 HTTP/1.1" "Host: httpbin.org" "Connection: close";

--- a/examples/default04.vcl
+++ b/examples/default04.vcl
@@ -11,6 +11,8 @@ backend httpbin_org {
   .ssl_sni_hostname = "httpbin.org";
   .ssl_cert_hostname = "httpbin.org";
   .ssl_check_cert = always;
+  .min_tls_version = "1.2";
+  .max_tls_version = "1.2";
   .probe = {
     .request = "GET /status/200 HTTP/1.1" "Host: httpbin.org" "Connection: close";
     .dummy = true;

--- a/linter/helper.go
+++ b/linter/helper.go
@@ -19,6 +19,8 @@ var BackendPropertyTypes = map[string]types.Type{
 	"port":                   types.StringType,
 	"ssl":                    types.BoolType,
 	"ssl_cert_hostname":      types.StringType,
+	"max_tls_version":        types.StringType,
+	"min_tls_version":        types.StringType,
 	"ssl_check_cert":         types.IDType,
 	"ssl_sni_hostname":       types.StringType,
 	"between_bytes_timeout":  types.RTimeType,


### PR DESCRIPTION
`min_tls_version`/`max_tls_version` is missing but it is supported in
https://developer.fastly.com/reference/api/services/backend/

Signed-off-by: Sotiris Nanopoulos <sotiris.nanopoulos@reddit.com>