### PR TITLE
support private edge dictionary

### DIFF
--- a/remote/client.go
+++ b/remote/client.go
@@ -76,6 +76,15 @@ func (c *FastlyClient) ListEdgeDictionaries(ctx context.Context, version int64) 
 	var once sync.Once
 	errch := make(chan error)
 	for _, d := range dicts {
+		// If WriteOnly field is true, the dictionary is private.
+		// The private dictionary could not access its items so we should prevent to fetch items.
+		// Then dictionary items are empty but it's OK for linting
+		if d.WriteOnly {
+			// Explicit empty items
+			d.Items = []*EdgeDictionaryItem{}
+			continue
+		}
+
 		wg.Add(1)
 		go func(d *EdgeDictionary) {
 			defer wg.Done()

--- a/remote/entity.go
+++ b/remote/entity.go
@@ -5,9 +5,10 @@ type Version struct {
 }
 
 type EdgeDictionary struct {
-	Id    string `json:"id"`
-	Name  string `json:"name"`
-	Items []*EdgeDictionaryItem
+	Id        string `json:"id"`
+	Name      string `json:"name"`
+	WriteOnly bool   `json:"write_only"`
+	Items     []*EdgeDictionaryItem
 }
 
 type EdgeDictionaryItem struct {


### PR DESCRIPTION
Fixes #141

This PR supports a private edge dictionary that is described at https://docs.fastly.com/en/guides/working-with-dictionaries-using-the-web-interface#private-dictionaries .

For the private edge dictionary, dictionary list API responds with `write_only: true` and if the dictionary is private, fetching dictionary item API responds 400 with `{"msg":"Bad request","detail":"Not allowed to read contents of write_only dictionary"}`.

Fortunately, falco does not need to access the dictionary item on linting, so if `write_only` is true, we prevent the additional call of item fetching, just only adding as empty dictionary.