### PR TITLE
Add glob filter option

### DIFF
--- a/cmd/falco/help.go
+++ b/cmd/falco/help.go
@@ -136,6 +136,7 @@ Flags:
     -h, --help         : Show this help
     -r, --remote       : Connect with Fastly API
     -t, --timeout      : Set timeout to running test
+    -f, --filter       : Override glob filter to find test files
     -json              : Output results as JSON
     -request           : Override request config
     --max_backends     : Override max backends limitation

--- a/config/command.go
+++ b/config/command.go
@@ -18,6 +18,8 @@ var needValueOptions = map[string]struct{}{
 	"--include_path": {},
 	"-t":             {},
 	"--transformer":  {},
+	"-f":             {},
+	"--filter":       {},
 }
 
 func parseCommands(args []string) Commands {

--- a/config/config.go
+++ b/config/config.go
@@ -30,7 +30,7 @@ type LinterConfig struct {
 type SimulatorConfig struct {
 	Port         int      `cli:"p,port" yaml:"port" default:"3124"`
 	IsDebug      bool     `cli:"debug"` // Enable only in CLI option
-	IncludePaths []string // may copied from root field
+	IncludePaths []string // Copy from root field
 
 	// Override Request configuration
 	OverrideRequest *RequestConfig
@@ -39,7 +39,8 @@ type SimulatorConfig struct {
 // Testing configuration
 type TestConfig struct {
 	Timeout      int      `cli:"t,timeout" yaml:"timeout"`
-	IncludePaths []string // may copied from root field
+	Filter       string   `cli:"f,filter" default:"*.test.vcl"`
+	IncludePaths []string // Copy from root field
 
 	// Override Request configuration
 	OverrideRequest *RequestConfig

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -59,6 +59,7 @@ func TestConfigFromCLI(t *testing.T) {
 			OverrideRequest: &RequestConfig{},
 		},
 		Testing: &TestConfig{
+			Filter:          "*.test.vcl",
 			IncludePaths:    []string{"."},
 			OverrideRequest: &RequestConfig{},
 		},

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -47,7 +47,8 @@ falco test -I . /path/to/your/default.vcl
 
 ## How to write test VCL
 
-When you run the testing command, falco finds test files that have `.test.vcl` suffix in the `include_paths`.
+When you run the testing command, falco finds test files that match the glob syntax of `*.test.vcl` in the `include_paths`, or you can override this by providing `-f,--filter` option to filter test target files you want.
+
 Normally you can put the testing file in the same place as main VCL:
 
 ```shell

--- a/tester/finder.go
+++ b/tester/finder.go
@@ -3,13 +3,14 @@ package tester
 import (
 	"io/fs"
 	"path/filepath"
-	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/ryanuber/go-glob"
 )
 
 type finder struct {
-	files []string
+	files  []string
+	filter string
 }
 
 // fs.WalkDirFunc implementation
@@ -20,19 +21,21 @@ func (f *finder) find(path string, entry fs.DirEntry, err error) error {
 		}
 		return err
 	}
-	if !strings.HasSuffix(path, ".test.vcl") {
+	if !glob.Glob(f.filter, path) {
 		return nil
 	}
 	f.files = append(f.files, path)
 	return nil
 }
 
-func findTestTargetFiles(root string) ([]string, error) {
+func findTestTargetFiles(root, filter string) ([]string, error) {
 	abs, err := filepath.Abs(root)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	f := &finder{}
+	f := &finder{
+		filter: filter,
+	}
 	if err := filepath.WalkDir(abs, f.find); err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -50,7 +50,7 @@ func (t *Tester) listTestFiles(mainVCL string) ([]string, error) {
 
 	var testFiles []string
 	for i := range searchDirs {
-		files, err := findTestTargetFiles(searchDirs[i])
+		files, err := findTestTargetFiles(searchDirs[i], t.config.Filter)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}


### PR DESCRIPTION
Add `-f, --filter` cli option to be enabled to customize the glob filter to find test target files.

## example

```shell
falco test -f "*.dev.test.vcl" /path/to/main.vcl
```

In the above case, the tester finds target files that match with the glob filter of `*.dev.test.vcl`.