### PR TITLE
doc: Fix unexpected strikethrough is appeared on rendered HTML

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -773,7 +773,7 @@ Failed to load include target module.
 
 Regex matched operator `re.group.N` value will be overriden.
 
-These variables could use if(else) block statement when condition has regex operator like "~" or "!~".
+These variables could use if(else) block statement when condition has regex operator like `~` or `!~`.
 Note that group matched variable has potential of making bugs due to its spec:
 
 1. re.group.N variable scope is subroutine-global, does not have block scope


### PR DESCRIPTION
In the current document, some `~` is treated as [Strikethrough](https://github.github.com/gfm/#strikethrough-extension-) expression of GFM.

I fixed to use [Code spans](https://github.github.com/gfm/#code-spans) to fix this.