### PR TITLE
correct parser for reserved word

### DIFF
--- a/linter/linter.go
+++ b/linter/linter.go
@@ -1187,28 +1187,28 @@ func (l *Linter) lintReturnStatement(stmt *ast.ReturnStatement, ctx *context.Con
 	switch ctx.Mode() {
 	case context.RECV:
 		// https://developer.fastly.com/reference/vcl/subroutines/recv/
-		expects = append(expects, "lookup", "pass")
+		expects = append(expects, "lookup", "pass", "error", "restart")
 	case context.HASH:
 		// https://developer.fastly.com/reference/vcl/subroutines/hash/
 		expects = append(expects, "hash")
 	case context.HIT:
 		// https://developer.fastly.com/reference/vcl/subroutines/hit/
-		expects = append(expects, "deliver", "pass")
+		expects = append(expects, "deliver", "pass", "error", "restart")
 	case context.MISS:
 		// https://developer.fastly.com/reference/vcl/subroutines/miss/
-		expects = append(expects, "fetch", "deliver_stale", "pass")
+		expects = append(expects, "fetch", "deliver_stale", "pass", "error")
 	case context.PASS:
 		// https://developer.fastly.com/reference/vcl/subroutines/pass/
 		expects = append(expects, "pass")
 	case context.FETCH:
 		// https://developer.fastly.com/reference/vcl/subroutines/fetch/
-		expects = append(expects, "deliver", "deliver_stale", "pass")
+		expects = append(expects, "deliver", "deliver_stale", "pass", "error", "restart")
 	case context.ERROR:
 		// https://developer.fastly.com/reference/vcl/subroutines/error/
-		expects = append(expects, "deliver", "deliver_stale")
+		expects = append(expects, "deliver", "deliver_stale", "restart")
 	case context.DELIVER:
 		// https://developer.fastly.com/reference/vcl/subroutines/deliver/
-		expects = append(expects, "deliver")
+		expects = append(expects, "deliver", "restart")
 	case context.LOG:
 		// https://developer.fastly.com/reference/vcl/subroutines/log/
 		expects = append(expects, "deliver")

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -1428,6 +1428,15 @@ sub vcl_recv {
 		assertNoError(t, input)
 	})
 
+	t.Run("pass: with reserved word", func(t *testing.T) {
+		input := `
+sub vcl_recv {
+	#Fastly recv
+	return (restart);
+}`
+		assertNoError(t, input)
+	})
+
 	t.Run("sub: return correct type", func(t *testing.T) {
 		input := `
 sub custom_sub INTEGER {

--- a/parser/expression_parser.go
+++ b/parser/expression_parser.go
@@ -20,6 +20,8 @@ func (p *Parser) registerExpressionParsers() {
 		token.FALSE:      func() (ast.Expression, error) { return p.parseBoolean(), nil },
 		token.LEFT_PAREN: func() (ast.Expression, error) { return p.parseGroupedExpression() },
 		token.IF:         func() (ast.Expression, error) { return p.parseIfExpression() },
+		token.ERROR:      func() (ast.Expression, error) { return p.parseIdent(), nil },
+		token.RESTART:    func() (ast.Expression, error) { return p.parseIdent(), nil },
 	}
 	p.infixParsers = map[token.TokenType]infixParser{
 		token.IF:                 p.parseInfixStringConcatExpression,


### PR DESCRIPTION
Fixes #114

VCL allows using `restart` word in `return` expression as state.

```vcl
sub vcl_recv {
  ...
  return (restart);
}
```

However, falco recognizes `restart` word as a reserved word (only can present on `restart` statement) so this PR fixes this problem by parsing it as `IDENT`.
And `error` word should be valid so I added them to expect states. see https://developer.fastly.com/learning/vcl/using/#the-vcl-request-lifecycle