### PR TITLE
Fix object like header treating

### DIFF
--- a/interpreter/variable/header.go
+++ b/interpreter/variable/header.go
@@ -1,0 +1,179 @@
+package variable
+
+import (
+	"fmt"
+	"net/http"
+	"net/textproto"
+	"strings"
+
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+func getRequestHeaderValue(r *http.Request, name string) *value.String {
+	// Header name can contain ":" for object-like value
+	if !strings.Contains(name, ":") {
+		return &value.String{
+			Value: strings.Join(r.Header.Values(name), ", "),
+		}
+	}
+	spl := strings.SplitN(name, ":", 2)
+	// Request header can modify cookie, then we need to retrieve value from Cookie pointer
+	if strings.EqualFold(spl[0], "cookie") {
+		for _, c := range r.Cookies() {
+			if c.Name == spl[1] {
+				return &value.String{Value: c.Value}
+			}
+		}
+	}
+
+	for _, hv := range r.Header.Values(spl[0]) {
+		kvs := strings.SplitN(hv, "=", 2)
+		if kvs[0] == spl[1] {
+			return &value.String{Value: kvs[1]}
+		}
+	}
+	return &value.String{Value: ""}
+}
+
+func getResponseHeaderValue(r *http.Response, name string) *value.String {
+	// Header name can contain ":" for object-like value
+	if !strings.Contains(name, ":") {
+		return &value.String{
+			Value: strings.Join(r.Header.Values(name), ", "),
+		}
+	}
+
+	spl := strings.SplitN(name, ":", 2)
+	for _, hv := range r.Header.Values(spl[0]) {
+		kvs := strings.SplitN(hv, "=", 2)
+		if kvs[0] == spl[1] {
+			return &value.String{Value: kvs[1]}
+		}
+	}
+	return &value.String{Value: ""}
+}
+
+func setRequestHeaderValue(r *http.Request, name string, val value.Value) {
+	if !strings.Contains(name, ":") {
+		r.Header.Set(name, val.String())
+		return
+	}
+
+	// If name contains ":" like req.http.VARS:xxx, add with key-value format
+	// HTTP Request can modify cookie
+	spl := strings.SplitN(name, ":", 2)
+	if strings.EqualFold(spl[0], "cookie") {
+		hh := http.Header{}
+		hh.Add("Cookie", fmt.Sprintf("%s=%s", spl[1], val.String()))
+		rr := http.Request{Header: hh}
+		c, _ := rr.Cookie(spl[1]) // nolint:errcheck
+		r.AddCookie(c)
+		return
+	}
+	r.Header.Add(spl[0], fmt.Sprintf("%s=%s", spl[1], val.String()))
+}
+
+func setResponseHeaderValue(r *http.Response, name string, val value.Value) {
+	if !strings.Contains(name, ":") {
+		r.Header.Set(name, val.String())
+		return
+	}
+
+	// If name contains ":" like req.http.VARS:xxx, add with key-value format
+	spl := strings.SplitN(name, ":", 2)
+	r.Header.Add(spl[0], fmt.Sprintf("%s=%s", spl[1], val.String()))
+}
+
+func unsetRequestHeaderValue(r *http.Request, name string) {
+	if !strings.Contains(name, ":") {
+		r.Header.Del(name)
+		return
+	}
+
+	// Header name contains ":" character, then filter value by key
+	spl := strings.SplitN(name, ":", 2)
+	// Request header can modify cookie, then we need to unset value from Cookie pointer
+	if strings.EqualFold(spl[0], "cookie") {
+		removeCookieByName(r, spl[1])
+		return
+	}
+
+	var filtered []string
+	for _, hv := range r.Header.Values(spl[0]) {
+		kvs := strings.SplitN(hv, "=", 2)
+		if kvs[0] == spl[1] {
+			continue
+		}
+		filtered = append(filtered, hv)
+	}
+
+	if len(filtered) > 0 {
+		r.Header[spl[0]] = filtered
+	} else {
+		r.Header.Del(name)
+	}
+}
+
+// removeCookieByName removes a part of Cookie headers that name is matched.
+// Go does not have DeleteCookie() method, so we need to modify actual header value.
+// This logic refers to readCookies() in net/http package.
+func removeCookieByName(r *http.Request, cookieName string) {
+	lines := r.Header["Cookie"]
+	if len(lines) == 0 {
+		return
+	}
+
+	var filtered []string
+	for _, line := range lines {
+		line = textproto.TrimString(line)
+
+		var sub []string
+		var part string
+		for len(line) > 0 { // continue since we have rest
+			part, line, _ = strings.Cut(line, ";")
+			trimmedPart := textproto.TrimString(part)
+			if trimmedPart == "" {
+				continue
+			}
+			name, _, _ := strings.Cut(trimmedPart, "=")
+			name = textproto.TrimString(name)
+			if name == cookieName {
+				continue
+			}
+			sub = append(sub, part)
+		}
+
+		if len(sub) > 0 {
+			filtered = append(filtered, strings.Join(sub, ";"))
+		}
+	}
+	if len(filtered) > 0 {
+		r.Header["Cookie"] = filtered
+	} else {
+		r.Header.Del("Cookie")
+	}
+}
+
+func unsetResponseHeaderValue(r *http.Response, name string) {
+	if !strings.Contains(name, ":") {
+		r.Header.Del(name)
+		return
+	}
+
+	// Header name contains ":" character, then filter value by key
+	spl := strings.SplitN(name, ":", 2)
+	var filtered []string
+	for _, hv := range r.Header.Values(spl[0]) {
+		kvs := strings.SplitN(hv, "=", 2)
+		if kvs[0] == spl[1] {
+			continue
+		}
+		filtered = append(filtered, hv)
+	}
+
+	if len(filtered) > 0 {
+		r.Header[spl[0]] = filtered
+	} else {
+		r.Header.Del(name)
+	}
+}

--- a/interpreter/variable/header_test.go
+++ b/interpreter/variable/header_test.go
@@ -1,0 +1,168 @@
+package variable
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+func TestGetRequestHeaderValue(t *testing.T) {
+	tests := []struct {
+		name   string
+		expect string
+	}{
+		{name: "foo", expect: "bar"},
+		{name: "hoge", expect: ""},
+		{name: "Text:lorem", expect: "ipsum"},
+		{name: "Text:amet", expect: ""},
+		{name: "Cookie:foo", expect: "bar"},
+		{name: "Cookie:baz", expect: ""},
+	}
+	req := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+	req.Header.Set("Foo", "bar")
+	req.Header.Add("Text", "lorem=ipsum")
+	req.Header.Add("Text", "dolor=sit")
+	req.Header.Set("Cookie", "foo=bar")
+
+	for _, tt := range tests {
+		ret := getRequestHeaderValue(req, tt.name)
+		if ret.Value != tt.expect {
+			t.Errorf("Return value unmatch, expect=%s, got=%s", tt.expect, ret.Value)
+		}
+	}
+
+}
+func TestGetReponseHeaderValue(t *testing.T) {
+	tests := []struct {
+		name   string
+		expect string
+	}{
+		{name: "foo", expect: "bar"},
+		{name: "hoge", expect: ""},
+		{name: "Text:lorem", expect: "ipsum"},
+		{name: "Text:amet", expect: ""},
+	}
+	header := http.Header{}
+	header.Set("Foo", "bar")
+	header.Add("Text", "lorem=ipsum")
+	header.Add("Text", "dolor=sit")
+	header.Set("Cookie", "foo=bar")
+	resp := &http.Response{Header: header}
+
+	for _, tt := range tests {
+		ret := getResponseHeaderValue(resp, tt.name)
+		if ret.Value != tt.expect {
+			t.Errorf("Return value unmatch, expect=%s, got=%s", tt.expect, ret.Value)
+		}
+	}
+
+}
+func TestSetRequestHeaderValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "foo", value: "bar"},
+		{name: "Text:lorem", value: "ipsum"},
+		{name: "Cookie:foo", value: "bar"},
+	}
+
+	for _, tt := range tests {
+		req := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+		setRequestHeaderValue(req, tt.name, &value.String{Value: tt.value})
+		ret := getRequestHeaderValue(req, tt.name)
+		if ret.Value != tt.value {
+			t.Errorf("Return value unmatch, expect=%s, got=%s", tt.value, ret.Value)
+		}
+	}
+
+}
+func TestSetResponseHeaderValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "foo", value: "bar"},
+		{name: "Text:lorem", value: "ipsum"},
+	}
+
+	for _, tt := range tests {
+		resp := &http.Response{Header: http.Header{}}
+		setResponseHeaderValue(resp, tt.name, &value.String{Value: tt.value})
+		ret := getResponseHeaderValue(resp, tt.name)
+		if ret.Value != tt.value {
+			t.Errorf("Return value unmatch, expect=%s, got=%s", tt.value, ret.Value)
+		}
+	}
+
+}
+func TestUnsetRequestHeaderValue(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{name: "foo"},
+		{name: "hoge"},
+		{name: "Text:lorem"},
+		{name: "Text:amet"},
+		{name: "Cookie:foo"},
+		{name: "Cookie:baz"},
+	}
+	req := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+	req.Header.Set("Foo", "bar")
+	req.Header.Add("Text", "lorem=ipsum")
+	req.Header.Add("Text", "dolor=sit")
+	req.Header.Set("Cookie", "foo=bar")
+
+	for _, tt := range tests {
+		unsetRequestHeaderValue(req, tt.name)
+		ret := getRequestHeaderValue(req, tt.name)
+		if ret.Value != "" {
+			t.Errorf("Unset value still not empty, got=%s", ret.Value)
+		}
+	}
+}
+
+func TestUnsetResponseHeaderValue(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{name: "foo"},
+		{name: "hoge"},
+		{name: "Text:lorem"},
+		{name: "Text:amet"},
+	}
+	header := http.Header{}
+	header.Set("Foo", "bar")
+	header.Add("Text", "lorem=ipsum")
+	header.Add("Text", "dolor=sit")
+	resp := &http.Response{Header: header}
+
+	for _, tt := range tests {
+		unsetResponseHeaderValue(resp, tt.name)
+		ret := getResponseHeaderValue(resp, tt.name)
+		if ret.Value != "" {
+			t.Errorf("Unset value still not empty, got=%s", ret.Value)
+		}
+	}
+}
+
+func TestRemoveCookieByName(t *testing.T) {
+	tests := []struct {
+		name   string
+		expect int
+	}{
+		{name: "foo", expect: 1},
+		{name: "hoge", expect: 2},
+	}
+	for _, tt := range tests {
+		req := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+		req.Header.Add("Cookie", "foo=bar")
+		req.Header.Add("Cookie", "cat=meow")
+		removeCookieByName(req, tt.name)
+		if len(req.Cookies()) != tt.expect {
+			t.Errorf("Cookie will not deleted for %s", tt.name)
+		}
+	}
+}

