### PR TITLE
Allow req.backend to be read as a string

### DIFF
--- a/__generator__/main.go
+++ b/__generator__/main.go
@@ -14,6 +14,7 @@ var typeToType = map[string]string{
 	"RTIME":       "types.RTimeType",
 	"TIME":        "types.TimeType",
 	"BACKEND":     "types.BackendType",
+	"REQBACKEND":  "types.ReqBackendType",
 	"IP":          "types.IPType",
 	"ID":          "types.IDType",
 	"ACL":         "types.AclType",

--- a/__generator__/predefined.yml
+++ b/__generator__/predefined.yml
@@ -223,8 +223,8 @@ beresp.used_alternate_path_to_origin:
 req.backend:
   reference: "https://developer.fastly.com/reference/vcl/variables/backend-connection/req-backend/"
   on: [RECV, HASH, HIT, MISS, PASS, FETCH, ERROR, DELIVER, LOG]
-  get: BACKEND
-  set: BACKEND
+  get: REQBACKEND
+  set: REQBACKEND
 
 req.backend.healthy:
   reference: "https://developer.fastly.com/reference/vcl/variables/backend-connection/req-backend-healthy/"

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -37,7 +37,7 @@ func TestContextSet(t *testing.T) {
 	t.Run("Can return right variable type", func(t *testing.T) {
 		c := New()
 		c.Scope(RECV)
-		expectedType := types.BackendType
+		expectedType := types.ReqBackendType
 		variableType, _ := c.Set("req.backend")
 		if variableType != expectedType {
 			t.Errorf("expected %s but got %s", expectedType, variableType)

--- a/context/predefined.go
+++ b/context/predefined.go
@@ -2940,8 +2940,8 @@ func predefinedVariables() Variables {
 						},
 					},
 					Value: &Accessor{
-						Get:       types.BackendType,
-						Set:       types.BackendType,
+						Get:       types.ReqBackendType,
+						Set:       types.ReqBackendType,
 						Unset:     false,
 						Scopes:    RECV | HASH | HIT | MISS | PASS | FETCH | ERROR | DELIVER | LOG,
 						Reference: "https://developer.fastly.com/reference/vcl/variables/backend-connection/req-backend/",

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -751,14 +751,14 @@ Calling function argument type mismatch.
 
 Problem:
 ```vcl
-declare local var.dir STRING;
-set var.dir = std.dirname(req.backend); // std.dirname expects 1st argument as STRING but BACKEND supplied
+declare local var.lat FLOAT;
+set var.lat = math.floor("2.2"); // math.floor expects 1st argument as FLOAT but STRING supplied
 ```
 
 Fix:
 ```vcl
-declare local var.dir STRING;
-set var.dir = std.dirname(req.url);
+declare local var.lat FLOAT;
+set var.lat = math.floor(2.2);
 ```
 
 ## include/module-not-found

--- a/linter/function.go
+++ b/linter/function.go
@@ -104,6 +104,14 @@ func (l *Linter) lintFunctionArguments(fn *context.BuiltinFunction, calledFn fun
 					calledFn.meta, calledFn.name, i+1, v, arg,
 				).Match(FUNCTION_ARGUMENT_TYPE).Ref(fn.Reference))
 			}
+		case types.StringType:
+			// fuzzy type check: some builtin function expects STRING type,
+			// then actual argument type could be REQBACKEND because VCL STRING type can be cast from REQBACKEND.
+			if !expectType(arg, types.StringType, types.ReqBackendType) {
+				l.Error(FunctionArgumentTypeMismatch(
+					calledFn.meta, calledFn.name, i+1, v, arg,
+				).Match(FUNCTION_ARGUMENT_TYPE).Ref(fn.Reference))
+			}
 		default:
 			// Otherwise, strict type check
 			if v != arg {

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -1344,6 +1344,8 @@ func (l *Linter) lintInfixExpression(exp *ast.InfixExpression, ctx *context.Cont
 	switch exp.Operator {
 	case "==", "!=":
 		// Cast req.backend to standard backend type for comparisons
+		// Fiddle demonstrating these comparisons are valid:
+		// https://fiddle.fastly.dev/fiddle/06865e2d
 		if left == types.ReqBackendType {
 			left = types.BackendType
 		}

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -1343,6 +1343,13 @@ func (l *Linter) lintInfixExpression(exp *ast.InfixExpression, ctx *context.Cont
 
 	switch exp.Operator {
 	case "==", "!=":
+		// Cast req.backend to standard backend type for comparisons
+		if left == types.ReqBackendType {
+			left = types.BackendType
+		}
+		if right == types.ReqBackendType {
+			right = types.BackendType
+		}
 		// Equal operator could compare any types but both left and right type must be the same.
 		if left != right {
 			l.Error(InvalidTypeComparison(exp.GetMeta(), left, right).Match(OPERATOR_CONDITIONAL))

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -449,6 +449,25 @@ sub foo {
 		assertNoError(t, input)
 	})
 
+	t.Run("set backend as req.backend", func(t *testing.T) {
+		input := `
+backend foo {}
+sub bar {
+	set req.backend = foo;
+}`
+
+		assertNoError(t, input)
+	})
+
+	t.Run("pass req.backend as string", func(t *testing.T) {
+		input := `
+sub foo {
+	set req.http.Debug-Backend = req.backend;
+}`
+
+		assertNoError(t, input)
+	})
+
 	t.Run("invalid variable name", func(t *testing.T) {
 		input := `
 sub foo {
@@ -1276,6 +1295,17 @@ sub foo {
 
 	set var.T = std.time(var.S, "Mon Jan 2 22:04:05 2006");
 }`
+		assertNoError(t, input)
+	})
+
+	t.Run("fuzzy type check for STRING type argument", func(t *testing.T) {
+		input := `
+sub foo {
+	declare local var.S STRING;
+
+	set var.S = substr(req.backend, 1);
+}
+`
 		assertNoError(t, input)
 	})
 }

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -850,6 +850,17 @@ sub foo {
 }`
 		assertError(t, input)
 	})
+
+	t.Run("req.backend is comparable with BACKEND type", func(t *testing.T) {
+		input := `
+backend foo {}
+sub foo {
+	if (req.backend == foo) {
+		restart;
+	}
+}`
+		assertNoError(t, input)
+	})
 }
 
 func TestLintNotEqualOperator(t *testing.T) {

--- a/linter/operator.go
+++ b/linter/operator.go
@@ -45,7 +45,7 @@ func (l *Linter) lintAssignOperator(op *ast.Operator, name string, left, right t
 		case types.StringType, types.BoolType:
 			return
 		// allows variable only, disallow literal
-		case types.IntegerType, types.FloatType, types.RTimeType, types.TimeType, types.IPType:
+		case types.IntegerType, types.FloatType, types.RTimeType, types.TimeType, types.IPType, types.ReqBackendType:
 			if isLiteral {
 				l.Error(InvalidType(op.Meta, name, left, right).Match(OPERATOR_ASSIGNMENT))
 			}
@@ -76,7 +76,25 @@ func (l *Linter) lintAssignOperator(op *ast.Operator, name string, left, right t
 		default:
 			l.Error(InvalidType(op.Meta, name, left, right).Match(OPERATOR_ASSIGNMENT))
 		}
-	default: // types.BackendType or types.BoolType
+	case types.BackendType:
+		switch right {
+		// allows both variable and literal
+		case types.BackendType, types.ReqBackendType:
+			return
+		// disallow
+		default:
+			l.Error(InvalidType(op.Meta, name, left, right).Match(OPERATOR_ASSIGNMENT))
+		}
+	case types.ReqBackendType:
+		switch right {
+		// allows both variable and literal
+		case types.BackendType, types.ReqBackendType:
+			return
+		// disallow
+		default:
+			l.Error(InvalidType(op.Meta, name, left, right).Match(OPERATOR_ASSIGNMENT))
+		}
+	default: // types.BoolType
 		if left != right {
 			l.Error(InvalidType(op.Meta, name, left, right).Match(OPERATOR_ASSIGNMENT))
 		}

--- a/types/types.go
+++ b/types/types.go
@@ -35,6 +35,11 @@ const (
 	// This type is used for variadic arguments of builtin function like h2.disable_header_compression(string...)
 	// Note that this type must not be used in VCL codes, only use for linting function arguments.
 	StringListType Type = 0x100000000001000
+	// ReqBackendType is a virtual type used to represent the special behavior of
+	// the req.backend variable. Unlike typical backend variables, it can be cast
+	// to a string.
+	// Any backend is implicitly cast to ReqBackendType when set to req.backend.
+	ReqBackendType Type = 0x100000000010000
 )
 
 func (t Type) String() string {
@@ -45,6 +50,8 @@ func (t Type) String() string {
 		return "ACL"
 	case BackendType:
 		return "BACKEND"
+	case ReqBackendType:
+		return "REQBACKEND"
 	case BoolType:
 		return "BOOL"
 	case FloatType:


### PR DESCRIPTION
Fastly [documents](https://developer.fastly.com/reference/vcl/variables/backend-connection/req-backend/) some curious behaviour for the `req.backend` variable:

> Upon reading in a [STRING](https://developer.fastly.com/reference/vcl/types/string/) context, `req.backend` is converted to a [STRING](https://developer.fastly.com/reference/vcl/types/string/) and prepended with the backend's `share_key` property, which is your service ID (for backends created via the API, CLI, or web interface), the string "fastlyshield" (for [shield](https://developer.fastly.com/learning/concepts/shielding) backends), or whatever you defined (for backends [defined in VCL](https://developer.fastly.com/reference/vcl/declarations/backend/)).

So `req.backend` is typically a `BACKEND` but it can be cast to a `STRING` as well, unlike other `BACKEND` values! We make use of this behaviour in our code to track what backend has been used for debugging purposes, i.e.:
```vcl
set resp.http.Debug-Fastly-Backend = req.backend;
```
Currently falco (understandably) prints a linter error when encountering this code
```
🔥 [ERROR] resp.http.Debug-Fastly-Backend wants type STRING but assign BACKEND (operator/assignment)
```

I'm honestly not sure what the best workaround for this would be. I think the big question is: do any other Fastly variables exhibit similar magical casting behaviour? If so, it would probably be worth expanding the `predefined.yml` specification to allow `get` and `set` fields to return an array or their different possible types.

For now, however, I'm assuming (or hoping) that this isn't the case and we can instead construct a specific hack for `req.backend`. I've started this off by adding an additional check in `lintAssignOperator` for whether you're reading the `req.backend` identifier. For this to work consistently we'll need to copy the check to all other places where a value is read, such as in `lintFunctionArguments`.

It's very messy work though and I'm wondering if anyone knows a better way to handle these values which can have multiple types. Is there anything in code already that supports this behaviour?

P.S. Thanks for giving me write access to the repository; I've made this change a branch in the repository rather than our fork!