### PR TITLE
add disallow empty return linting rule

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -109,24 +109,28 @@ type Accessor struct {
 }
 
 type Context struct {
+	// private fields
 	curMode        int
 	prevMode       int
 	curName        string
-	Acls           map[string]*types.Acl
-	Backends       map[string]*types.Backend
-	Tables         map[string]*types.Table
-	Directors      map[string]*types.Director
-	Subroutines    map[string]*types.Subroutine
-	Penaltyboxes   map[string]*types.Penaltybox
-	Ratecounters   map[string]*types.Ratecounter
-	Gotos          map[string]*types.Goto
-	Identifiers    map[string]struct{}
 	functions      Functions
 	Variables      Variables
-	RegexVariables map[string]int
-	ReturnType     *types.Type
 	resolver       resolver.Resolver
 	fastlySnippets *FastlySnippet
+
+	// public fields
+	Acls              map[string]*types.Acl
+	Backends          map[string]*types.Backend
+	Tables            map[string]*types.Table
+	Directors         map[string]*types.Director
+	Subroutines       map[string]*types.Subroutine
+	Penaltyboxes      map[string]*types.Penaltybox
+	Ratecounters      map[string]*types.Ratecounter
+	Gotos             map[string]*types.Goto
+	Identifiers       map[string]struct{}
+	RegexVariables    map[string]int
+	ReturnType        *types.Type
+	CurrentSubroutine *ast.SubroutineDeclaration
 }
 
 func New(opts ...Option) *Context {
@@ -155,6 +159,14 @@ func New(opts ...Option) *Context {
 
 func (c *Context) Mode() int {
 	return c.curMode
+}
+
+// Returns true if statement/expression is inside state-mechine subroutine like "vcl_recv", fastly reserved one
+func (c *Context) IsStateMachineMethod() bool {
+	if c.CurrentSubroutine == nil {
+		return false
+	}
+	return IsFastlySubroutine(c.CurrentSubroutine.Name.Value)
 }
 
 func (c *Context) Resolver() resolver.Resolver {

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -2613,3 +2613,40 @@ sub vcl_recv {
 }`
 	assertNoError(t, input)
 }
+
+func TestEmptyReturnStatement(t *testing.T) {
+	t.Run("Error on state-machine-methods", func(t *testing.T) {
+		methodWithMacros := map[string]string{
+			"vcl_recv":    "#FASTLY RECV",
+			"vcl_hash":    "#FASTLY HASH",
+			"vcl_hit":     "#FASTLY HIT",
+			"vcl_miss":    "#FASTLY MISS",
+			"vcl_pass":    "#FASTLY PASS",
+			"vcl_fetch":   "#FASTLY FETCH",
+			"vcl_error":   "#FASTLY ERROR",
+			"vcl_deliver": "#FASTLY DELIVER",
+			"vcl_log":     "#FASTLY LOG",
+		}
+		for method, macro := range methodWithMacros {
+			input := fmt.Sprintf(
+				`
+sub %s {
+	%s
+	return;
+}`, method, macro)
+			assertError(t, input)
+		}
+	})
+
+	t.Run("Pass on other subroutine", func(t *testing.T) {
+		input := `
+sub foo {
+	return;
+}
+sub vcl_recv {
+	#FASTLY RECV
+	call foo;
+}`
+		assertNoError(t, input)
+	})
+}

--- a/linter/rules.go
+++ b/linter/rules.go
@@ -66,6 +66,7 @@ const (
 	UNUSED_DECLARATION                   = "unused/declaration"
 	UNUSED_VARIABLE                      = "unused/variable"
 	UNUSED_GOTO                          = "unused/goto"
+	DISALLOW_EMPTY_RETURN                = "disallow-empty-return"
 )
 
 var references = map[Rule]string{
@@ -100,4 +101,5 @@ var references = map[Rule]string{
 	ERROR_STATEMENT_CODE:             "https://developer.fastly.com/reference/vcl/statements/error/#best-practices-for-using-status-codes-for-errors",
 	SYNTHETIC_STATEMENT_SCOPE:        "https://developer.fastly.com/reference/vcl/statements/synthetic/",
 	SYNTHETIC_BASE64_STATEMENT_SCOPE: "https://developer.fastly.com/reference/vcl/statements/synthetic-base64/",
+	DISALLOW_EMPTY_RETURN:            "https://developer.fastly.com/reference/vcl/subroutines#returning-a-state",
 }


### PR DESCRIPTION
Fix #152 

This PR adds a new linter rule that disallows empty return statement in the state-machine method.