--- a/interpreter/variable/hit.go
+++ b/interpreter/variable/hit.go
@@ -89,9 +89,7 @@ func (v *HitScopeVariables) Get(s context.Scope, name string) (value.Value, erro
 func (v *HitScopeVariables) getFromRegex(name string) value.Value {
 	// HTTP request header matching
 	if match := objectHttpHeaderRegex.FindStringSubmatch(name); match != nil {
-		return &value.String{
-			Value: v.ctx.Object.Header.Get(match[1]),
-		}
+		return getResponseHeaderValue(v.ctx.Object, match[1])
 	}
 	return v.base.getFromRegex(name)
 }
@@ -128,7 +126,7 @@ func (v *HitScopeVariables) Set(s context.Scope, name, operator string, val valu
 		if err := limitations.CheckProtectedHeader(match[1]); err != nil {
 			return errors.WithStack(err)
 		}
-		v.ctx.Object.Header.Set(match[1], val.String())
+		setResponseHeaderValue(v.ctx.Object, match[1], val)
 		return nil
 	}
 
@@ -160,6 +158,6 @@ func (v *HitScopeVariables) Unset(s context.Scope, name string) error {
 	if err := limitations.CheckProtectedHeader(match[1]); err != nil {
 		return errors.WithStack(err)
 	}
-	v.ctx.Object.Header.Del(match[1])
+	unsetResponseHeaderValue(v.ctx.Object, match[1])
 	return nil
 }

--- a/interpreter/variable/pass.go
+++ b/interpreter/variable/pass.go
@@ -96,25 +96,7 @@ func (v *PassScopeVariables) Get(s context.Scope, name string) (value.Value, err
 func (v *PassScopeVariables) getFromRegex(name string) value.Value {
 	// HTTP request header matching
 	if match := backendRequestHttpHeaderRegex.FindStringSubmatch(name); match != nil {
-		// If name is Cookie, header name can contain ":" with cookie name
-		if !strings.Contains(name, ":") {
-			return &value.String{
-				Value: v.ctx.BackendRequest.Header.Get(match[1]),
-			}
-		}
-		spl := strings.SplitN(name, ":", 2)
-		if !strings.EqualFold(spl[0], "cookie") {
-			return &value.String{
-				Value: v.ctx.BackendRequest.Header.Get(match[1]),
-			}
-		}
-
-		for _, c := range v.ctx.BackendRequest.Cookies() {
-			if c.Name == spl[1] {
-				return &value.String{Value: c.Value}
-			}
-		}
-		return &value.String{Value: ""}
+		return getRequestHeaderValue(v.ctx.BackendRequest, match[1])
 	}
 	return v.base.getFromRegex(name)
 }
@@ -204,6 +186,6 @@ func (v *PassScopeVariables) Unset(s context.Scope, name string) error {
 	if err := limitations.CheckProtectedHeader(match[1]); err != nil {
 		return errors.WithStack(err)
 	}
-	v.ctx.BackendRequest.Header.Del(match[1])
+	unsetRequestHeaderValue(v.ctx.BackendRequest, match[1])
 	return nil
 }


### PR DESCRIPTION
Fixes #177 

Refer to the issue, we have bugs for manipulating Fastly's Object-like header like `VARS:foo`.
This PR fixes the problem and a little refactor to integrate these header manipulations by shared function.