### PR TITLE
Combine included VCL modules into main and parse once

### DIFF
--- a/cmd/falco/main.go
+++ b/cmd/falco/main.go
@@ -222,7 +222,7 @@ func runLint(runner *Runner) error {
 		return ErrExit
 	}
 
-	if err := runner.Transform(result.Vcls); err != nil {
+	if err := runner.Transform(result.Vcl); err != nil {
 		writeln(red, err.Error())
 		return ErrExit
 	}

--- a/cmd/falco/runner.go
+++ b/cmd/falco/runner.go
@@ -37,7 +37,7 @@ type RunnerResult struct {
 	Infos    int
 	Warnings int
 	Errors   int
-	Vcl     *plugin.VCL
+	Vcl      *plugin.VCL
 }
 
 type StatsResult struct {
@@ -231,7 +231,7 @@ func (r *Runner) Run() (*RunnerResult, error) {
 		Infos:    r.infos,
 		Warnings: r.warnings,
 		Errors:   r.errors,
-		Vcl:     vcl,
+		Vcl:      vcl,
 	}, nil
 }
 
@@ -259,7 +259,7 @@ func (r *Runner) run(v *VCL, mode RunMode) (*plugin.VCL, error) {
 	lt.Lint(vcl, r.context)
 
 	// If runner is running as stat mode, prevent to output lint result
-	if mode & RunModeStat > 0 {
+	if mode&RunModeStat > 0 {
 		return nil, nil
 	}
 
@@ -275,7 +275,7 @@ func (r *Runner) run(v *VCL, mode RunMode) (*plugin.VCL, error) {
 
 	return &plugin.VCL{
 		File: v.Name,
-		AST: vcl,
+		AST:  vcl,
 	}, nil
 }
 

--- a/cmd/falco/runner.go
+++ b/cmd/falco/runner.go
@@ -289,19 +289,11 @@ func (r *Runner) resolveStatements(statements []ast.Statement) ([]ast.Statement,
 			if err != nil {
 				return nil, err
 			}
-			lx := lexer.NewFromString(module.Data, lexer.WithFile(module.Name))
-			p := parser.New(lx)
-			vcl, err := p.ParseVCL()
+
+			vcl, err := r.parseVCL(module.Name, module.Data)
 			if err != nil {
-				lx.NewLine()
-				pe, ok := errors.Cause(err).(*parser.ParseError)
-				if ok {
-					r.printParseError(lx, pe)
-				}
-				return nil, ErrParser
+				return nil, err
 			}
-			lx.NewLine()
-			r.lexers[module.Name] = lx
 
 			vcl.Statements, err = r.resolveStatements(vcl.Statements)
 			if err != nil {

--- a/cmd/falco/runner.go
+++ b/cmd/falco/runner.go
@@ -37,7 +37,7 @@ type RunnerResult struct {
 	Infos    int
 	Warnings int
 	Errors   int
-	Vcls     []*plugin.VCL
+	Vcl     *plugin.VCL
 }
 
 type StatsResult struct {
@@ -51,16 +51,19 @@ type StatsResult struct {
 	Lines       int    `json:"lines"`
 }
 
-type RunMode struct {
-	isMain bool
-	isStat bool
-}
+type RunMode int
+
+const (
+	RunModeLint RunMode = 0x000001
+	RunModeStat RunMode = 0x000010
+)
 
 type Runner struct {
 	transformers []*Transformer
 	resolver     Resolver
 	overrides    map[string]linter.Severity
 	lexers       map[string]*lexer.Lexer
+	snippets     []snippetItem
 
 	level Level
 
@@ -99,13 +102,13 @@ func NewRunner(rz Resolver, c *Config) (*Runner, error) {
 			ctx, timeout := _context.WithTimeout(_context.Background(), 20*time.Second)
 			defer timeout()
 
-			snippet := NewSnippet(serviceId, apiKey)
 			// Remote communication is optional so we keep processing even if remote communication is failed
-			if err := snippet.Fetch(ctx); err != nil {
-				writeln(red, err.Error())
-			} else if err := snippet.Compile(r.context); err != nil {
+			snippets, err := NewSnippet(serviceId, apiKey).Fetch(ctx)
+			if err != nil {
 				writeln(red, err.Error())
 			}
+			// Stack to runner field, combime before run()
+			r.snippets = snippets
 		}()
 	}
 
@@ -182,9 +185,9 @@ func (r *Runner) initOverrides() {
 	}
 }
 
-func (r *Runner) Transform(vcls []*plugin.VCL) error {
+func (r *Runner) Transform(vcl *plugin.VCL) error {
 	// VCL data is shared between parser and transformar through the falco/io package.
-	encoded, err := plugin.Encode(vcls)
+	encoded, err := plugin.Encode(vcl)
 	if err != nil {
 		return fmt.Errorf("Failed to encode VCL: %w", err)
 	}
@@ -197,29 +200,8 @@ func (r *Runner) Transform(vcls []*plugin.VCL) error {
 	return nil
 }
 
-func (r *Runner) Run() (*RunnerResult, error) {
-	main, err := r.resolver.MainVCL()
-	if err != nil {
-		return nil, err
-	}
-	vcls, err := r.run(main, &RunMode{
-		isMain: true,
-		isStat: false,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return &RunnerResult{
-		Infos:    r.infos,
-		Warnings: r.warnings,
-		Errors:   r.errors,
-		Vcls:     vcls,
-	}, nil
-}
-
-func (r *Runner) run(v *VCL, mode *RunMode) ([]*plugin.VCL, error) {
-	lx := lexer.NewFromString(v.Data, lexer.WithFile(v.Name))
+func (r *Runner) parseVCL(name, code string) (*ast.VCL, error) {
+	lx := lexer.NewFromString(code, lexer.WithFile(name))
 	p := parser.New(lx)
 	vcl, err := p.ParseVCL()
 	if err != nil {
@@ -231,48 +213,54 @@ func (r *Runner) run(v *VCL, mode *RunMode) ([]*plugin.VCL, error) {
 		return nil, ErrParser
 	}
 	lx.NewLine()
-	r.lexers[v.Name] = lx
+	r.lexers[name] = lx
+	return vcl, nil
+}
+
+func (r *Runner) Run() (*RunnerResult, error) {
+	main, err := r.resolver.MainVCL()
+	if err != nil {
+		return nil, err
+	}
+	vcl, err := r.run(main, RunModeLint)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RunnerResult{
+		Infos:    r.infos,
+		Warnings: r.warnings,
+		Errors:   r.errors,
+		Vcl:     vcl,
+	}, nil
+}
+
+func (r *Runner) run(v *VCL, mode RunMode) (*plugin.VCL, error) {
+	vcl, err := r.parseVCL(v.Name, v.Data)
+	if err != nil {
+		return nil, err
+	}
+
+	// If remote snippets exists, prepare parse and prepend to main VCL
+	for _, snip := range r.snippets {
+		s, err := r.parseVCL(snip.Name, snip.Data)
+		if err != nil {
+			return nil, err
+		}
+		vcl.Statements = append(s.Statements, vcl.Statements...)
+	}
 
 	vcl.Statements, err = r.resolveStatements(vcl.Statements)
 	if err != nil {
 		return nil, err
 	}
 
-	vcls := []*plugin.VCL{
-		{ File: v.Name, AST: vcl },
-	}
-	// var vcls []*plugin.VCL
-	// // Lint dependent VCLs before execute main VCL
-	// for _, stmt := range vcl.Statements {
-	// 	include, ok := stmt.(*ast.IncludeStatement)
-	// 	if !ok {
-	// 		continue
-	// 	}
-
-	// 	if module, err := r.resolver.Resolve(include.Module.Value); err == nil {
-	// 		subVcl, err := r.run(module, &RunMode{
-	// 			isMain: false,
-	// 			isStat: mode.isStat,
-	// 		})
-	// 		if err != nil {
-	// 			return nil, err
-	// 		}
-	// 		vcls = append(vcls, subVcl...)
-	// 	}
-	// }
-
-	// // Append main to the last of proceeds VCLs
-	// vcls = append(vcls, &plugin.VCL{
-	// 	File: v.Name,
-	// 	AST:  vcl,
-	// })
-
 	lt := linter.New()
-	lt.Lint(vcl, r.context, mode.isMain)
+	lt.Lint(vcl, r.context)
 
 	// If runner is running as stat mode, prevent to output lint result
-	if mode.isStat {
-		return vcls, nil
+	if mode & RunModeStat > 0 {
+		return nil, nil
 	}
 
 	if len(lt.Errors) > 0 {
@@ -281,11 +269,14 @@ func (r *Runner) run(v *VCL, mode *RunMode) ([]*plugin.VCL, error) {
 			if !ok {
 				continue
 			}
-			r.printLinterError(lx, le)
+			r.printLinterError(r.lexers[v.Name], le)
 		}
 	}
 
-	return vcls, nil
+	return &plugin.VCL{
+		File: v.Name,
+		AST: vcl,
+	}, nil
 }
 
 func (r *Runner) resolveStatements(statements []ast.Statement) ([]ast.Statement, error) {
@@ -396,6 +387,8 @@ func (r *Runner) printLinterError(lx *lexer.Lexer, err *linter.LintError) {
 	if err.Rule != "" {
 		rule = " (" + string(err.Rule) + ")"
 	}
+
+	// Override lexer because error may cause in other included module
 	if err.Token.File != "" {
 		file = "in " + err.Token.File + " "
 		lx = r.lexers[err.Token.File]
@@ -460,11 +453,7 @@ func (r *Runner) Stats() (*StatsResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	vcls, err := r.run(main, &RunMode{
-		isMain: true,
-		isStat: true,
-	})
-	if err != nil {
+	if _, err := r.run(main, RunModeStat); err != nil {
 		return nil, err
 	}
 
@@ -477,9 +466,9 @@ func (r *Runner) Stats() (*StatsResult, error) {
 		Directors:   len(r.context.Directors),
 	}
 
-	for _, vcl := range vcls {
+	for _, lx := range r.lexers {
 		stats.Files++
-		stats.Lines += r.lexers[vcl.File].LineCount()
+		stats.Lines += lx.LineCount()
 	}
 
 	return stats, nil

--- a/cmd/falco/runner_test.go
+++ b/cmd/falco/runner_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+type mockResolver struct {
+	dependency map[string]string
+	main       string
+}
+
+func (m *mockResolver) MainVCL() (*VCL, error) {
+	return &VCL{
+		Name: "main.vcl",
+		Data: m.main,
+	}, nil
+}
+
+func (m *mockResolver) Resolve(module string) (*VCL, error) {
+	if v, ok := m.dependency[module]; !ok {
+		return nil, errors.New(module + " is not defined")
+	} else {
+		return &VCL{
+			Name: module + ".vcl",
+			Data: v,
+		}, nil
+	}
+}
+
+func (m *mockResolver) Name() string {
+	return ""
+}
+
+func TestResolveIncludeStatement(t *testing.T) {
+	mock := &mockResolver{
+		dependency: map[string]string{
+			"deps01": `
+sub foo {
+	set req.backend = httpbin_org;
+}
+
+sub bar {
+	set req.http.Foo = "bar";
+}
+			`,
+		},
+		main: `
+backend httpbin_org {
+  .connect_timeout = 1s;
+  .dynamic = true;
+  .port = "443";
+  .host = "httpbin.org";
+  .first_byte_timeout = 20s;
+  .max_connections = 500;
+  .between_bytes_timeout = 20s;
+  .share_key = "xei5lohleex3Joh5ie5uy7du";
+  .ssl = true;
+  .ssl_sni_hostname = "httpbin.org";
+  .ssl_cert_hostname = "httpbin.org";
+  .ssl_check_cert = always;
+  .min_tls_version = "1.2";
+  .max_tls_version = "1.2";
+}
+
+include "deps01";
+
+sub vcl_recv {
+   #FASTLY RECV
+   call foo;
+}
+		`,
+	}
+	r, err := NewRunner(mock, &Config{V: true})
+	if err != nil {
+		t.Errorf("Unexpected runner creation error: %s", err)
+		return
+	}
+	ret, err := r.Run()
+	if err != nil {
+		t.Errorf("Unexpected Run() error: %s", err)
+		return
+	}
+	if ret.Infos > 0 {
+		t.Errorf("Infos expects 0, got %d", ret.Infos)
+	}
+	// Above VCL should have one warning that subroutine "bar" is not defined
+	if ret.Warnings != 1 {
+		t.Errorf("Warning expects 0, got %d", ret.Warnings)
+	}
+	if ret.Errors > 0 {
+		t.Errorf("Errors expects 0, got %d", ret.Errors)
+	}
+	if len(ret.Vcl.AST.Statements) != 4 {
+		t.Errorf("Parsed VCL should have 4 statements, got %d", len(ret.Vcl.AST.Statements))
+	}
+}
+
+func TestResolveNestedIncludeStatement(t *testing.T) {
+	mock := &mockResolver{
+		dependency: map[string]string{
+			"deps01": `
+include "deps02";
+			`,
+			"deps02": `
+sub foo {
+	set req.backend = httpbin_org;
+}
+			`,
+		},
+		main: `
+backend httpbin_org {
+  .connect_timeout = 1s;
+  .dynamic = true;
+  .port = "443";
+  .host = "httpbin.org";
+  .first_byte_timeout = 20s;
+  .max_connections = 500;
+  .between_bytes_timeout = 20s;
+  .share_key = "xei5lohleex3Joh5ie5uy7du";
+  .ssl = true;
+  .ssl_sni_hostname = "httpbin.org";
+  .ssl_cert_hostname = "httpbin.org";
+  .ssl_check_cert = always;
+  .min_tls_version = "1.2";
+  .max_tls_version = "1.2";
+}
+
+include "deps01";
+
+sub vcl_recv {
+   #FASTLY RECV
+   call foo;
+}
+		`,
+	}
+	r, err := NewRunner(mock, &Config{V: true})
+	if err != nil {
+		t.Errorf("Unexpected runner creation error: %s", err)
+		return
+	}
+	ret, err := r.Run()
+	if err != nil {
+		t.Errorf("Unexpected Run() error: %s", err)
+		return
+	}
+	if ret.Infos > 0 {
+		t.Errorf("Infos expects 0, got %d", ret.Infos)
+	}
+	if ret.Warnings > 0 {
+		t.Errorf("Warning expects 0, got %d", ret.Warnings)
+	}
+	if ret.Errors > 0 {
+		t.Errorf("Errors expects 0, got %d", ret.Errors)
+	}
+	if len(ret.Vcl.AST.Statements) != 3 {
+		t.Errorf("Parsed VCL should have 3 statements, got %d", len(ret.Vcl.AST.Statements))
+	}
+}

--- a/cmd/falco/snippet.go
+++ b/cmd/falco/snippet.go
@@ -33,8 +33,7 @@ type snippetItem struct {
 }
 
 type Snippet struct {
-	client   *remote.FastlyClient
-	snippets []snippetItem
+	client *remote.FastlyClient
 }
 
 func NewSnippet(serviceId, apiKey string) *Snippet {

--- a/cmd/falco/snippet.go
+++ b/cmd/falco/snippet.go
@@ -39,6 +39,7 @@ director {{ .Name }} {{ .Type | printtype }} {
 	{{- end }}
 }
 `
+
 type snippetItem struct {
 	Data string
 	Name string
@@ -186,8 +187,8 @@ func (s *Snippet) renderBackendShields(backends []*remote.Backend) ([]snippetIte
 		return ""
 	}
 	dirTmpl, err := template.New("director").
-	  Funcs(template.FuncMap{"printtype": printType}).
-	  Parse(directorTemplate)
+		Funcs(template.FuncMap{"printtype": printType}).
+		Parse(directorTemplate)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compile director template: %w", err)
 	}

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -34,7 +34,7 @@ func (l *Linter) Error(err error) {
 
 // Expose lint function to call from external program.
 // It means this method is bootstrap, called only once.
-func (l *Linter) Lint(node ast.Node, ctx *context.Context, isMain bool) types.Type {
+func (l *Linter) Lint(node ast.Node, ctx *context.Context) types.Type {
 	if ctx == nil {
 		ctx = context.New()
 	}
@@ -42,15 +42,13 @@ func (l *Linter) Lint(node ast.Node, ctx *context.Context, isMain bool) types.Ty
 	l.lint(node, ctx)
 
 	// After whole VCLs have been linted in main VCL, check all definitions are exactly used.
-	if isMain {
-		l.lintUnusedTables(ctx)
-		l.lintUnusedAcls(ctx)
-		l.lintUnusedBackends(ctx)
-		l.lintUnusedSubroutines(ctx)
-		l.lintUnusedGotos(ctx)
-		l.lintUnusedPenaltyboxes(ctx)
-		l.lintUnusedRatecounters(ctx)
-	}
+	l.lintUnusedTables(ctx)
+	l.lintUnusedAcls(ctx)
+	l.lintUnusedBackends(ctx)
+	l.lintUnusedSubroutines(ctx)
+	l.lintUnusedGotos(ctx)
+	l.lintUnusedPenaltyboxes(ctx)
+	l.lintUnusedRatecounters(ctx)
 
 	return types.NeverType
 }

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -1426,7 +1426,7 @@ sub bar {
 		}
 
 		l := New()
-		l.Lint(vcl, context.New(), true)
+		l.Lint(vcl, context.New())
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
 		}
@@ -1442,7 +1442,7 @@ acl foo {}
 		}
 
 		l := New()
-		l.Lint(vcl, context.New(), true)
+		l.Lint(vcl, context.New())
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
 		}
@@ -1464,7 +1464,7 @@ sub bar {
 		}
 
 		l := New()
-		l.Lint(vcl, context.New(), true)
+		l.Lint(vcl, context.New())
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
 		}
@@ -1480,7 +1480,7 @@ table foo {}
 		}
 
 		l := New()
-		l.Lint(vcl, context.New(), true)
+		l.Lint(vcl, context.New())
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
 		}
@@ -1502,7 +1502,7 @@ sub vcl_recl {
 		}
 
 		l := New()
-		l.Lint(vcl, context.New(), true)
+		l.Lint(vcl, context.New())
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
 		}
@@ -1518,7 +1518,7 @@ backend foo {}
 		}
 
 		l := New()
-		l.Lint(vcl, context.New(), true)
+		l.Lint(vcl, context.New())
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
 		}
@@ -1540,7 +1540,7 @@ sub vcl_recl {
 		}
 
 		l := New()
-		l.Lint(vcl, context.New(), true)
+		l.Lint(vcl, context.New())
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
 		}
@@ -1556,7 +1556,7 @@ sub foo {}
 		}
 
 		l := New()
-		l.Lint(vcl, context.New(), true)
+		l.Lint(vcl, context.New())
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
 		}
@@ -1577,7 +1577,7 @@ sub vcl_recv {
 		}
 
 		l := New()
-		l.Lint(vcl, context.New(), true)
+		l.Lint(vcl, context.New())
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
 		}
@@ -1596,7 +1596,7 @@ sub vcl_recv {
 		}
 
 		l := New()
-		l.Lint(vcl, context.New(), true)
+		l.Lint(vcl, context.New())
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
 		}

--- a/plugin/io.go
+++ b/plugin/io.go
@@ -72,10 +72,10 @@ type Metadata struct {
 
 type FalcoTransformInput struct {
 	Metadata Metadata
-	VCLs     []*VCL
+	VCL     *VCL
 }
 
-func Encode(vcls []*VCL) ([]byte, error) {
+func Encode(vcl *VCL) ([]byte, error) {
 	buf := new(bytes.Buffer)
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -85,7 +85,7 @@ func Encode(vcls []*VCL) ([]byte, error) {
 		Metadata: Metadata{
 			WorkingDirectory: cwd,
 		},
-		VCLs: vcls,
+		VCL: vcl,
 	}); err != nil {
 		return nil, err
 	}

--- a/plugin/io.go
+++ b/plugin/io.go
@@ -72,7 +72,7 @@ type Metadata struct {
 
 type FalcoTransformInput struct {
 	Metadata Metadata
-	VCL     *VCL
+	VCL      *VCL
 }
 
 func Encode(vcl *VCL) ([]byte, error) {

--- a/plugin/io_test.go
+++ b/plugin/io_test.go
@@ -9,14 +9,12 @@ import (
 )
 
 func TestEncodeDecode(t *testing.T) {
-	vcls := []*VCL{
-		{
-			File: "foobar",
-			AST:  &ast.VCL{},
-		},
+	vcl := &VCL{
+		File: "foobar",
+		AST:  &ast.VCL{},
 	}
 
-	buf, err := Encode(vcls)
+	buf, err := Encode(vcl)
 	if err != nil {
 		t.Errorf("Encode error: %s", err)
 		t.FailNow()
@@ -31,11 +29,11 @@ func TestEncodeDecode(t *testing.T) {
 		t.Errorf("Metadata should be set: %s", err)
 		t.FailNow()
 	}
-	if len(dec.VCLs) == 0 {
+	if dec.VCL == nil {
 		t.Errorf("VCL should have one item")
 		t.FailNow()
 	}
-	if diff := cmp.Diff(dec.VCLs[0].AST, &ast.VCL{}); diff != "" {
+	if diff := cmp.Diff(dec.VCL.AST, &ast.VCL{}); diff != "" {
 		t.Errorf("assertion error, diff= %s", diff)
 	}
 }


### PR DESCRIPTION
Fixes #78 

Resolve include modules that are declared at `include "xxx";` statement, replace the parsed AST into its declaration position, and lint whole codes as a single VCL tree

This implementation still does not use DFS style parsing but it's should be lint properly.

### Example

From #78, the example case of VCLs:

```vcl
# dependency1.vcl
sub foo {
   set req.backend = httpbin_org;
}
```

```vcl
# main.vcl

include "dependency1";

backend httpbin_org {
  .connect_timeout = 1s;
  .dynamic = true;
  .port = "443";
  .host = "httpbin.org";
  .first_byte_timeout = 20s;
  .max_connections = 500;
  .between_bytes_timeout = 20s;
  .share_key = "xei5lohleex3Joh5ie5uy7du";
  .ssl = true;
  .ssl_sni_hostname = "httpbin.org";
  .ssl_cert_hostname = "httpbin.org";
  .ssl_check_cert = always;
  .min_tls_version = "1.2";
  .max_tls_version = "1.2";
}

sub vcl_recv {
   call foo;
}
```

Then resolved VCL should be:

```vcl
sub foo {
   set req.backend = httpbin_org;
}

backend httpbin_org {
  .connect_timeout = 1s;
  .dynamic = true;
  .port = "443";
  .host = "httpbin.org";
  .first_byte_timeout = 20s;
  .max_connections = 500;
  .between_bytes_timeout = 20s;
  .share_key = "xei5lohleex3Joh5ie5uy7du";
  .ssl = true;
  .ssl_sni_hostname = "httpbin.org";
  .ssl_cert_hostname = "httpbin.org";
  .ssl_check_cert = always;
  .min_tls_version = "1.2";
  .max_tls_version = "1.2";
}

sub vcl_recv {
   call foo;
}
```

And linter should not raise any errors.

## Additional Specs

- [x] Remote snippets (EdgeDictionary, ACL) also valid
- [x] Nested inclusion also valid
- [x] VCL error of included module still displays its filename and line