### PR TITLE
display actual line and position even identity is not found in context

### DIFF
--- a/linter/linter.go
+++ b/linter/linter.go
@@ -1274,7 +1274,13 @@ func (l *Linter) lintIdent(exp *ast.Ident, ctx *context.Context) types.Type {
 		} else if _, ok := ctx.Identifiers[exp.Value]; ok {
 			return types.IDType
 		}
-		l.Error(err)
+
+		// Convert to lint error
+		l.Error(&LintError{
+			Severity: ERROR,
+			Token: exp.GetMeta().Token,
+			Message: err.Error(),
+		})
 	}
 	return v
 }


### PR DESCRIPTION
I found a tiny bug that a variable is not found in context, falco displays a raw error without its line and position.

Example:

```vcl
🔥 [ERROR] undefined variable "req.http.Cookie:__some.cookie.name"
at line 0, position 0
 1| xxxxxxxxx
```

This PR fixes the above problem by converting the raw Error into `LintError`.

Note:
Cu