### PR TITLE
feat(lint): Add warning for backend health check prober

### DIFF
--- a/examples/default01.vcl
+++ b/examples/default01.vcl
@@ -16,7 +16,7 @@ backend httpbin_org {
   .probe = {
     .request = "GET /status/200 HTTP/1.1" "Host: httpbin.org" "Connection: close";
     .dummy = true;
-    .threshold = 1;
+    .threshold = 6;
     .window = 2;
     .timeout = 5s;
     .initial = 1;

--- a/examples/default01.vcl
+++ b/examples/default01.vcl
@@ -16,7 +16,7 @@ backend httpbin_org {
   .probe = {
     .request = "GET /status/200 HTTP/1.1" "Host: httpbin.org" "Connection: close";
     .dummy = true;
-    .threshold = 6;
+    .threshold = 1;
     .window = 2;
     .timeout = 5s;
     .initial = 1;

--- a/linter/helper.go
+++ b/linter/helper.go
@@ -351,6 +351,11 @@ func isProbeMakingTheBackendStartAsUnhealthy(prober ast.BackendProbeObject) erro
 	var threshold int
 	var initial int
 	var err error
+
+	// The code below works also if either/both initial and threshold are not present:
+	// * if both dont appear then both have values 0 and 0 in which case you get no warning
+	// * if initial exists but no threshold then it is also correct because initial > 0 (threshold)
+	// * if threshold exists but no initial then we generate an error correctly because threshold > 0 (initial)
 	for _, v := range prober.Values {
 		if strings.EqualFold(v.Key.Value, "initial") {
 			// Optimistically cast this to int, if we can do it because the value is a literal

--- a/linter/helper.go
+++ b/linter/helper.go
@@ -348,7 +348,6 @@ func hasFastlyBoilerPlateMacro(commentText, phrase string) bool {
 // then the prober will be marked as unhealthy at the beginning which is can
 // cause issues at startup.
 func isProbeMakingTheBackendStartAsUnhealthy(prober ast.BackendProbeObject) error {
-
 	var threshold int
 	var initial int
 	var err error

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -385,6 +385,17 @@ func (l *Linter) lintBackendProperty(prop *ast.BackendProperty, ctx *context.Con
 				l.Error(InvalidType(v.Value.GetMeta(), v.Key.Value, kt, vt).Match(BACKEND_SYNTAX))
 			}
 		}
+
+		err := isProbeMakingTheBackendStartAsUnhealthy(*t)
+		if err != nil {
+			err := &LintError{
+				Severity: WARNING,
+				Token:    prop.Key.GetMeta().Token,
+				Message:  err.Error(),
+			}
+			l.Error(err.Match(BACKEND_PROBER_CONFIGURATION))
+		}
+
 	default:
 		// Otherwise, simply compare key type
 		kt, ok := BackendPropertyTypes[prop.Key.Value]

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -137,6 +137,34 @@ backend foo {
 `
 		assertError(t, input)
 	})
+
+	t.Run("Probe is configured correctly", func(t *testing.T) {
+		input := `
+backend foo {
+  .host = "example.com";
+
+  .probe = {
+    .request = "GET / HTTP/1.1";
+	.threshold = 1;
+	.initial = 5;
+  }
+}`
+		assertNoError(t, input)
+	})
+
+	t.Run("Probe is configured in such a way that the backend will start as unhealthy", func(t *testing.T) {
+		input := `
+backend foo {
+  .host = "example.com";
+
+  .probe = {
+    .request = "GET / HTTP/1.1";
+	.threshold = 5;
+	.initial = 1;
+  }
+}`
+		assertError(t, input)
+	})
 }
 
 func TestLintTableStatement(t *testing.T) {

--- a/linter/rules.go
+++ b/linter/rules.go
@@ -15,6 +15,7 @@ const (
 	BACKEND_SYNTAX                       = "backend/syntax"
 	BACKEND_DUPLICATED                   = "backend/duplicated"
 	BACKEND_NOTFOUND                     = "backend/notfound"
+	BACKEND_PROBER_CONFIGURATION         = "backend/prober-configuration"
 	DIRECTOR_SYNTAX                      = "director/syntax"
 	DIRECTOR_DUPLICATED                  = "director/duplicated"
 	DIRECTOR_PROPS_RANDOM                = "director/props-random"


### PR DESCRIPTION
If the backend prober has an initial value that is less than the threshold
then when the backend is loaded the initial health checks will not be sufficient
to mark it as healthy.

As such the backend will be considered unhealthy at startup.

I know that it doesnt follow the spec of VCL but it seems valuable to have this imo.

Signed-off-by: Sotiris Nanopoulos <sotiris.nanopoulos@reddit.com>