### PR TITLE
lint protected HTTP headers

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -194,22 +194,24 @@ func (c *Context) UserDefinedFunctionScope(name string, mode int, returnType typ
 // ```
 // declare local var.S STRING;
 // set var.S = "foo bar baz";
-// if (req.http.Host) {
-// 	if (var.S) {
-// 		if (var.S !~ "(foo)\s(bar)\s(baz)") { // make matched values first (1)
-// 			set req.http.First = "1";
-// 		}
-// 		set var.S = "hoge huga";
-// 		if (var.S ~ "(hoge)\s(huga)") { // override matched values (2)
-// 			set req.http.First = re.group.1;
-// 		}
-// 	}
-// 	set req.http.Third = re.group.2; // difficult to know which (1) or (2) matched result is used
-// }
 //
-// if (req.http.Host) {
-// 	set req.http.Fourth = re.group.3; // difficult to know which (1) or (2) matched result is used or empty
-// }
+//	if (req.http.Host) {
+//		if (var.S) {
+//			if (var.S !~ "(foo)\s(bar)\s(baz)") { // make matched values first (1)
+//				set req.http.First = "1";
+//			}
+//			set var.S = "hoge huga";
+//			if (var.S ~ "(hoge)\s(huga)") { // override matched values (2)
+//				set req.http.First = re.group.1;
+//			}
+//		}
+//		set req.http.Third = re.group.2; // difficult to know which (1) or (2) matched result is used
+//	}
+//
+//	if (req.http.Host) {
+//		set req.http.Fourth = re.group.3; // difficult to know which (1) or (2) matched result is used or empty
+//	}
+//
 // ```
 //
 // Therefore we will raise warning if matched value is overridden in subroutine.

--- a/linter/errors.go
+++ b/linter/errors.go
@@ -339,3 +339,11 @@ func DuplicatedUseForGotoDestination(m *ast.Meta, name string) *LintError {
 		Message:  fmt.Sprintf("goto destination %s has been already in use", name),
 	}
 }
+
+func ProtectedHTTPHeader(m *ast.Meta, name string) *LintError {
+	return &LintError{
+		Severity: ERROR,
+		Token:    m.Token,
+		Message:  fmt.Sprintf("%s HTTP header could not be modified in VCL", name),
+	}
+}

--- a/linter/helper.go
+++ b/linter/helper.go
@@ -466,3 +466,28 @@ func isTypeLiteral(node ast.Node) bool {
 		return false
 	}
 }
+
+// Some HTTP Headers is protected in Fastly.
+// @see https://developer.fastly.com/reference/http/http-headers/
+// Consider the character case, we always treat header names as lower-case.
+var protectedHeaderNames = map[string]struct{}{
+	"req.http.proxy-authenticate":  struct{}{},
+	"req.http.proxy-authorization": struct{}{},
+	"req.http.content-length":      struct{}{},
+	"req.http.content-range":       struct{}{},
+	"req.http.te":                  struct{}{},
+	"req.http.trailer":             struct{}{},
+	"req.http.expect":              struct{}{},
+	"req.http.transfer-encoding":   struct{}{},
+	"req.http.upgrade":             struct{}{},
+	"req.http.fastly-ff":           struct{}{},
+}
+
+// Check header name exists in protected header names
+func isProtectedHTTPHeaderName(name string) bool {
+	lower := strings.ToLower(name)
+	if _, ok := protectedHeaderNames[lower]; ok {
+		return true
+	}
+	return false
+}

