### PR TITLE
Fix lint of `log` statement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ generate:
 	cd ./__generator__/ && go generate .
 
 test: generate
-	go list ./... | xargs go test
+	go test ./...
 
 linux:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build \

--- a/linter/helper.go
+++ b/linter/helper.go
@@ -437,3 +437,20 @@ func isProbeMakingTheBackendStartAsUnhealthy(prober ast.BackendProbeObject) erro
 
 	return nil
 }
+
+func isTypeLiteral(node ast.Node) bool {
+	switch node.(type) {
+	case *ast.IP:
+		return true
+	case *ast.Boolean:
+		return true
+	case *ast.Integer:
+		return true
+	case *ast.String:
+		return true
+	case *ast.Float:
+		return true
+	default:
+		return false
+	}
+}

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -1083,6 +1083,20 @@ func (l *Linter) lintErrorStatement(stmt *ast.ErrorStatement, ctx *context.Conte
 }
 
 func (l *Linter) lintLogStatement(stmt *ast.LogStatement, ctx *context.Context) types.Type {
+	if isTypeLiteral(stmt.Value) {
+		switch stmt.Value.(type) {
+		case *ast.String:
+			return types.NeverType
+		default:
+			l.Error(&LintError{
+				Severity: ERROR,
+				Token:    stmt.GetMeta().Token,
+				Message:  "Only string literals can be passed to log directly.",
+			})
+			return types.NeverType
+		}
+	}
+
 	l.lint(stmt.Value, ctx)
 	return types.NeverType
 }


### PR DESCRIPTION
Fastly doesn't allow literals to be passed to log staments but
falco was ok with it. We fix it and add some tests to solidify
the behavior.

Fiddle: https://fiddle.fastlydemo.net/fiddle/1d772f20

Signed-off-by: Sotiris Nanopoulos <sotiris.nanopoulos@reddit.com>