### PR TITLE
deps: upgrade golangci-lint and action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Lint programs
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.42
+        version: v1.54
         skip-pkg-cache: true
         skip-build-cache: true
         skip-go-installation: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,15 +10,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: 1.17.5
     - name: Run tests
       run: make test
     - name: Lint programs
-      uses: golangci/golangci-lint-action@v2
+      uses: golangci/golangci-lint-action@v3
       with:
         version: v1.54
         skip-pkg-cache: true

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -8,15 +8,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: 1.17.5
     - name: Run tests
       run: make test
     - name: Lint programs
-      uses: golangci/golangci-lint-action@v2
+      uses: golangci/golangci-lint-action@v3
       with:
         version: v1.54
         skip-pkg-cache: true

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Lint programs
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.42
+        version: v1.54
         skip-pkg-cache: true
         skip-build-cache: true
         skip-go-installation: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.17.5
       - name: Run tests
         run: make test
       - name: Lint programs
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.54
           skip-pkg-cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Lint programs
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.42
+          version: v1.54
           skip-pkg-cache: true
           skip-build-cache: true
           skip-go-installation: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,10 +17,7 @@ linters:
     - staticcheck
     - unused
     - gosimple
-    - structcheck
-    - varcheck
     - ineffassign
-    - deadcode
     - dogsled
       #- dupl disable, because parser and lexer may have similer logic
     - funlen

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.16
 
 require (
 	github.com/fatih/color v1.12.0
-	github.com/go-yaml/yaml v2.1.0+incompatible // indirect
 	github.com/google/go-cmp v0.5.9
 	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect
 	github.com/k0kubun/pp v2.4.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/fatih/color v1.12.0
+	github.com/go-yaml/yaml v2.1.0+incompatible // indirect
 	github.com/google/go-cmp v0.5.9
 	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect
 	github.com/k0kubun/pp v2.4.0+incompatible


### PR DESCRIPTION
```
$ golangci-lint run ./...
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused.
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused.
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused.
```