--- a/linter/helper.go
+++ b/linter/helper.go
@@ -471,16 +471,16 @@ func isTypeLiteral(node ast.Node) bool {
 // @see https://developer.fastly.com/reference/http/http-headers/
 // Consider the character case, we always treat header names as lower-case.
 var protectedHeaderNames = map[string]struct{}{
-	"req.http.proxy-authenticate":  struct{}{},
-	"req.http.proxy-authorization": struct{}{},
-	"req.http.content-length":      struct{}{},
-	"req.http.content-range":       struct{}{},
-	"req.http.te":                  struct{}{},
-	"req.http.trailer":             struct{}{},
-	"req.http.expect":              struct{}{},
-	"req.http.transfer-encoding":   struct{}{},
-	"req.http.upgrade":             struct{}{},
-	"req.http.fastly-ff":           struct{}{},
+	"req.http.proxy-authenticate":  {},
+	"req.http.proxy-authorization": {},
+	"req.http.content-length":      {},
+	"req.http.content-range":       {},
+	"req.http.te":                  {},
+	"req.http.trailer":             {},
+	"req.http.expect":              {},
+	"req.http.transfer-encoding":   {},
+	"req.http.upgrade":             {},
+	"req.http.fastly-ff":           {},
 }
 
 // Check header name exists in protected header names

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -837,6 +837,11 @@ func (l *Linter) lintSetStatement(stmt *ast.SetStatement, ctx *context.Context) 
 		l.Error(InvalidName(stmt.Ident.GetMeta(), stmt.Ident.Value, "set").Match(SET_STATEMENT_SYNTAX))
 	}
 
+	// Check protected header will be modified
+	if isProtectedHTTPHeaderName(stmt.Ident.Value) {
+		l.Error(ProtectedHTTPHeader(stmt.Ident.GetMeta(), stmt.Ident.Value))
+	}
+
 	left, err := ctx.Set(stmt.Ident.Value)
 	if err != nil {
 		err := &LintError{
@@ -885,6 +890,11 @@ func (l *Linter) lintUnsetStatement(stmt *ast.UnsetStatement, ctx *context.Conte
 		l.Error(InvalidName(stmt.Ident.GetMeta(), stmt.Ident.Value, "unset").Match(UNSET_STATEMENT_SYNTAX))
 	}
 
+	// Check protected header will be modified
+	if isProtectedHTTPHeaderName(stmt.Ident.Value) {
+		l.Error(ProtectedHTTPHeader(stmt.Ident.GetMeta(), stmt.Ident.Value))
+	}
+
 	if err := ctx.Unset(stmt.Ident.Value); err != nil {
 		l.Error(&LintError{
 			Severity: ERROR,
@@ -899,6 +909,11 @@ func (l *Linter) lintUnsetStatement(stmt *ast.UnsetStatement, ctx *context.Conte
 func (l *Linter) lintRemoveStatement(stmt *ast.RemoveStatement, ctx *context.Context) types.Type {
 	if !isValidVariableName(stmt.Ident.Value) {
 		l.Error(InvalidName(stmt.Ident.GetMeta(), stmt.Ident.Value, "remove").Match(REMOVE_STATEMENT_SYNTAX))
+	}
+
+	// Check protected header will be modified
+	if isProtectedHTTPHeaderName(stmt.Ident.Value) {
+		l.Error(ProtectedHTTPHeader(stmt.Ident.GetMeta(), stmt.Ident.Value))
 	}
 
 	if err := ctx.Unset(stmt.Ident.Value); err != nil {
@@ -996,6 +1011,11 @@ func (l *Linter) lintEsiStatement(stmt *ast.EsiStatement, ctx *context.Context) 
 func (l *Linter) lintAddStatement(stmt *ast.AddStatement, ctx *context.Context) types.Type {
 	if !isValidVariableName(stmt.Ident.Value) {
 		l.Error(InvalidName(stmt.Ident.GetMeta(), stmt.Ident.Value, "add").Match(ADD_STATEMENT_SYNTAX))
+	}
+
+	// Check protected header will be modified
+	if isProtectedHTTPHeaderName(stmt.Ident.Value) {
+		l.Error(ProtectedHTTPHeader(stmt.Ident.GetMeta(), stmt.Ident.Value))
 	}
 
 	// Add statement could use only for HTTP headers.


### PR DESCRIPTION
Fastly protects some HTTP headers modification in VCL so the user could not modify them.
This PR validates the user will modify on `set`, `add`, `unset`, and `remove` statements and raise an error for that operation.

ref: https://developer.fastly.com/reference/http/http-headers/