### PR TITLE
fix misunderstood variables implementation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.20.2
+        go-version: 1.21.1
     - name: Run tests
       run: make test
     - name: Lint programs

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.20.2
+        go-version: 1.21.1
     - name: Run tests
       run: make test
     - name: Lint programs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.2
+          go-version: 1.21.1
       - name: Run tests
         run: make test
       - name: Lint programs

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/ysugimoto/falco
 
-go 1.20
+go 1.21
+
+toolchain go1.21.1
 
 require (
 	github.com/avct/uasurfer v0.0.0-20191028135549-26b5daa857f1

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,7 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kyokomi/emoji v2.2.4+incompatible h1:np0woGKwx9LiHAQmwZx79Oc0rHpNw3o+3evou4BEPv4=
@@ -100,6 +101,7 @@ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 modernc.org/libc v1.17.0 h1:nbL2Lv0I323wLc1GmTh/AqVtI9JeBVc7Nhapdg9EONs=

--- a/interpreter/function/builtin/randomstr.go
+++ b/interpreter/function/builtin/randomstr.go
@@ -27,6 +27,10 @@ func Randomstr_Validate(args []value.Value) error {
 	return nil
 }
 
+var Randomstr_default_characters = []rune(
+	"abcdedfhijklmnopqrstuvwxyzABCDEDFHIJKLMNOPQRSTUVWXYZ0123456789-_",
+)
+
 // Fastly built-in function implementation of randomstr
 // Arguments may be:
 // - INTEGER
@@ -39,7 +43,10 @@ func Randomstr(ctx *context.Context, args ...value.Value) (value.Value, error) {
 	}
 
 	length := value.Unwrap[*value.Integer](args[0])
-	characters := []rune(value.Unwrap[*value.String](args[1]).Value)
+	characters := Randomstr_default_characters
+	if len(args) > 1 {
+		characters = []rune(value.Unwrap[*value.String](args[1]).Value)
+	}
 
 	rand.Seed(time.Now().UnixNano())
 	ret := make([]rune, int(length.Value))

--- a/interpreter/function/builtin/time_runits.go
+++ b/interpreter/function/builtin/time_runits.go
@@ -4,6 +4,7 @@ package builtin
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/ysugimoto/falco/interpreter/context"
 	"github.com/ysugimoto/falco/interpreter/function/errors"
@@ -42,19 +43,22 @@ func Time_runits(ctx *context.Context, args ...value.Value) (value.Value, error)
 	switch unit {
 	case "s":
 		return &value.String{
-			Value: fmt.Sprintf("%ds", int64(rtime.Seconds())),
+			Value: fmt.Sprintf("%d", int64(rtime.Seconds())),
 		}, nil
 	case "ms":
+		v := float64(rtime.Milliseconds()) / 1000
 		return &value.String{
-			Value: fmt.Sprintf("%dms", rtime.Milliseconds()),
+			Value: strconv.FormatFloat(v, 'f', 3, 64),
 		}, nil
 	case "us":
+		v := float64(rtime.Microseconds()) / 1000000
 		return &value.String{
-			Value: fmt.Sprintf("%dus", rtime.Microseconds()),
+			Value: strconv.FormatFloat(v, 'f', 6, 64),
 		}, nil
 	case "ns":
+		v := float64(rtime.Nanoseconds()) / 1000000000
 		return &value.String{
-			Value: fmt.Sprintf("%dns", rtime.Nanoseconds()),
+			Value: strconv.FormatFloat(v, 'f', 9, 64),
 		}, nil
 	default:
 		ctx.FastlyError = &value.String{Value: "EINVAL"}

--- a/interpreter/function/builtin/time_runits_test.go
+++ b/interpreter/function/builtin/time_runits_test.go
@@ -22,10 +22,10 @@ func Test_Time_runits(t *testing.T) {
 		expect  string
 		isError bool
 	}{
-		{unit: "s", rtime: time.Duration(time.Second), expect: "1s"},
-		{unit: "ms", rtime: time.Duration(time.Second), expect: "1000ms"},
-		{unit: "us", rtime: time.Duration(time.Second), expect: "1000000us"},
-		{unit: "ns", rtime: time.Duration(time.Second), expect: "1000000000ns"},
+		{unit: "s", rtime: time.Duration(time.Second), expect: "1"},
+		{unit: "ms", rtime: time.Duration(time.Second), expect: "1.000"},
+		{unit: "us", rtime: time.Duration(time.Second), expect: "1.000000"},
+		{unit: "ns", rtime: time.Duration(time.Second), expect: "1.000000000"},
 		{unit: "z", rtime: time.Duration(time.Second), expect: "", isError: true},
 	}
 

--- a/interpreter/function/builtin/time_units.go
+++ b/interpreter/function/builtin/time_units.go
@@ -4,6 +4,7 @@ package builtin
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/ysugimoto/falco/interpreter/context"
 	"github.com/ysugimoto/falco/interpreter/function/errors"
@@ -42,19 +43,22 @@ func Time_units(ctx *context.Context, args ...value.Value) (value.Value, error) 
 	switch unit {
 	case "s":
 		return &value.String{
-			Value: fmt.Sprintf("%ds", t.Unix()),
+			Value: fmt.Sprintf("%d", t.Unix()),
 		}, nil
 	case "ms":
+		v := float64(t.UnixMilli()) / 1000
 		return &value.String{
-			Value: fmt.Sprintf("%dms", t.UnixMilli()),
+			Value: strconv.FormatFloat(v, 'f', 3, 64),
 		}, nil
 	case "us":
+		v := float64(t.UnixMicro()) / 1000000
 		return &value.String{
-			Value: fmt.Sprintf("%dus", t.UnixMicro()),
+			Value: strconv.FormatFloat(v, 'f', 6, 64),
 		}, nil
 	case "ns":
+		v := float64(t.UnixNano()) / 1000000000
 		return &value.String{
-			Value: fmt.Sprintf("%dns", t.UnixNano()),
+			Value: strconv.FormatFloat(v, 'f', 9, 64),
 		}, nil
 	default:
 		ctx.FastlyError = &value.String{Value: "EINVAL"}

--- a/interpreter/function/builtin/time_units_test.go
+++ b/interpreter/function/builtin/time_units_test.go
@@ -22,10 +22,10 @@ func Test_Time_units(t *testing.T) {
 		expect  string
 		isError bool
 	}{
-		{unit: "s", time: time.Date(2023, 3, 3, 21, 57, 0, 0, time.UTC), expect: "1677880620s"},
-		{unit: "ms", time: time.Date(2023, 3, 3, 21, 57, 0, 0, time.UTC), expect: "1677880620000ms"},
-		{unit: "us", time: time.Date(2023, 3, 3, 21, 57, 0, 0, time.UTC), expect: "1677880620000000us"},
-		{unit: "ns", time: time.Date(2023, 3, 3, 21, 57, 0, 0, time.UTC), expect: "1677880620000000000ns"},
+		{unit: "s", time: time.Date(2023, 3, 3, 21, 57, 0, 0, time.UTC), expect: "1677880620"},
+		{unit: "ms", time: time.Date(2023, 3, 3, 21, 57, 0, 0, time.UTC), expect: "1677880620.000"},
+		{unit: "us", time: time.Date(2023, 3, 3, 21, 57, 0, 0, time.UTC), expect: "1677880620.000000"},
+		{unit: "ns", time: time.Date(2023, 3, 3, 21, 57, 0, 0, time.UTC), expect: "1677880620.000000000"},
 		{unit: "z", time: time.Date(2023, 3, 3, 21, 57, 0, 0, time.UTC), expect: "", isError: true},
 	}
 

--- a/interpreter/variable/fetch.go
+++ b/interpreter/variable/fetch.go
@@ -186,8 +186,6 @@ func (v *FetchScopeVariables) Get(s context.Scope, name string) (value.Value, er
 
 	case BERESP_RESPONSE:
 		return v.ctx.BackendResponseResponse, nil
-	case BERESP_SAINTMODE:
-		return v.ctx.BackendResponseSaintMode, nil
 	case BERESP_STALE_IF_ERROR:
 		return v.ctx.BackendResponseStaleIfError, nil
 	case BERESP_STALE_WHILE_REVALIDATE:
@@ -195,7 +193,7 @@ func (v *FetchScopeVariables) Get(s context.Scope, name string) (value.Value, er
 	case BERESP_STATUS:
 		return &value.Integer{Value: int64(beresp.StatusCode)}, nil
 	case BERESP_TTL:
-		return v.ctx.BackendResponseGzip, nil
+		return v.ctx.BackendResponseTTL, nil
 
 	case BERESP_USED_ALTERNATE_PATH_TO_ORIGIN:
 		// https://docs.fastly.com/en/guides/precision-path
@@ -360,7 +358,7 @@ func (v *FetchScopeVariables) Set(s context.Scope, name, operator string, val va
 		beresp.Status = http.StatusText(int(left.Value))
 		return nil
 	case BERESP_TTL:
-		if err := doAssign(v.ctx.BackendResponseBrotli, operator, val); err != nil {
+		if err := doAssign(v.ctx.BackendResponseTTL, operator, val); err != nil {
 			return errors.WithStack(err)
 		}
 		return nil


### PR DESCRIPTION
This PR includes some of misunderstood built-in function implementations.

- `saint_mode` is **settable** only
- Fix `beresp.ttl` returns actual ttl RTIME
- `time.units` and `time.runits` responds only string, without unit string like `s`