### PR TITLE
Allow function expressions in error statements

### DIFF
--- a/linter/linter.go
+++ b/linter/linter.go
@@ -1070,6 +1070,11 @@ func (l *Linter) lintErrorStatement(stmt *ast.ErrorStatement, ctx *context.Conte
 		if code != types.IntegerType {
 			l.Error(InvalidType(t.GetMeta(), t.Value, types.IntegerType, code))
 		}
+	case *ast.FunctionCallExpression:
+		code := l.lint(t, ctx)
+		if code != types.IntegerType {
+			l.Error(InvalidType(t.GetMeta(), "error code", types.IntegerType, code))
+		}
 	case *ast.Integer:
 		if t.Value > 699 {
 			l.Error(ErrorCodeRange(t.GetMeta(), t.Value).Match(ERROR_STATEMENT_CODE))

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -625,6 +625,24 @@ sub foo {
 `
 		assertError(t, input)
 	})
+
+	t.Run("pass with function", func(t *testing.T) {
+		input := `
+sub foo {
+	error std.atoi("10");
+}
+`
+		assertNoError(t, input)
+	})
+
+	t.Run("invalid function return type", func(t *testing.T) {
+		input := `
+sub foo {
+	error std.strrev("error");
+}
+`
+		assertError(t, input)
+	})
 }
 
 func TestLintIfStatement(t *testing.T) {

--- a/parser/statement_parser.go
+++ b/parser/statement_parser.go
@@ -316,7 +316,13 @@ func (p *Parser) parseErrorStatement() (*ast.ErrorStatement, error) {
 		stmt.Code, err = p.parseInteger()
 	case token.IDENT:
 		p.nextToken()
-		stmt.Code = p.parseIdent()
+		if p.peekTokenIs(token.LEFT_PAREN) {
+			i := p.parseIdent()
+			p.nextToken()
+			stmt.Code, err = p.parseFunctionCallExpression(i)
+		} else {
+			stmt.Code = p.parseIdent()
+		}
 	default:
 		err = UnexpectedToken(p.peekToken)
 	}


### PR DESCRIPTION
Hey there, I'm currently working on getting the Financial Times' Fastly VCL working with Falco, and have been fixing any false positives I've found. So I might make a few PRs to upstream the fixes over the next few days if that's okay! Thanks for this great resource.

The first change is allowing function calls in `error` statements. We're currently using a `table` to track all the custom error codes we return so that we can minimise duplication and bugs when handling them in `error` subroutines. For example, we might declare an error like
```vcl
error table.lookup_integer(synthetic_errors, "gtg", 601) "Report health on cdn";
```
to (verbosely) enforce the same error code across subroutines (though the non-optional fallback argument doesn't feel great...)

Currently, Falco only expects identifiers or numbers as the first argument to `error`, but functions are also accepted by Fastly. I've added additional parsing logic to allow for this. The linter will also check to make sure that the function returns an integer.