### PR TITLE
Filter the fastly service without VCL in constructing service from the planned output by terraform

### DIFF
--- a/terraform/data/terraform-without-vcl.json
+++ b/terraform/data/terraform-without-vcl.json
@@ -1,0 +1,114 @@
+{
+    "planned_values": {
+        "root_module": {
+            "resources": [
+                {
+                    "provider_name": "registry.terraform.io/fastly/fastly",
+                    "type": "fastly_service_vcl",
+                    "values": {
+                        "acl": [
+                            {
+                                "acl_id": "this is another id",
+                                "force_destroy": false,
+                                "name": "foo_acl"
+                            }
+                        ],
+                        "backend": [
+                            {
+                            "address": "foo.com",
+                            "auto_loadbalance": false,
+                            "between_bytes_timeout": 10000,
+                            "connect_timeout": 1000,
+                            "error_threshold": 0,
+                            "first_byte_timeout": 15000,
+                            "healthcheck": "foo_check",
+                            "max_conn": 200,
+                            "max_tls_version": "",
+                            "min_tls_version": "1.2",
+                            "name": "foo_backend",
+                            "override_host": "",
+                            "port": 443,
+                            "request_condition": "",
+                            "shield": "",
+                            "ssl_ca_cert": "",
+                            "ssl_check_cert": true,
+                            "ssl_ciphers": "",
+                            "ssl_client_cert": "",
+                            "ssl_client_key": "",
+                            "ssl_hostname": "",
+                            "ssl_sni_hostname": "",
+                            "use_ssl": true,
+                            "weight": 100
+                            }
+                        ],
+                        "dictionary": [
+                            {
+                                "dictionary_id": "this is an id",
+                                "force_destroy": false,
+                                "name": "foo_dictionary",
+                                "write_only": false
+                            }
+                        ],
+                        "vcl": [
+                            {
+                                "content": "sub vcl_recv { \n #FASTLY RECV \n if (req.http.foo ~ foo_acl && table.contains(foo_dictionary, \"foo\")){ \n set req.backend = F_foo_backend;\n}\n}",
+                                "main": true,
+                                "name": "main.vcl"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "provider_name": "registry.terraform.io/fastly/fastly",
+                    "type": "fastly_service_vcl",
+                    "values": {
+                        "acl": [
+                            {
+                                "acl_id": "this is another id",
+                                "force_destroy": false,
+                                "name": "foo_acl"
+                            }
+                        ],
+                        "backend": [
+                            {
+                            "address": "foo.com",
+                            "auto_loadbalance": false,
+                            "between_bytes_timeout": 10000,
+                            "connect_timeout": 1000,
+                            "error_threshold": 0,
+                            "first_byte_timeout": 15000,
+                            "healthcheck": "foo_check",
+                            "max_conn": 200,
+                            "max_tls_version": "",
+                            "min_tls_version": "1.2",
+                            "name": "foo_backend",
+                            "override_host": "",
+                            "port": 443,
+                            "request_condition": "",
+                            "shield": "",
+                            "ssl_ca_cert": "",
+                            "ssl_check_cert": true,
+                            "ssl_ciphers": "",
+                            "ssl_client_cert": "",
+                            "ssl_client_key": "",
+                            "ssl_hostname": "",
+                            "ssl_sni_hostname": "",
+                            "use_ssl": true,
+                            "weight": 100
+                            }
+                        ],
+                        "dictionary": [
+                            {
+                                "dictionary_id": "this is an id",
+                                "force_destroy": false,
+                                "name": "foo_dictionary",
+                                "write_only": false
+                            }
+                        ],
+                        "vcl": []
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/terraform/terraform.go
+++ b/terraform/terraform.go
@@ -136,5 +136,5 @@ func UnmarshalTerraformPlannedInput(buf []byte) ([]*FastlyService, error) {
 
 func isFastlyVCLServiceResource(r *TerraformPlannedResource) bool {
 	return r.ProviderName == fastlyTerraformProviderName &&
-		(r.Type == fastlyVCLServiceType || r.Type == fastlyVCLServiceTypeV1)
+		(r.Type == fastlyVCLServiceType || r.Type == fastlyVCLServiceTypeV1) && len(r.Values.Vcl) > 0
 }

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -48,3 +48,21 @@ func TestUnmarshallInValidTfJson(t *testing.T) {
 		t.Fatalf("Expected error when unarshalling tf %s ", fileName)
 	}
 }
+
+func TestUnmarshallInWithoutVCLTfJson(t *testing.T) {
+	fileName := "./data/terraform-without-vcl.json"
+	buf, err := os.ReadFile(fileName)
+
+	if err != nil {
+		t.Fatalf("Unexpected error %s reading file %s ", fileName, err)
+	}
+
+	services, err := UnmarshalTerraformPlannedInput(buf)
+	if err != nil {
+		t.Fatalf("Unexpected error when unarshalling tf %s ", fileName)
+	}
+
+	if len(services) != 1 {
+		t.Errorf("Length of services should be %d, got %d", 1, len(services))
+	}
+}


### PR DESCRIPTION
## Summary

Filter the fastly service without VCL in constructing service from the planned output by terraform

Fixes: #185 

I made `UnmarshalTerraformPlannedInput`, which constructs fastly service from terraform planned output, filter the fastly service without VCL. As #185 , falco will crush to handle the fastly service without VCL, so filtering in advance is needed.

If there is a better approach, please feel free to close this PR 👌 
