### PR TITLE
Improve include statement parsing

### DIFF
--- a/cmd/falco/resolver.go
+++ b/cmd/falco/resolver.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"io/ioutil"
@@ -77,7 +78,6 @@ func (f *FileResolver) getVCL(file string) (*VCL, error) {
 	if _, err := os.Stat(file); err != nil {
 		return nil, err
 	}
-
 	fp, err := os.Open(file)
 	if err != nil {
 		return nil, err
@@ -100,13 +100,17 @@ func (f *FileResolver) MainVCL() (*VCL, error) {
 }
 
 func (f *FileResolver) Resolve(module string) (*VCL, error) {
+	module_path_with_extension := module
+	if !strings.HasSuffix(module_path_with_extension, ".vcl") {
+		module_path_with_extension += ".vcl"
+	}
+
 	// Find for each include paths
 	for _, p := range f.includePaths {
-		if vcl, err := f.getVCL(filepath.Join(p, module+".vcl")); err == nil {
+		if vcl, err := f.getVCL(filepath.Join(p, module_path_with_extension)); err == nil {
 			return vcl, nil
 		}
 	}
-
 	return nil, errors.New(fmt.Sprintf("Failed to resolve include file: %s.vcl", module))
 }
 

--- a/linter/errors.go
+++ b/linter/errors.go
@@ -110,7 +110,7 @@ func UndefinedSubroutine(m *ast.Meta, name string) *LintError {
 	return &LintError{
 		Severity: ERROR,
 		Token:    m.Token,
-		Message:  fmt.Sprintf("Subroutine %s is not defined. Did you forget to include of typo its name?", name),
+		Message:  fmt.Sprintf("Subroutine %s is not defined. Did you forget to include it or have a typo in the name?", name),
 	}
 }
 

--- a/parser/declaration_parser_test.go
+++ b/parser/declaration_parser_test.go
@@ -267,7 +267,7 @@ table tbl {
 							HasComma: true,
 						},
 						{
-							Meta: ast.New(T, 1, comments("// Leading comment")),
+							Meta: ast.New(T, 1, comments("// Leading comment"), comments("// Trailing comment")),
 							Key: &ast.String{
 								Meta:  ast.New(T, 1),
 								Value: "dolor",

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,6 +1,8 @@
 package parser
 
 import (
+	"strings"
+
 	"github.com/pkg/errors"
 	"github.com/ysugimoto/falco/ast"
 	"github.com/ysugimoto/falco/lexer"
@@ -106,6 +108,12 @@ func (p *Parser) trailing() ast.Comments {
 			break
 		}
 		if tok.Type == token.EOF {
+			if len(p.peekToken.LeadingComment()) > 0 {
+				cs = append(cs, &ast.Comment{
+					Token: tok,
+					Value: strings.TrimSpace(p.peekToken.LeadingComment()),
+				})
+			}
 			return cs
 		}
 		if tok.Type == token.COMMENT {

--- a/parser/statement_parser.go
+++ b/parser/statement_parser.go
@@ -34,12 +34,13 @@ func (p *Parser) parseIncludeStatement() (ast.Statement, error) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "STRING"))
 	}
 	i.Module = p.parseString()
-
-	if !p.peekTokenIs(token.SEMICOLON) {
-		return nil, errors.WithStack(MissingSemicolon(p.curToken))
-	}
 	i.Meta.Trailing = p.trailing()
-	p.nextToken() // point to SEMICOLON
+
+	// Semicolons are actually not required at the end of include lines
+	// either works on fastly.
+	if p.peekTokenIs(token.SEMICOLON) {
+		p.nextToken() // point to SEMICOLON
+	}
 
 	return i, nil
 }

--- a/parser/statement_parser_test.go
+++ b/parser/statement_parser_test.go
@@ -31,25 +31,49 @@ import boltsort; // Trailing comment`
 }
 
 func TestParseInclude(t *testing.T) {
-	input := `// Leading comment
+	t.Run("with semicolon at the end", func(t *testing.T) {
+		input := `// Leading comment
 include "feature_mod"; // Trailing comment`
-	expect := &ast.VCL{
-		Statements: []ast.Statement{
-			&ast.IncludeStatement{
-				Meta: ast.New(T, 0, comments("// Leading comment"), comments("// Trailing comment")),
-				Module: &ast.String{
-					Meta:  ast.New(token.Token{}, 0),
-					Value: "feature_mod",
+		expect := &ast.VCL{
+			Statements: []ast.Statement{
+				&ast.IncludeStatement{
+					Meta: ast.New(T, 0, comments("// Leading comment"), comments("// Trailing comment")),
+					Module: &ast.String{
+						Meta:  ast.New(token.Token{}, 0),
+						Value: "feature_mod",
+					},
 				},
 			},
-		},
-	}
+		}
 
-	vcl, err := New(lexer.NewFromString(input)).ParseVCL()
-	if err != nil {
-		t.Errorf("%+v", err)
-	}
-	assert(t, vcl, expect)
+		vcl, err := New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Errorf("%+v", err)
+		}
+		assert(t, vcl, expect)
+	})
+
+	t.Run("without semicolon at the end", func(t *testing.T) {
+		input := `// Leading comment
+include "feature_mod" // Trailing comment`
+		expect := &ast.VCL{
+			Statements: []ast.Statement{
+				&ast.IncludeStatement{
+					Meta: ast.New(T, 0, comments("// Leading comment"), comments("// Trailing comment")),
+					Module: &ast.String{
+						Meta:  ast.New(token.Token{}, 0),
+						Value: "feature_mod",
+					},
+				},
+			},
+		}
+
+		vcl, err := New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Errorf("%+v", err)
+		}
+		assert(t, vcl, expect)
+	})
 }
 func TestParseSetStatement(t *testing.T) {
 	t.Run("simple assign", func(t *testing.T) {


### PR DESCRIPTION
* Resolve include staments with ".vcl" suffix. This is correct per Fastly linting so we make falco a bit more
flexible.
* Include statements are not required to have a `;` at the end of
the line by fastly. It seems like it is optional.

Signed-off-by: Sotiris Nanopoulos <sotiris.nanopoulos@reddit.com>