### PR TITLE
do no use x/net/context

### DIFF
--- a/cmd/documentation-checker/main.go
+++ b/cmd/documentation-checker/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/kyokomi/emoji"
 	"github.com/mattn/go-colorable"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 var (


### PR DESCRIPTION
Tiny fix, the `vim-go` auto completes `context` as `x/net/context` but go already provides `context` package.