### PR TITLE
Add more implicit conversion fuzy types

### DIFF
--- a/__generator__/builtin.yml
+++ b/__generator__/builtin.yml
@@ -651,8 +651,8 @@ std.collect:
   reference: "https://developer.fastly.com/reference/vcl/functions/miscellaneous/std-collect/"
   on: [RECV, HASH, HIT, MISS, PASS, FETCH, ERROR, DELIVER, LOG]
   arguments:
-    - [STRING]
-    - [STRING, STRING]
+    - [ID]
+    - [ID, STRING]
 
 std.count:
   reference: "https://developer.fastly.com/reference/vcl/functions/miscellaneous/std-count/"

--- a/context/builtin.go
+++ b/context/builtin.go
@@ -1380,8 +1380,8 @@ func builtinFunctions() Functions {
 					Items: map[string]*FunctionSpec{},
 					Value: &BuiltinFunction{
 						Arguments: [][]types.Type{
-							[]types.Type{types.StringType},
-							[]types.Type{types.StringType, types.StringType},
+							[]types.Type{types.IDType},
+							[]types.Type{types.IDType, types.StringType},
 						},
 						Scopes:    RECV | HASH | HIT | MISS | PASS | FETCH | ERROR | DELIVER | LOG,
 						Reference: "https://developer.fastly.com/reference/vcl/functions/miscellaneous/std-collect/",

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -1391,14 +1391,22 @@ sub foo {
 	})
 
 	t.Run("fuzzy type check for STRING type argument", func(t *testing.T) {
-		input := `
-sub foo {
-	declare local var.S STRING;
 
-	set var.S = substr(req.backend, 1);
-}
-`
-		assertNoError(t, input)
+		tests := []string{
+			"req.backend",
+			"fastly_info.is_h2",
+			"client.socket.ploss",
+		}
+		for _, c := range tests {
+			input := fmt.Sprintf(`
+			sub foo {
+				declare local var.S STRING;
+				set var.S = substr(%s, 1);
+			}
+			`, c)
+			assertNoError(t, input)
+		}
+
 	})
 }
 


### PR DESCRIPTION
According to fastly https://developer.fastly.com/reference/vcl/types/ all primitive types can be casted to string.

> These types all have implicit conversions to strings,
such that their values may be used in contexts where a STRING value is necessary.

We don't allow that in Falco so changed it here to match what Fastly accepts.

Signed-off-by: Sotiris Nanopoulos <sotiris.nanopoulos@reddit.com>