### PR TITLE
Add support to parse function calls

### DIFF
--- a/ast/functioncall_statement.go
+++ b/ast/functioncall_statement.go
@@ -1,0 +1,30 @@
+package ast
+
+import (
+	"bytes"
+)
+
+type FunctionCallStatement struct {
+	*Meta
+	Function  *Ident
+	Arguments []Expression
+}
+
+func (fc *FunctionCallStatement) statement()     {}
+func (fc *FunctionCallStatement) GetMeta() *Meta { return fc.Meta }
+func (fc *FunctionCallStatement) String() string {
+	var buf bytes.Buffer
+
+	buf.WriteString(fc.LeadingInlineComment())
+	buf.WriteString(fc.Function.String() + "(")
+	for i, a := range fc.Arguments {
+		buf.WriteString(a.String())
+		if i != len(fc.Arguments)-1 {
+			buf.WriteString(", ")
+		}
+	}
+	buf.WriteString(")")
+	buf.WriteString(fc.TrailingComment())
+
+	return buf.String()
+}

--- a/ast/functioncall_statement_test.go
+++ b/ast/functioncall_statement_test.go
@@ -1,0 +1,31 @@
+package ast
+
+import (
+	"testing"
+)
+
+func TestFunctionCallStatement(t *testing.T) {
+	fn := &FunctionCallStatement{
+		Meta: New(T, 0, comments("/* This is comment */"), comments("/* This is comment */")),
+		Function: &Ident{
+			Meta:  New(T, 0),
+			Value: "std.collect",
+		},
+		Arguments: []Expression{
+			&String{
+				Meta:  New(T, 0),
+				Value: "req.http.Cookie",
+			},
+			&String{
+				Meta:  New(T, 0),
+				Value: ";",
+			},
+		},
+	}
+
+	expect := `/* This is comment */ std.collect("req.http.Cookie", ";") /* This is comment */`
+
+	if fn.String() != expect {
+		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, fn.String())
+	}
+}

--- a/ast/include_statement_test.go
+++ b/ast/include_statement_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func testingncludeStatement(t *testing.T) {
+func TestIncludeStatement(t *testing.T) {
 	is := &IncludeStatement{
 		Meta: New(T, 0, comments("// This is comment"), comments("// This is comment")),
 		Module: &String{

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -201,3 +201,8 @@ func (p *Parser) parse() (ast.Statement, error) {
 	p.nextToken()
 	return stmt, nil
 }
+
+func (p *Parser) isFunctionCall() bool {
+	leftParen := "("
+	return p.curTokenIs(token.IDENT) && p.peekToken.Token.Literal == leftParen
+}

--- a/parser/statement_parser_test.go
+++ b/parser/statement_parser_test.go
@@ -1317,3 +1317,142 @@ sub vcl_recv {
 		assert(t, vcl, expect)
 	})
 }
+
+func TestFunctionCallStatement(t *testing.T) {
+	t.Run("normal function call without arguments", func(t *testing.T) {
+		input := `
+sub vcl_recv {
+	testFun();
+}`
+
+		expect := &ast.VCL{
+			Statements: []ast.Statement{
+				&ast.SubroutineDeclaration{
+					Meta: ast.New(T, 0),
+					Name: &ast.Ident{
+						Meta:  ast.New(T, 0),
+						Value: "vcl_recv",
+					},
+					Block: &ast.BlockStatement{
+						Meta: ast.New(T, 1),
+						Statements: []ast.Statement{
+							&ast.FunctionCallStatement{
+								Meta: ast.New(T, 1),
+								Function: &ast.Ident{
+									Meta:  ast.New(T, 1),
+									Value: "testFun",
+								},
+								Arguments: []ast.Expression{},
+							},
+						},
+					},
+				},
+			},
+		}
+		vcl, err := New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Errorf("%+v", err)
+		}
+		assert(t, vcl, expect)
+	})
+
+	t.Run("normal function call with arguments", func(t *testing.T) {
+		input := `
+sub vcl_recv {
+	testFun(test1, "test2", 3);
+}`
+
+		expect := &ast.VCL{
+			Statements: []ast.Statement{
+				&ast.SubroutineDeclaration{
+					Meta: ast.New(T, 0),
+					Name: &ast.Ident{
+						Meta:  ast.New(T, 0),
+						Value: "vcl_recv",
+					},
+					Block: &ast.BlockStatement{
+						Meta: ast.New(T, 1),
+						Statements: []ast.Statement{
+							&ast.FunctionCallStatement{
+								Meta: ast.New(T, 1),
+								Function: &ast.Ident{
+									Meta:  ast.New(T, 1),
+									Value: "testFun",
+								},
+								Arguments: []ast.Expression{
+									&ast.Ident{
+										Meta:  ast.New(T, 1),
+										Value: "test1",
+									},
+									&ast.String{
+										Meta:  ast.New(T, 1),
+										Value: "test2",
+									},
+									&ast.Integer{
+										Meta:  ast.New(T, 1),
+										Value: 3,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		vcl, err := New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Errorf("%+v", err)
+		}
+		assert(t, vcl, expect)
+	})
+
+	t.Run("method call with arguments", func(t *testing.T) {
+		input := `
+sub vcl_recv {
+	std.collect(test1, "test2", 3);
+}`
+
+		expect := &ast.VCL{
+			Statements: []ast.Statement{
+				&ast.SubroutineDeclaration{
+					Meta: ast.New(T, 0),
+					Name: &ast.Ident{
+						Meta:  ast.New(T, 0),
+						Value: "vcl_recv",
+					},
+					Block: &ast.BlockStatement{
+						Meta: ast.New(T, 1),
+						Statements: []ast.Statement{
+							&ast.FunctionCallStatement{
+								Meta: ast.New(T, 1),
+								Function: &ast.Ident{
+									Meta:  ast.New(T, 1),
+									Value: "std.collect",
+								},
+								Arguments: []ast.Expression{
+									&ast.Ident{
+										Meta:  ast.New(T, 1),
+										Value: "test1",
+									},
+									&ast.String{
+										Meta:  ast.New(T, 1),
+										Value: "test2",
+									},
+									&ast.Integer{
+										Meta:  ast.New(T, 1),
+										Value: 3,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		vcl, err := New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Errorf("%+v", err)
+		}
+		assert(t, vcl, expect)
+	})
+}

--- a/plugin/io.go
+++ b/plugin/io.go
@@ -31,6 +31,7 @@ func init() {
 	gob.Register(&ast.EsiStatement{})
 	gob.Register(&ast.Float{})
 	gob.Register(&ast.FunctionCallExpression{})
+	gob.Register(&ast.FunctionCallStatement{})
 	gob.Register(&ast.IP{})
 	gob.Register(&ast.Ident{})
 	gob.Register(&ast.IfExpression{})


### PR DESCRIPTION
**What is this PR?**
This PR adds support for calling functions like statements. 
An example for that would be calling [std.collect()](https://developer.fastly.com/reference/vcl/functions/miscellaneous/std-collect/)
```
# For a request with these Cookie headers:
# Cookie: name1=value1
# Cookie: name2=value2
std.collect(req.http.Cookie, ";");
# req.http.Cookie is now "name1=value1; name2=value2"
```