### PR TITLE
Adds JSON support for generic, terraform and lint usage

### DIFF
--- a/cmd/falco/main.go
+++ b/cmd/falco/main.go
@@ -63,9 +63,9 @@ Flags:
     -h, --help         : Show this help
     -r, --remote       : Communicate with Fastly API
     -V, --version      : Display build version
-    -v                 : Output lint warnings
-    -vv                : Output all lint results
-    -json              : Output results as JSON
+    -v                 : Output lint warnings (verbose)
+    -vv                : Output all lint results (very verbose)
+    -json              : Output results as JSON (very verbose)
 
 Simple Linting example:
     falco -I . -vv /path/to/vcl/main.vcl

--- a/cmd/falco/runner.go
+++ b/cmd/falco/runner.go
@@ -201,7 +201,7 @@ func (r *Runner) Run(rslv resolver.Resolver) (*RunnerResult, error) {
 	// Note: this context is not Go context, our parsing context :)
 	ctx := context.New(options...)
 	vcl, err := r.run(ctx, main, RunModeLint)
-	if err != nil {
+	if err != nil && !r.jsonMode {
 		return nil, err
 	}
 
@@ -289,7 +289,9 @@ func (r *Runner) printParseError(lx *lexer.Lexer, err *parser.ParseError) {
 	var file string
 	if err.Token.File != "" {
 		file = "in " + err.Token.File + " "
-		r.parseErrors[err.Token.File] = err
+		if r.jsonMode {
+			r.parseErrors[err.Token.File] = err
+		}
 	}
 
 	// Nothing to print to stdout if JSON mode is enabled, exit early.
@@ -340,7 +342,7 @@ func (r *Runner) printLinterError(lx *lexer.Lexer, err *linter.LintError) {
 	}
 
 	// Store all but ignored linter errors
-	if severity != linter.IGNORE {
+	if r.jsonMode && severity != linter.IGNORE {
 		r.lintErrors[err.Token.File] = append(r.lintErrors[err.Token.File], err)
 	}
 


### PR DESCRIPTION
Proposed implementation for https://github.com/ysugimoto/falco/issues/156

This PR proposes that the following commands will emit JSON-serialized output:

- `falco -json`
- `falco terraform -json`
- `falco stat -json`
- `falco terraform -json`

The other main change with this flag is that `ParseError`s aren't surfaced, but marshalled into the emitted JSON.

`-json` ignores `-v` and `-vv`: all linter errors, warnings and suggestions are returned.
