### PR TITLE
chore: add cache related headers

### DIFF
--- a/examples/default01.vcl
+++ b/examples/default01.vcl
@@ -37,7 +37,7 @@ sub vcl_recv {
   set req.backend = httpbin_org;
   set req.http.Foo = {" foo bar baz "};
   call custom_logger;
-  return (pass);
+  return (lookup);
 }
 
 sub vcl_deliver {


### PR DESCRIPTION
The interpreter follows Fastly's cache-related behaviors:

- Add cache-related headers of `X-Cache` `X-Cache-Hits` `X-Served-By`