### PR TITLE
Support PCRE Regular Expressions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,17 +14,17 @@ darwin-deps:
 linux-deps:
 	apt-get install -y libpcre3-dev
 
-linux: linux-deps 
+linux:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build \
 			 -ldflags "-X main.version=$(BUILD_VERSION)" \
 			 -o dist/falco-linux-amd64 ./cmd/falco
 
-darwin_amd64: darwin-deps
+darwin_amd64:
 	GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go build \
 			 -ldflags "-X main.version=$(BUILD_VERSION)" \
 			 -o dist/falco-darwin-amd64 ./cmd/falco
 
-darwin_arm64: darwin-deps
+darwin_arm64:
 	GOOS=darwin GOARCH=arm64 go build \
 			 -ldflags "-X main.version=$(BUILD_VERSION)" \
 			 -o dist/falco-darwin-arm64 ./cmd/falco

--- a/Makefile
+++ b/Makefile
@@ -8,20 +8,23 @@ generate:
 test: generate
 	go list ./... | xargs go test
 
-linux:
+darwin-deps:
+	brew list pcre || brew install pcre
+
+linux-deps:
 	apt-get install -y libpcre3-dev
+
+linux: linux-deps
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build \
 			 -ldflags "-X main.version=$(BUILD_VERSION)" \
 			 -o dist/falco-linux-amd64 ./cmd/falco
 
-darwin_amd64:
-	brew install pcre
+darwin_amd64: darwin-deps
 	GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go build \
 			 -ldflags "-X main.version=$(BUILD_VERSION)" \
 			 -o dist/falco-darwin-amd64 ./cmd/falco
 
-darwin_arm64:
-	brew install pcre
+darwin_arm64: darwin-deps
 	GOOS=darwin GOARCH=arm64 go build \
 			 -ldflags "-X main.version=$(BUILD_VERSION)" \
 			 -o dist/falco-darwin-arm64 ./cmd/falco

--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,19 @@ test: generate
 	go list ./... | xargs go test
 
 linux:
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build \
+	apt-get install -y libpcre3-dev
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build \
 			 -ldflags "-X main.version=$(BUILD_VERSION)" \
 			 -o dist/falco-linux-amd64 ./cmd/falco
 
-darwin:
-	GOOS=darwin GOARCH=amd64 go build \
+darwin_amd64:
+	brew install pcre
+	GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go build \
 			 -ldflags "-X main.version=$(BUILD_VERSION)" \
 			 -o dist/falco-darwin-amd64 ./cmd/falco
+
+darwin_arm64:
+	brew install pcre
 	GOOS=darwin GOARCH=arm64 go build \
 			 -ldflags "-X main.version=$(BUILD_VERSION)" \
 			 -o dist/falco-darwin-arm64 ./cmd/falco
@@ -26,8 +31,6 @@ lint:
 
 local: test lint
 	go build ./cmd/falco
-
-all: linux darwin
 
 clean:
 	rm ./dist/falco-*

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ darwin-deps:
 linux-deps:
 	apt-get install -y libpcre3-dev
 
-linux: linux-deps
+linux: linux-deps 
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build \
 			 -ldflags "-X main.version=$(BUILD_VERSION)" \
 			 -o dist/falco-linux-amd64 ./cmd/falco

