### PR TITLE
fix fourth argument type of accept.language_filter_basic

### DIFF
--- a/__generator__/builtin.yml
+++ b/__generator__/builtin.yml
@@ -16,7 +16,7 @@ accept.language_filter_basic:
   reference: "https://developer.fastly.com/reference/vcl/functions/content-negotiation/accept-language-filter-basic/"
   on: [RECV, HASH, HIT, MISS, PASS, FETCH, ERROR, DELIVER, LOG]
   arguments:
-    - [STRING, STRING, STRING, STRING]
+    - [STRING, STRING, STRING, INTEGER]
   return: STRING
 
 accept.language_lookup:

--- a/context/builtin.go
+++ b/context/builtin.go
@@ -53,7 +53,7 @@ func builtinFunctions() Functions {
 					Value: &BuiltinFunction{
 						Return: types.StringType,
 						Arguments: [][]types.Type{
-							[]types.Type{types.StringType, types.StringType, types.StringType, types.StringType},
+							[]types.Type{types.StringType, types.StringType, types.StringType, types.IntegerType},
 						},
 						Scopes:    RECV | HASH | HIT | MISS | PASS | FETCH | ERROR | DELIVER | LOG,
 						Reference: "https://developer.fastly.com/reference/vcl/functions/content-negotiation/accept-language-filter-basic/",


### PR DESCRIPTION
Fix `accept.language_filter_basic` function argument type.
The 4th argument type must be `INTEGER` but defined as `STRING` so I've changed it.

see doc: https://developer.fastly.com/reference/vcl/functions/content-negotiation/accept-language-filter-basic/