### PR TITLE
embed init type vcl snippets

### DIFF
--- a/context/snippet.go
+++ b/context/snippet.go
@@ -23,7 +23,7 @@ func (f *FastlySnippet) EmbedSnippets() []FastlySnippetItem {
 	// Embed Backends
 	snippets = append(snippets, f.Backends...)
 
-	// And also we need to embed VCL snippets which is registerd as "init" type
+	// And also we need to embed VCL snippets which is registered as "init" type
 	if scoped, ok := f.ScopedSnippets["init"]; ok {
 		snippets = append(snippets, scoped...)
 	}

--- a/context/snippet.go
+++ b/context/snippet.go
@@ -14,8 +14,19 @@ type FastlySnippet struct {
 }
 
 func (f *FastlySnippet) EmbedSnippets() []FastlySnippetItem {
-	return append(
-		f.Dictionaries,
-		append(f.Acls, f.Backends...)...,
-	)
+	var snippets []FastlySnippetItem
+
+	// Embed Dictionaries
+	snippets = append(snippets, f.Dictionaries...)
+	// Embed Acls
+	snippets = append(snippets, f.Acls...)
+	// Embed Backends
+	snippets = append(snippets, f.Backends...)
+
+	// And also we need to embed VCL snippets which is registerd as "init" type
+	if scoped, ok := f.ScopedSnippets["init"]; ok {
+		snippets = append(snippets, scoped...)
+	}
+
+	return snippets
 }


### PR DESCRIPTION
Since I implemented VCL snippets support on https://github.com/ysugimoto/falco/pull/120 but I forget to support `init` type snippets support. This PR fixes it.