### PR TITLE
Add support for subroutines operating in multiple scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,13 +99,13 @@ Following table describes subroutine name and recognizing scope:
 
 ### Annotation
 
-For some reasons, the subroutine name could not be changed. Or you want to use this function in multiple scopes.
+For some reasons, the subroutine name could not be changed. Or you want to use this function in multiple scopes. Multiple scopes
+are declared as comma seperated values.
 
 Then, if you apply a hint of scope on annotation, `falco` also understands scope:
 
 ```vcl
-// @recv
-// @miss
+// @recv, miss
 sub custom_process {
    // subroutine has `recv` annotation, lint with RECV|MISS scope.
    // All variables must be accessible in both RECV and MISS scope.

--- a/README.md
+++ b/README.md
@@ -102,17 +102,19 @@ Following table describes subroutine name and recognizing scope:
 For some reasons, the subroutine name could not be changed. Or you want to use this function in multiple scopes. Multiple scopes
 are declared as comma seperated values.
 
-Then, if you apply a hint of scope on annotation, `falco` also understands scope:
+Then, if you apply a hint of scope on annotation, `falco` also understands scope. There are two ways to define the scope annotation:
+1. `@scope: <scope_name1>, <scope_name2>` this is the newest annotation method and it should be prefered over 2.
+2. `@<scope_name1>, <scope_name2>`, this is used to maintain backwards compatibility and it may be deprecated in the future.
 
 ```vcl
-// @recv, miss
+// @scope: recv, miss
 sub custom_process {
    // subroutine has `recv` annotation, lint with RECV|MISS scope.
    // All variables must be accessible in both RECV and MISS scope.
   ...
 }
 
