### PR TITLE
chore: add README about homebrew installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,14 @@ To solve them, we made a Fastly dedicated VCL parser and linter tool to notice s
 
 ## Installation
 
-Download binary from [releases page](https://github.com/ysugimoto/falco/releases) according to your platform and place it under the `$PATH`.
+Download binary from [releases page](https://github.com/ysugimoto/falco/releases) according to your platform and place it under the `$PATH`, or you can install via Homebrew:
 
-Or compile it yourself with `go install github.com/ysugimoto/falco/cmd/falco@latest`.
+```shell
+brew tap ysugimoto/falco
+brew install falco
+```
+
+You can compile project yourself with `go install github.com/ysugimoto/falco/cmd/falco@latest`.
 
 ## Usage
 


### PR DESCRIPTION
Now we support installation from Homebrew. The repository is [here](https://github.com/ysugimoto/homebrew-falco).
I added installation instructions about Homebrew on README.