### PR TITLE
Fetch backend snippets from Fastly API

### DIFF
--- a/remote/client.go
+++ b/remote/client.go
@@ -158,3 +158,13 @@ func (c *FastlyClient) ListAccessControlEntries(ctx context.Context, aclId strin
 
 	return entries, nil
 }
+
+func (c *FastlyClient) ListBackends(ctx context.Context, version int64) ([]*Backend, error) {
+	endpoint := fmt.Sprintf("/service/%s/version/%d/backend", c.serviceId, version)
+	var backends []*Backend
+	if err := c.request(ctx, endpoint, &backends); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return backends, nil
+}

--- a/remote/client_test.go
+++ b/remote/client_test.go
@@ -220,3 +220,41 @@ func TestListAccessControlEntiries(t *testing.T) {
 		t.FailNow()
 	}
 }
+
+func TestListBackends(t *testing.T) {
+	c := NewFastlyClient(&http.Client{
+		Transport: &TestRoundTripper{
+			StatusCode: 200,
+			Body: `
+[
+  {
+    "updated_at": "2021-11-25T23:40:33Z",
+		"name": "some_backend",
+		"shield": "some_shield",
+    "service_id": "0yGwmmav8rcXRC7yRwzPNQ",
+    "comment": "example",
+    "created_at": "2021-11-25T23:40:33Z"
+  }
+]`,
+		},
+	}, "dummy", "dummy")
+
+	items, err := c.ListBackends(context.Background(), 10)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		t.FailNow()
+	}
+	if len(items) != 1 {
+		t.Errorf("backends should have 1 items but got %d", len(items))
+		t.FailNow()
+	}
+	i := items[0]
+	if i.Name != "some_backend" {
+		t.Errorf("item name assertion error, expects=some_backend but got=%s", i.Name)
+		t.FailNow()
+	}
+	if *i.Shield != "some_shield" {
+		t.Errorf("item shield assertion error, expects=some_shield but got=%s", *i.Shield)
+		t.FailNow()
+	}
+}

--- a/remote/entity.go
+++ b/remote/entity.go
@@ -42,6 +42,7 @@ const (
 )
 
 type Director struct {
-	Name string       `json:"name"`
-	Type DirectorType `json:"type"`
+	Name     string       `json:"name"`
+	Type     DirectorType `json:"type"`
+	Backends []string     `json:"backends"`
 }

--- a/remote/entity.go
+++ b/remote/entity.go
@@ -27,3 +27,21 @@ type AccessControlEntry struct {
 	Subnet  *int64 `json:"subnet"`
 	Comment string `json:"comment"`
 }
+
+type Backend struct {
+	Name   string  `json:"name"`
+	Shield *string `json:"shield"`
+}
+
+type DirectorType int8
+
+const (
+	Random DirectorType = iota + 1
+	Hash
+	Client
+)
+
+type Director struct {
+	Name string       `json:"name"`
+	Type DirectorType `json:"type"`
+}


### PR DESCRIPTION
Falco already supports pulling in some data from the Fastly API with the `--remote` flag but does not currently support getting backends configured in the Fastly UI or via the API. This meant we were seeing a lot of undefined variable errors when linting our VCL, as Falco didn't know about all of our backends.

I've added support for calling the [Backends API](https://developer.fastly.com/reference/api/services/backend/#list-backends) to get these backends now. Additionally, it also checks the `shield` value in each backend, as Fastly will implicitly create a director for each region you have configured to use shields in so that it can balance load across all the shield instances. I've tried to make this latter code a little generic so that it could be refactored and reused if someone wants to add support for fetching the [Director API](https://developer.fastly.com/reference/api/load-balancing/directors/director/#list-directors) later on (though note that this API does not return the shield directors Fastly creates.) The snippet templates are pretty simple as we don't really need any data from the backends/directors we're appending: just their names are required to fix the undefined variable errors really.