### PR TITLE
chore: move to `GITHUB_OUTPUT`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         id: version
         run: |
           VERSION=$(echo ${{ github.ref }} | sed -e "s#refs/tags/##g")
-          echo ::set-output name=version::$VERSION
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Build platform binaries
         run: VERSION=${{ steps.version.outputs.version }} make all
       - name: Create Release


### PR DESCRIPTION
Hi @ysugimoto 
Thank you for developing awesome tool!

I fixed warning annotation on Github Actions.
![image](https://user-images.githubusercontent.com/29038315/234633588-4edabb96-cf21-4985-be59-55499e73fbbd.png)

This PR resolved `set-output` warning.
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Other warnings are will resolve when updated third-party actions.