### PR TITLE
fix panic error for getting remote snippet

### DIFF
--- a/cmd/falco/snippet.go
+++ b/cmd/falco/snippet.go
@@ -174,7 +174,7 @@ func (s *Snippet) fetchBackend() ([]snippetItem, error) {
 		})
 	}
 
-	// Generate director snippet at least one backend is declared
+	// Generate director snippet only when at least one backend is declared
 	if len(backends) > 0 {
 		directors, err := s.renderBackendShields(backends)
 		if err != nil {

--- a/cmd/falco/snippet.go
+++ b/cmd/falco/snippet.go
@@ -174,11 +174,14 @@ func (s *Snippet) fetchBackend() ([]snippetItem, error) {
 		})
 	}
 
-	directors, err := s.renderBackendShields(backends)
-	if err != nil {
-		return nil, err
+	// Generate director snippet at least one backend is declared
+	if len(backends) > 0 {
+		directors, err := s.renderBackendShields(backends)
+		if err != nil {
+			return nil, err
+		}
+		snippets = append(snippets, directors...)
 	}
-	snippets = append(snippets, directors...)
 
 	return snippets, nil
 }


### PR DESCRIPTION
This PR avoids unexpected out-of-range panic when `remote` option is provided.

On generating a remote snippet, sometimes nothing backend is defined in Faslty console, then generating a director snippet causes panic by accessing `backends[0]` for empty backends.

The error message is:
```
Remote option supplied. Fetch snippets from Fastly.
Fetching Edge Dictionaries...Done
Fatching Access Control Lists...Done
Fatching Backends...panic: runtime error: index out of range [0] with length 0
```

It causes on https://github.com/ysugimoto/falco/blob/main/cmd/falco/snippet.go#L214