### PR TITLE
add release binary as archived files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,9 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
+            dist/falco-linux-amd64
+            dist/falco-darwin-amd64
+            dist/falco-darwin-arm64
             dist/falco-linux-amd64.tar.gz
             dist/falco-darwin-amd64.tar.gz
             dist/falco-darwin-arm64.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,8 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            dist/falco-linux-amd64
-            dist/falco-darwin-amd64
-            dist/falco-darwin-arm64
+            dist/falco-linux-amd64.tar.gz
+            dist/falco-darwin-amd64.tar.gz
+            dist/falco-darwin-arm64.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -12,16 +12,19 @@ linux:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build \
 			 -ldflags "-X main.version=$(BUILD_VERSION)" \
 			 -o dist/falco-linux-amd64 ./cmd/falco
+	cd ./dist/ && mv ./falco-linux-amd64 ./falco && tar cfz falco-linux-amd64.tar.gz ./falco
 
 darwin_amd64:
 	GOOS=darwin GOARCH=amd64 go build \
 			 -ldflags "-X main.version=$(BUILD_VERSION)" \
 			 -o dist/falco-darwin-amd64 ./cmd/falco
+	cd ./dist/ && mv ./falco-darwin-amd64 ./falco && tar cfz falco-darwin-amd64.tar.gz ./falco
 
 darwin_arm64:
 	GOOS=darwin GOARCH=arm64 go build \
 			 -ldflags "-X main.version=$(BUILD_VERSION)" \
 			 -o dist/falco-darwin-arm64 ./cmd/falco
+	cd ./dist/ && mv ./falco-darwin-arm64 ./falco && tar cfz falco-darwin-arm64.tar.gz ./falco
 
 all: linux darwin_amd64 darwin_arm64
 

--- a/Makefile
+++ b/Makefile
@@ -12,19 +12,19 @@ linux:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build \
 			 -ldflags "-X main.version=$(BUILD_VERSION)" \
 			 -o dist/falco-linux-amd64 ./cmd/falco
-	cd ./dist/ && mv ./falco-linux-amd64 ./falco && tar cfz falco-linux-amd64.tar.gz ./falco
+	cd ./dist/ && cp ./falco-linux-amd64 ./falco && tar cfz falco-linux-amd64.tar.gz ./falco
 
 darwin_amd64:
 	GOOS=darwin GOARCH=amd64 go build \
 			 -ldflags "-X main.version=$(BUILD_VERSION)" \
 			 -o dist/falco-darwin-amd64 ./cmd/falco
-	cd ./dist/ && mv ./falco-darwin-amd64 ./falco && tar cfz falco-darwin-amd64.tar.gz ./falco
+	cd ./dist/ && cp ./falco-darwin-amd64 ./falco && tar cfz falco-darwin-amd64.tar.gz ./falco
 
 darwin_arm64:
 	GOOS=darwin GOARCH=arm64 go build \
 			 -ldflags "-X main.version=$(BUILD_VERSION)" \
 			 -o dist/falco-darwin-arm64 ./cmd/falco
-	cd ./dist/ && mv ./falco-darwin-arm64 ./falco && tar cfz falco-darwin-arm64.tar.gz ./falco
+	cd ./dist/ && cp ./falco-darwin-arm64 ./falco && tar cfz falco-darwin-arm64.tar.gz ./falco
 
 all: linux darwin_amd64 darwin_arm64
 


### PR DESCRIPTION
This PR adds tar archived files to the release artifacts.

Downloading raw binary is also fine, but we follow the other CLI command-line tools releasing way.
This has a guarantee that can support Homebrew 🍺 