### PR TITLE
add fastly_info.h2.fingerprint

### DIFF
--- a/__generator__/predefined.yml
+++ b/__generator__/predefined.yml
@@ -10,6 +10,11 @@ fastly_info.is_cluster_shield:
   on: [MISS, FETCH]
   get: BOOL
 
+fastly_info.h2.fingerprint:
+  reference: "https://www.integralist.co.uk/posts/fastly-varnish/"
+  on: [RECV, HASH, HIT, MISS, PASS, FETCH, ERROR, DELIVER, LOG]
+  get: STRING
+
 req.backend.is_cluster:
   reference: "https://www.integralist.co.uk/posts/fastly-varnish/"
   on: [DELIVER]

--- a/context/predefined.go
+++ b/context/predefined.go
@@ -1784,6 +1784,16 @@ func predefinedVariables() Variables {
 				},
 				"h2": &Object{
 					Items: map[string]*Object{
+						"fingerprint": &Object{
+							Items: map[string]*Object{},
+							Value: &Accessor{
+								Get:       types.StringType,
+								Set:       types.NeverType,
+								Unset:     false,
+								Scopes:    RECV | HASH | HIT | MISS | PASS | FETCH | ERROR | DELIVER | LOG,
+								Reference: "https://www.integralist.co.uk/posts/fastly-varnish/",
+							},
+						},
 						"is_push": &Object{
 							Items: map[string]*Object{},
 							Value: &Accessor{

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -2535,3 +2535,13 @@ sub vcl_recv {
 `
 	assertError(t, input, context.WithFastlySnippets(snippets))
 }
+
+func TestFastlyInfoH2FingerPrintCouldLint(t *testing.T) {
+	input := `
+sub vcl_recv {
+   #FASTLY RECV
+   set req.http.H2-Fingerprint = fastly_info.h2.fingerprint;
+}
+		`
+	assertNoError(t, input)
+}


### PR DESCRIPTION
This PR is just a workaround, we specify an undocumented fastly predefined variable.

`fastly_info.h2.fingerprint` variable seems to come from Faslty Next-Gen WAF but we could not find any documentation in Faslty site.

However, we should manage their VCL and lint them successfully so we add it as undocumented variables.

