### PR TITLE
Fix error with `ast.GOTO` and Encoder

### DIFF
--- a/plugin/io.go
+++ b/plugin/io.go
@@ -58,6 +58,8 @@ func init() {
 	gob.Register(&ast.TableProperty{})
 	gob.Register(&ast.UnsetStatement{})
 	gob.Register(&ast.GroupedExpression{})
+	gob.Register(&ast.GotoStatement{})
+	gob.Register(&ast.GotoDestinationStatement{})
 	gob.Register(&ast.VCL{})
 }
 


### PR DESCRIPTION
Because `ast.GOTO` is not registered in the enccoder the following error appears after the liniting

`Failed to encode VCL: gob: type not registered for interface: ast.GotoStatement`

Signed-off-by: Sotiris Nanopoulos <sotiris.nanopoulos@reddit.com>