### PR TITLE
Fixup: Accept `.backend` in chash director

### DIFF
--- a/linter/helper.go
+++ b/linter/helper.go
@@ -95,6 +95,7 @@ var DirectorPropertyTypes = map[string]DirectorProps{
 			"quorum":          types.StringType,
 			"weight":          types.IntegerType,
 			"id":              types.StringType,
+			"backend":         types.BackendType,
 		},
 		Requires: []string{"id"},
 	},

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -225,6 +225,10 @@ backend foo {
 director bar client {
 	.quorum  = 50%;
 	{ .backend = foo; .weight = 1; }
+}
+
+director fiz chash {
+	{ .backend = foo; .id = "foo"; }
 }`
 		assertNoError(t, input)
 	})


### PR DESCRIPTION
Previously it wasn't accepted and this is not correct based on fastly [examples](https://developer.fastly.com/reference/vcl/declarations/director/#consistent-hashing)