### PR TITLE
add lint rule of allow-public-url-purge

### DIFF
--- a/linter/rules.go
+++ b/linter/rules.go
@@ -66,6 +66,7 @@ const (
 	UNUSED_DECLARATION                   = "unused/declaration"
 	UNUSED_VARIABLE                      = "unused/variable"
 	UNUSED_GOTO                          = "unused/goto"
+	ALLOW_PUBLIC_URL_PURGE               = "allow-public-url-purge"
 )
 
 var references = map[Rule]string{
@@ -100,4 +101,5 @@ var references = map[Rule]string{
 	ERROR_STATEMENT_CODE:             "https://developer.fastly.com/reference/vcl/statements/error/#best-practices-for-using-status-codes-for-errors",
 	SYNTHETIC_STATEMENT_SCOPE:        "https://developer.fastly.com/reference/vcl/statements/synthetic/",
 	SYNTHETIC_BASE64_STATEMENT_SCOPE: "https://developer.fastly.com/reference/vcl/statements/synthetic-base64/",
+	ALLOW_PUBLIC_URL_PURGE:           "https://docs.fastly.com/en/guides/authenticating-api-purge-requests",
 }


### PR DESCRIPTION
Add new linting rule of `allow-public-url-purge` .

This rule means the URL purge request should be authenticated via API, not be called publicly,
because it causes unexpected cache purging from anonymous users and the traffic will pass to the origin.

ref: https://docs.fastly.com/en/guides/authenticating-api-purge-requests

Of course, this is a matter of the service policy so this rule's severity should be `INFO`.