### PR TITLE
Sanitize invalid chars in backend name before adding them as snippets

### DIFF
--- a/cmd/falco/runner_test.go
+++ b/cmd/falco/runner_test.go
@@ -52,25 +52,26 @@ func loadFromTfJson(fileName string, t *testing.T) ([]Resolver, Fetcher) {
 }
 
 func TestResolveExternalWithExternalProperties(t *testing.T) {
-	fileName := "../../terraform/data/terraform-valid.json"
-	rslv, f := loadFromTfJson(fileName, t)
-	r, err := NewRunner(rslv[0], &Config{V: true}, f)
-	if err != nil {
-		t.Fatalf("Unexpected runner creation error: %s", err)
-		return
-	}
-	ret, err := r.Run()
-	if err != nil {
-		t.Fatalf("Unexpected Run() error: %s", err)
-	}
-	if ret.Infos > 0 {
-		t.Errorf("Infos expects 0, got %d", ret.Infos)
-	}
-	if ret.Warnings != 0 {
-		t.Errorf("Warning expects 0, got %d", ret.Warnings)
-	}
-	if ret.Errors > 0 {
-		t.Errorf("Errors expects 0, got %d", ret.Errors)
+	for _, fileName := range []string{"../../terraform/data/terraform-valid.json", "../../terraform/data/terraform-valid-weird-name.json"} {
+		rslv, f := loadFromTfJson(fileName, t)
+		r, err := NewRunner(rslv[0], &Config{V: true}, f)
+		if err != nil {
+			t.Fatalf("Unexpected runner creation error: %s", err)
+			return
+		}
+		ret, err := r.Run()
+		if err != nil {
+			t.Fatalf("Unexpected Run() error: %s", err)
+		}
+		if ret.Infos > 0 {
+			t.Errorf("Infos expects 0, got %d", ret.Infos)
+		}
+		if ret.Warnings != 0 {
+			t.Errorf("Warning expects 0, got %d", ret.Warnings)
+		}
+		if ret.Errors > 0 {
+			t.Errorf("Errors expects 0, got %d", ret.Errors)
+		}
 	}
 }
 

--- a/cmd/falco/snippet.go
+++ b/cmd/falco/snippet.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"text/template"
@@ -38,6 +39,12 @@ director {{ .Name }} {{ .Type | printtype }} {
 	{{- end }}
 }
 `
+
+func TerraformBackendNameSanitizer(name string) string {
+	invalid := regexp.MustCompile(`\W`)
+	s := invalid.ReplaceAllString(name, "_")
+	return s
+}
 
 type snippetItem struct {
 	Data string
@@ -152,6 +159,7 @@ func (s *Snippet) fetchBackend() ([]snippetItem, error) {
 
 	for _, b := range backends {
 		buf := new(bytes.Buffer)
+		b.Name = TerraformBackendNameSanitizer(b.Name)
 		if err := backTmpl.Execute(buf, b); err != nil {
 			return nil, fmt.Errorf("failed to render backend template: %w", err)
 		}

--- a/terraform/data/terraform-valid-weird-name.json
+++ b/terraform/data/terraform-valid-weird-name.json
@@ -1,0 +1,64 @@
+{
+    "planned_values": {
+        "root_module": {
+            "resources": [
+                {
+                    "provider_name": "registry.terraform.io/fastly/fastly",
+                    "type": "fastly_service_vcl",
+                    "values": {
+                        "acl": [
+                            {
+                                "acl_id": "this is another id",
+                                "force_destroy": false,
+                                "name": "foo_acl"
+                            }
+                        ],
+                        "backend": [
+                            {
+                            "address": "foo.com",
+                            "auto_loadbalance": false,
+                            "between_bytes_timeout": 10000,
+                            "connect_timeout": 1000,
+                            "error_threshold": 0,
+                            "first_byte_timeout": 15000,
+                            "healthcheck": "foo_check",
+                            "max_conn": 200,
+                            "max_tls_version": "",
+                            "min_tls_version": "1.2",
+                            "name": "foo backend",
+                            "override_host": "",
+                            "port": 443,
+                            "request_condition": "",
+                            "shield": "",
+                            "ssl_ca_cert": "",
+                            "ssl_check_cert": true,
+                            "ssl_ciphers": "",
+                            "ssl_client_cert": "",
+                            "ssl_client_key": "",
+                            "ssl_hostname": "",
+                            "ssl_sni_hostname": "",
+                            "use_ssl": true,
+                            "weight": 100
+                            }
+                        ],
+                        "dictionary": [
+                            {
+                                "dictionary_id": "this is an id",
+                                "force_destroy": false,
+                                "name": "foo_dictionary",
+                                "write_only": false
+                            }
+                        ],
+                        "vcl": [
+                            {
+                                "content": "sub vcl_recv { \n #FASTLY RECV \n if (req.http.foo ~ foo_acl && table.contains(foo_dictionary, \"foo\")){ \n set req.backend = F_foo_backend;\n}\n}",
+                                "main": true,
+                                "name": "main.vcl"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Invalid characters are automatically translated into `_` by fastly on the generated VCL. Match that behaviour in Falco.

Signed-off-by: Sotiris Nanopoulos <sotiris.nanopoulos@reddit.com>