### PR TITLE
treat obective access in req.http contains semicolon character

### DIFF
--- a/context/context_test.go
+++ b/context/context_test.go
@@ -190,3 +190,21 @@ func TestDynamicVariableExist(t *testing.T) {
 		}
 	})
 }
+
+func TestSplitName(t *testing.T) {
+	t.Run(`concat after ":" token`, func(t *testing.T) {
+		first, remain := splitName("req.http.Cookie:foo-bar.baz")
+		if first != "req" {
+			t.Errorf("expect req, got %s", first)
+		}
+		if len(remain) != 2 {
+			t.Errorf("remaining token length should be 2, got %d", len(remain))
+		}
+		if remain[0] != "http" {
+			t.Errorf("expect http, got %s", remain[0])
+		}
+		if remain[1] != "Cookie:foo-bar.baz" {
+			t.Errorf("expect Cookie:foo-bar.baz, got %s", remain[1])
+		}
+	})
+}


### PR DESCRIPTION
Related: https://github.com/ysugimoto/falco/pull/112

I found a problem that `req.http.Cookie` allows to contain "." character and then falco raises an "undefined variable" error like:

```vcl
declare local var.cookie STRING;
set var.cookie = req.http.Cookie:dot-included.name
```

Then falco recognizes its syntax as object/variable access and raises an error of "Undefined Variable".
It causes by `splitName` function so I fixed it when ":" character is found in splitted identity names, concatenate remainings.