-// @fetch
+// @fetch, miss
 sub custom_request {
   // subroutine has `fetch` annotation, lint with FETCH scope
   ...

--- a/README.md
+++ b/README.md
@@ -99,16 +99,22 @@ Following table describes subroutine name and recognizing scope:
 
 ### Annotation
 
-For some reasons, the subroutine name could not be changed. Then, if you apply a hint of scope on annotation, `falco` also understands scope:
+For some reasons, the subroutine name could not be changed. Or you want to use this function in multiple scopes.
+
+Then, if you apply a hint of scope on annotation, `falco` also understands scope:
 
 ```vcl
 // @recv
-sub custom_process { // subroutine has `recv` annotation, lint with RECV scope
+// @miss
+sub custom_process {
+   // subroutine has `recv` annotation, lint with RECV|MISS scope.
+   // All variables must be accessible in both RECV and MISS scope.
   ...
 }
 
 // @fetch
-sub custom_request { // subroutine has `fetch` annotation, lint with FETCH scope
+sub custom_request {
+  // subroutine has `fetch` annotation, lint with FETCH scope
   ...
 }
 ```

--- a/context/context.go
+++ b/context/context.go
@@ -58,7 +58,7 @@ func ScopesString(s int) string {
 	return sb.String()
 }
 
-func CanAccessVariableInScope(objScope int, objReference string, name string, currentScope int) error {
+func CanAccessVariableInScope(objScope int, objReference, name string, currentScope int) error {
 	// objScope: is a bitmap of all the scopes that the variable is available in e.g. 0x100000001 is only available in RECV and LOG
 	// currentScope: is the bitmap of the current scope. In VCL state functions such as vcl_recv only one bit will be set.
 	// however in subroutines or user defined functions things are different, since a subroutine might be used in multiple function.

--- a/context/context.go
+++ b/context/context.go
@@ -48,7 +48,7 @@ func ScopeString(s int) string {
 
 func ScopesString(s int) string {
 	var sb strings.Builder
-	for i := RECV; i != LOG; i = i << 4 {
+	for i := RECV; i != LOG; i <<= 4 {
 		scope := ScopeString(s & i)
 		if scope != "UNKNOWN" {
 			sb.WriteString(scope)
@@ -59,7 +59,7 @@ func ScopesString(s int) string {
 }
 
 func CanAccessVariableInScope(objScope int, objReference string, name string, currentScope int) error {
-	// objScope: is a bitmap of all the scopes that the variable is available in e.g. 0x100000001 is only avaiable in RECV and LOG
+	// objScope: is a bitmap of all the scopes that the variable is available in e.g. 0x100000001 is only available in RECV and LOG
 	// currentScope: is the bitmap of the current scope. In VCL state functions such as vcl_recv only one bit will be set.
 	// however in subroutines or user defined functions things are different, since a subroutine might be used in multiple function.
 	// We calculate if objScope & currentScope (the common scopes) is the same as the current scope

--- a/examples/default01.vcl
+++ b/examples/default01.vcl
@@ -25,11 +25,16 @@ backend httpbin_org {
   }
 }
 
+//@scope: recv,deliver,log
+sub custom_logger {
+  log req.http.header;
+}
+
 sub vcl_recv {
 
   #Fastly recv
   set req.backend = httpbin_org;
-
+  call custom_logger;
   return (pass);
 }
 
@@ -37,11 +42,13 @@ sub vcl_deliver {
 
   #Fastly deliver
   set resp.http.X-Custom-Header = "Custom Header";
+  call custom_logger;
   return (deliver);
 }
 
 sub vcl_fetch {
 
   #Fastly fetch
+  call custom_logger;
   return(deliver);
 }

--- a/linter/helper.go
+++ b/linter/helper.go
@@ -302,16 +302,18 @@ func expectState(cur string, expects ...string) bool {
 }
 
 func annotations(comments ast.Comments) []string {
-	var a []string
-
+	var rv []string
 	for i := range comments {
 		l := strings.TrimLeft(comments[i].Value, " */#")
 		if strings.HasPrefix(l, "@") {
-			a = append(a, strings.TrimPrefix(l, "@"))
+			an := strings.Split(strings.TrimPrefix(l, "@"), ",")
+			for _, s := range an {
+				rv = append(rv, strings.TrimSpace(s))
+			}
 		}
 	}
 
-	return a
+	return rv
 }
 
 func getSubroutineCallScope(s *ast.SubroutineDeclaration) int {

--- a/linter/helper.go
+++ b/linter/helper.go
@@ -339,29 +339,33 @@ func getSubroutineCallScope(s *ast.SubroutineDeclaration) int {
 
 	// If could not via subroutine name, find by annotations
 	// typically defined is module file
+	scopes := 0
 	for _, a := range annotations(s.Leading) {
 		switch strings.ToUpper(a) {
 		case "RECV":
-			return context.RECV
+			scopes |= context.RECV
 		case "HASH":
-			return context.HASH
+			scopes |= context.HASH
 		case "HIT":
-			return context.HIT
+			scopes |= context.HIT
 		case "MISS":
-			return context.MISS
+			scopes |= context.MISS
 		case "PASS":
-			return context.PASS
+			scopes |= context.PASS
 		case "FETCH":
-			return context.FETCH
+			scopes |= context.FETCH
 		case "ERROR":
-			return context.ERROR
+			scopes |= context.ERROR
 		case "DELIVER":
-			return context.DELIVER
+			scopes |= context.DELIVER
 		case "LOG":
-			return context.LOG
+			scopes |= context.LOG
 		}
 	}
-	return context.RECV
+	if scopes == 0 {
+		return context.RECV
+	}
+	return scopes
 }
 
 func getFastlySubroutineScope(name string) string {

--- a/linter/helper.go
+++ b/linter/helper.go
@@ -306,7 +306,12 @@ func annotations(comments ast.Comments) []string {
 	for i := range comments {
 		l := strings.TrimLeft(comments[i].Value, " */#")
 		if strings.HasPrefix(l, "@") {
-			an := strings.Split(strings.TrimPrefix(l, "@"), ",")
+			var an []string
+			if strings.HasPrefix(l, "@scope:") {
+				an = strings.Split(strings.TrimPrefix(l, "@scope:"), ",")
+			} else {
+				an = strings.Split(strings.TrimPrefix(l, "@"), ",")
+			}
 			for _, s := range an {
 				rv = append(rv, strings.TrimSpace(s))
 			}

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -1223,7 +1223,7 @@ func (l *Linter) lintIdent(exp *ast.Ident, ctx *context.Context) types.Type {
 		} else if _, ok := ctx.Identifiers[exp.Value]; ok {
 			return types.IDType
 		}
-		l.Error(UndefinedVariable(exp.GetMeta(), exp.Value))
+		l.Error(err)
 	}
 	return v
 }

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -375,8 +375,7 @@ sub vcl_recv BOOL {
 
 	t.Run("Subroutines can be reused in multiple vcl state functions", func(t *testing.T) {
 		input := `
-//@recv
-//@log
+//@recv, log
 sub example {
 	set req.http.Host = "example.com";
 }
@@ -396,8 +395,7 @@ call example;
 
 	t.Run("Functions can be reused in multiple vcl state functions", func(t *testing.T) {
 		input := `
-//@recv
-//@log
+//@recv, log
 sub example BOOL {
 	return true;
 }
@@ -421,8 +419,7 @@ sub vcl_recv {
 
 	t.Run("Errros when subroutines want variables they don't have access to", func(t *testing.T) {
 		input := `
-//@recv
-//@deliver
+//@recv, deliver
 sub example {
 	log resp.http.bar;
 }


### PR DESCRIPTION
The current way we set annotations only allows for subroutines to be used
in a single vcl state function.

Fastly is allows that and it also leads to copy-pasting functions with different
annotations, which is not a good pattern.

I only implemented them as annotations in the form `@<state_name>` instead of supporting them in the
function name because I think it will be weird to have `sub foo_recv_miss_deliver`

Fixes #84

Signed-off-by: Sotiris Nanopoulos <sotiris.nanopoulos@reddit.com>