--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ Download binary from [releases page](https://github.com/ysugimoto/falco/releases
 
 Or compile it yourself with `go install github.com/ysugimoto/falco/cmd/falco@latest`.
 
+**Note:** Varnish supports [PCRE regular expressions](https://www.pcre.org/). To be able to parse regex you need to install the PCRE library on your machine.  
+
+For mac:
+```
+brew install pcre
+``` 
+For Linux
+```
+apt-get install -y libpcre3-dev
+```
+
 ## Usage
 
 Command help displays following:

--- a/README.md
+++ b/README.md
@@ -42,11 +42,12 @@ Or compile it yourself with `go install github.com/ysugimoto/falco/cmd/falco@lat
 
 For mac:
 ```
-brew install pcre
+make darwin-deps
 ``` 
+
 For Linux
 ```
-apt-get install -y libpcre3-dev
+make linux-deps
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Download binary from [releases page](https://github.com/ysugimoto/falco/releases
 
 Or compile it yourself with `go install github.com/ysugimoto/falco/cmd/falco@latest`.
 
-**Note:** [Fastly](https://developer.fastly.com/reference/vcl/regex/) supports [PCRE regular expressions](https://www.pcre.org/). To be able to parse regex you need to install the PCRE library on your machine.  
+## Compiling
+[Fastly](https://developer.fastly.com/reference/vcl/regex/) supports [PCRE regular expressions](https://www.pcre.org/). To be able to parse regex you need to install the PCRE library on your machine before compiling the binary.
 
 For mac:
 ```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Download binary from [releases page](https://github.com/ysugimoto/falco/releases
 
 Or compile it yourself with `go install github.com/ysugimoto/falco/cmd/falco@latest`.
 
-**Note:** Varnish supports [PCRE regular expressions](https://www.pcre.org/). To be able to parse regex you need to install the PCRE library on your machine.  
+**Note:** [Fastly](https://developer.fastly.com/reference/vcl/regex/) supports [PCRE regular expressions](https://www.pcre.org/). To be able to parse regex you need to install the PCRE library on your machine.  
 
 For mac:
 ```

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/fatih/color v1.12.0
+	github.com/gijsbers/go-pcre v0.0.0-20161214203829-a84f3096ab3c
 	github.com/goccy/go-yaml v1.8.9
 	github.com/google/go-cmp v0.5.6
 	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect
@@ -12,5 +13,4 @@ require (
 	github.com/mattn/go-colorable v0.1.8
 	github.com/pkg/errors v0.9.1
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,9 +2,14 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.12.0 h1:mRhaKNwANqRgUBGKmnI5ZxEk7QXmjQeCcuYFMX2bfcc=
 github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
+github.com/gijsbers/go-pcre v0.0.0-20161214203829-a84f3096ab3c h1:o5z/Stj4aWUiDiCVFdEOgXcwNF+Z7mQSlvDTaWBK98Q=
+github.com/gijsbers/go-pcre v0.0.0-20161214203829-a84f3096ab3c/go.mod h1:Bd83Kcti1U5OMXYYTjilhd6os+l6AmlTMVbDtaBvycQ=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
+github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
+github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD876Lmtgy7VtROAbHHXk8no=
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
+github.com/go-playground/validator/v10 v10.4.1 h1:pH2c5ADXtd66mxoE0Zm9SUhxE20r7aM3F26W0hOn+GE=
 github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
 github.com/goccy/go-yaml v1.8.9 h1:4AEXg2qx+/w29jXnXpMY6mTckmYu1TMoHteKuMf0HFg=
 github.com/goccy/go-yaml v1.8.9/go.mod h1:U/jl18uSupI5rdI2jmuCswEA2htH9eXfferR3KfscvA=
@@ -16,6 +21,7 @@ github.com/k0kubun/pp v2.4.0+incompatible h1:M9iQzcejGfiBjDa7+Tc0rJgR7WFKP6rim/Q
 github.com/k0kubun/pp v2.4.0+incompatible/go.mod h1:GWse8YhT0p8pT4ir3ZgBbfZild3tgzSScAn6HmfYukg=
 github.com/kyokomi/emoji v1.5.1 h1:qp9dub1mW7C4MlvoRENH6EAENb9skEFOvIEbp1Waj38=
 github.com/kyokomi/emoji v1.5.1/go.mod h1:mZ6aGCD7yk8j6QY6KICwnZ2pxoszVseX1DNoGtU2tBA=
+github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
@@ -27,6 +33,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -3,9 +3,9 @@ package linter
 import (
 	"fmt"
 	"net"
-	"regexp"
 	"strings"
 
+	regexp "github.com/gijsbers/go-pcre"
 	"github.com/ysugimoto/falco/ast"
 	"github.com/ysugimoto/falco/context"
 	"github.com/ysugimoto/falco/token"
@@ -1355,7 +1355,7 @@ func (l *Linter) lintInfixExpression(exp *ast.InfixExpression, ctx *context.Cont
 		}
 		// And, if right expression is STRING, regex must be valid
 		if v, ok := exp.Right.(*ast.String); ok {
-			if _, err := regexp.Compile(strings.ReplaceAll(v.Value, "\\", "\\\\")); err != nil {
+			if _, err := regexp.Compile(v.Value, regexp.BSR_UNICODE); err != nil {
 				err := &LintError{
 					Severity: ERROR,
 					Token:    exp.Right.GetMeta().Token,

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -1070,6 +1070,36 @@ sub foo {
 }`
 		assertError(t, input)
 	})
+
+	t.Run("pass with PCRE expression", func(t *testing.T) {
+		input := `
+sub foo {
+	if (req.http.Host ~ "(?i)^word") {
+		restart;
+	}
+}`
+		assertNoError(t, input)
+	})
+
+	t.Run("pass with expression that has backslash", func(t *testing.T) {
+		input := `
+sub foo {
+	if (req.http.Host ~ "\(compatible.?; Googlebot/2.1.?; \+http://www.google.com/bot.html") {
+		restart;
+	}
+}`
+		assertNoError(t, input)
+	})
+
+	t.Run("pass with PCRE expression that has backslash", func(t *testing.T) {
+		input := `
+sub foo {
+	if (req.http.Host ~ "(?i)windows\ ?ce") {
+		restart;
+	}
+}`
+		assertNoError(t, input)
+	})
 }
 
 func TestLintRegexNotOperator(t *testing.T) {

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -1084,7 +1084,7 @@ sub foo {
 	t.Run("pass with expression that has backslash", func(t *testing.T) {
 		input := `
 sub foo {
-	if (req.http.Host ~ "\(compatible.?; Googlebot/2.1.?; \+http://www.google.com/bot.html") {
+	if (req.http.User-Agent ~ "\(compatible.?; Googlebot/2.1.?; \+http://www.google.com/bot.html") {
 		restart;
 	}
 }`
@@ -1094,7 +1094,7 @@ sub foo {
 	t.Run("pass with PCRE expression that has backslash", func(t *testing.T) {
 		input := `
 sub foo {
-	if (req.http.Host ~ "(?i)windows\ ?ce") {
+	if (req.http.User-Agent ~ "(?i)windows\ ?ce") {
 		restart;
 	}
 }`


### PR DESCRIPTION
**Why?**
Falco ([the go regexp pkg](https://pkg.go.dev/regexp) to be more accurate!) right now doesn't know how to parse [PCRE](https://www.pcre.org/) regular expressions that Varnish uses.
An example of that would be this file:
https://github.com/varnishcache/varnish-devicedetect/blob/master/devicedetect.vcl