### PR TITLE
implement testing.override_host function

### DIFF
--- a/tester/function/assert.go
+++ b/tester/function/assert.go
@@ -6,25 +6,25 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Assert_lookup_Name = "assert"
+const Assert_Name = "assert"
 
-var Assert_lookup_ArgumentTypes = []value.Type{value.BooleanType}
+var Assert_ArgumentTypes = []value.Type{value.BooleanType}
 
-func Assert_lookup_Validate(args []value.Value) error {
+func Assert_Validate(args []value.Value) error {
 	if len(args) < 1 || len(args) > 2 {
-		return errors.ArgumentNotInRange(Assert_lookup_Name, 1, 2, args)
+		return errors.ArgumentNotInRange(Assert_Name, 1, 2, args)
 	}
 
 	if len(args) == 2 {
 		if args[1].Type() != value.StringType {
-			return errors.TypeMismatch(Assert_lookup_Name, 2, value.StringType, args[1].Type())
+			return errors.TypeMismatch(Assert_Name, 2, value.StringType, args[1].Type())
 		}
 	}
 	return nil
 }
 
 func Assert(ctx *context.Context, args ...value.Value) (value.Value, error) {
-	if err := Assert_lookup_Validate(args); err != nil {
+	if err := Assert_Validate(args); err != nil {
 		return nil, errors.NewTestingError(err.Error())
 	}
 

--- a/tester/function/assert_contains.go
+++ b/tester/function/assert_contains.go
@@ -8,31 +8,31 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Assert_contains_lookup_Name = "assert"
+const Assert_contains_Name = "assert"
 
-var Assert_contains_lookup_ArgumentTypes = []value.Type{value.StringType, value.StringType}
+var Assert_contains_ArgumentTypes = []value.Type{value.StringType, value.StringType}
 
-func Assert_contains_lookup_Validate(args []value.Value) error {
+func Assert_contains_Validate(args []value.Value) error {
 	if len(args) < 2 || len(args) > 3 {
-		return errors.ArgumentNotInRange(Assert_contains_lookup_Name, 2, 3, args)
+		return errors.ArgumentNotInRange(Assert_contains_Name, 2, 3, args)
 	}
 
-	for i := range Assert_contains_lookup_ArgumentTypes {
-		if args[i].Type() != Assert_contains_lookup_ArgumentTypes[i] {
-			return errors.TypeMismatch(Assert_contains_lookup_Name, i+1, Assert_contains_lookup_ArgumentTypes[i], args[i].Type())
+	for i := range Assert_contains_ArgumentTypes {
+		if args[i].Type() != Assert_contains_ArgumentTypes[i] {
+			return errors.TypeMismatch(Assert_contains_Name, i+1, Assert_contains_ArgumentTypes[i], args[i].Type())
 		}
 	}
 
 	if len(args) == 3 {
 		if args[2].Type() != value.StringType {
-			return errors.TypeMismatch(Assert_contains_lookup_Name, 3, value.StringType, args[2].Type())
+			return errors.TypeMismatch(Assert_contains_Name, 3, value.StringType, args[2].Type())
 		}
 	}
 	return nil
 }
 
 func Assert_contains(ctx *context.Context, args ...value.Value) (value.Value, error) {
-	if err := Assert_contains_lookup_Validate(args); err != nil {
+	if err := Assert_contains_Validate(args); err != nil {
 		return nil, errors.NewTestingError(err.Error())
 	}
 

--- a/tester/function/assert_ends_with.go
+++ b/tester/function/assert_ends_with.go
@@ -8,31 +8,31 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Assert_ends_with_lookup_Name = "assert"
+const Assert_ends_with_Name = "assert"
 
-var Assert_ends_with_lookup_ArgumentTypes = []value.Type{value.StringType, value.StringType}
+var Assert_ends_with_ArgumentTypes = []value.Type{value.StringType, value.StringType}
 
-func Assert_ends_with_lookup_Validate(args []value.Value) error {
+func Assert_ends_with_Validate(args []value.Value) error {
 	if len(args) < 2 || len(args) > 3 {
-		return errors.ArgumentNotInRange(Assert_ends_with_lookup_Name, 2, 3, args)
+		return errors.ArgumentNotInRange(Assert_ends_with_Name, 2, 3, args)
 	}
 
-	for i := range Assert_ends_with_lookup_ArgumentTypes {
-		if args[i].Type() != Assert_ends_with_lookup_ArgumentTypes[i] {
-			return errors.TypeMismatch(Assert_ends_with_lookup_Name, i+1, Assert_ends_with_lookup_ArgumentTypes[i], args[i].Type())
+	for i := range Assert_ends_with_ArgumentTypes {
+		if args[i].Type() != Assert_ends_with_ArgumentTypes[i] {
+			return errors.TypeMismatch(Assert_ends_with_Name, i+1, Assert_ends_with_ArgumentTypes[i], args[i].Type())
 		}
 	}
 
 	if len(args) == 3 {
 		if args[2].Type() != value.StringType {
-			return errors.TypeMismatch(Assert_ends_with_lookup_Name, 3, value.StringType, args[2].Type())
+			return errors.TypeMismatch(Assert_ends_with_Name, 3, value.StringType, args[2].Type())
 		}
 	}
 	return nil
 }
 
 func Assert_ends_with(ctx *context.Context, args ...value.Value) (value.Value, error) {
-	if err := Assert_ends_with_lookup_Validate(args); err != nil {
+	if err := Assert_ends_with_Validate(args); err != nil {
 		return nil, errors.NewTestingError(err.Error())
 	}
 

--- a/tester/function/assert_equal.go
+++ b/tester/function/assert_equal.go
@@ -6,22 +6,22 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Assert_equal_lookup_Name = "assert"
+const Assert_equal_Name = "assert"
 
-func Assert_equal_lookup_Validate(args []value.Value) error {
+func Assert_equal_Validate(args []value.Value) error {
 	if len(args) < 2 || len(args) > 3 {
-		return errors.ArgumentNotInRange(Assert_equal_lookup_Name, 2, 3, args)
+		return errors.ArgumentNotInRange(Assert_equal_Name, 2, 3, args)
 	}
 	if len(args) == 3 {
 		if args[2].Type() != value.StringType {
-			return errors.TypeMismatch(Assert_equal_lookup_Name, 3, value.StringType, args[2].Type())
+			return errors.TypeMismatch(Assert_equal_Name, 3, value.StringType, args[2].Type())
 		}
 	}
 	return nil
 }
 
 func Assert_equal(ctx *context.Context, args ...value.Value) (value.Value, error) {
-	if err := Assert_equal_lookup_Validate(args); err != nil {
+	if err := Assert_equal_Validate(args); err != nil {
 		return nil, errors.NewTestingError(err.Error())
 	}
 

--- a/tester/function/assert_false.go
+++ b/tester/function/assert_false.go
@@ -6,23 +6,23 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Assert_false_lookup_Name = "assert"
+const Assert_false_Name = "assert"
 
-func Assert_false_lookup_Validate(args []value.Value) error {
+func Assert_false_Validate(args []value.Value) error {
 	if len(args) < 1 || len(args) > 2 {
-		return errors.ArgumentNotInRange(Assert_false_lookup_Name, 1, 2, args)
+		return errors.ArgumentNotInRange(Assert_false_Name, 1, 2, args)
 	}
 
 	if len(args) == 2 {
 		if args[1].Type() != value.StringType {
-			return errors.TypeMismatch(Assert_false_lookup_Name, 2, value.StringType, args[1].Type())
+			return errors.TypeMismatch(Assert_false_Name, 2, value.StringType, args[1].Type())
 		}
 	}
 	return nil
 }
 
 func Assert_false(ctx *context.Context, args ...value.Value) (value.Value, error) {
-	if err := Assert_false_lookup_Validate(args); err != nil {
+	if err := Assert_false_Validate(args); err != nil {
 		return nil, errors.NewTestingError(err.Error())
 	}
 

--- a/tester/function/assert_match.go
+++ b/tester/function/assert_match.go
@@ -8,31 +8,31 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Assert_match_lookup_Name = "assert"
+const Assert_match_Name = "assert"
 
-var Assert_match_lookup_ArgumentTypes = []value.Type{value.StringType, value.StringType}
+var Assert_match_ArgumentTypes = []value.Type{value.StringType, value.StringType}
 
-func Assert_match_lookup_Validate(args []value.Value) error {
+func Assert_match_Validate(args []value.Value) error {
 	if len(args) < 2 || len(args) > 3 {
-		return errors.ArgumentNotInRange(Assert_match_lookup_Name, 2, 3, args)
+		return errors.ArgumentNotInRange(Assert_match_Name, 2, 3, args)
 	}
 
-	for i := range Assert_match_lookup_ArgumentTypes {
-		if args[i].Type() != Assert_match_lookup_ArgumentTypes[i] {
-			return errors.TypeMismatch(Assert_match_lookup_Name, i+1, Assert_match_lookup_ArgumentTypes[i], args[i].Type())
+	for i := range Assert_match_ArgumentTypes {
+		if args[i].Type() != Assert_match_ArgumentTypes[i] {
+			return errors.TypeMismatch(Assert_match_Name, i+1, Assert_match_ArgumentTypes[i], args[i].Type())
 		}
 	}
 
 	if len(args) == 3 {
 		if args[2].Type() != value.StringType {
-			return errors.TypeMismatch(Assert_match_lookup_Name, 3, value.StringType, args[2].Type())
+			return errors.TypeMismatch(Assert_match_Name, 3, value.StringType, args[2].Type())
 		}
 	}
 	return nil
 }
 
 func Assert_match(ctx *context.Context, args ...value.Value) (value.Value, error) {
-	if err := Assert_match_lookup_Validate(args); err != nil {
+	if err := Assert_match_Validate(args); err != nil {
 		return nil, errors.NewTestingError(err.Error())
 	}
 

--- a/tester/function/assert_not_contains.go
+++ b/tester/function/assert_not_contains.go
@@ -8,31 +8,31 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Assert_not_contains_lookup_Name = "assert"
+const Assert_not_contains_Name = "assert"
 
-var Assert_not_contains_lookup_ArgumentTypes = []value.Type{value.StringType, value.StringType}
+var Assert_not_contains_ArgumentTypes = []value.Type{value.StringType, value.StringType}
 
-func Assert_not_contains_lookup_Validate(args []value.Value) error {
+func Assert_not_contains_Validate(args []value.Value) error {
 	if len(args) < 2 || len(args) > 3 {
-		return errors.ArgumentNotInRange(Assert_not_contains_lookup_Name, 2, 3, args)
+		return errors.ArgumentNotInRange(Assert_not_contains_Name, 2, 3, args)
 	}
 
-	for i := range Assert_not_contains_lookup_ArgumentTypes {
-		if args[i].Type() != Assert_not_contains_lookup_ArgumentTypes[i] {
-			return errors.TypeMismatch(Assert_not_contains_lookup_Name, i+1, Assert_not_contains_lookup_ArgumentTypes[i], args[i].Type())
+	for i := range Assert_not_contains_ArgumentTypes {
+		if args[i].Type() != Assert_not_contains_ArgumentTypes[i] {
+			return errors.TypeMismatch(Assert_not_contains_Name, i+1, Assert_not_contains_ArgumentTypes[i], args[i].Type())
 		}
 	}
 
 	if len(args) == 3 {
 		if args[2].Type() != value.StringType {
-			return errors.TypeMismatch(Assert_not_contains_lookup_Name, 3, value.StringType, args[2].Type())
+			return errors.TypeMismatch(Assert_not_contains_Name, 3, value.StringType, args[2].Type())
 		}
 	}
 	return nil
 }
 
 func Assert_not_contains(ctx *context.Context, args ...value.Value) (value.Value, error) {
-	if err := Assert_not_contains_lookup_Validate(args); err != nil {
+	if err := Assert_not_contains_Validate(args); err != nil {
 		return nil, errors.NewTestingError(err.Error())
 	}
 

--- a/tester/function/assert_not_equal.go
+++ b/tester/function/assert_not_equal.go
@@ -6,22 +6,22 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Assert_not_equal_lookup_Name = "assert"
+const Assert_not_equal_Name = "assert"
 
-func Assert_not_equal_lookup_Validate(args []value.Value) error {
+func Assert_not_equal_Validate(args []value.Value) error {
 	if len(args) < 2 || len(args) > 3 {
-		return errors.ArgumentNotInRange(Assert_not_equal_lookup_Name, 2, 3, args)
+		return errors.ArgumentNotInRange(Assert_not_equal_Name, 2, 3, args)
 	}
 	if len(args) == 3 {
 		if args[2].Type() != value.StringType {
-			return errors.TypeMismatch(Assert_not_equal_lookup_Name, 3, value.StringType, args[2].Type())
+			return errors.TypeMismatch(Assert_not_equal_Name, 3, value.StringType, args[2].Type())
 		}
 	}
 	return nil
 }
 
 func Assert_not_equal(ctx *context.Context, args ...value.Value) (value.Value, error) {
-	if err := Assert_not_equal_lookup_Validate(args); err != nil {
+	if err := Assert_not_equal_Validate(args); err != nil {
 		return nil, errors.NewTestingError(err.Error())
 	}
 

--- a/tester/function/assert_not_match.go
+++ b/tester/function/assert_not_match.go
@@ -8,31 +8,31 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Assert_not_match_lookup_Name = "assert"
+const Assert_not_match_Name = "assert"
 
-var Assert_not_match_lookup_ArgumentTypes = []value.Type{value.StringType, value.StringType}
+var Assert_not_match_ArgumentTypes = []value.Type{value.StringType, value.StringType}
 
-func Assert_not_match_lookup_Validate(args []value.Value) error {
+func Assert_not_match_Validate(args []value.Value) error {
 	if len(args) < 2 || len(args) > 3 {
-		return errors.ArgumentNotInRange(Assert_not_match_lookup_Name, 2, 3, args)
+		return errors.ArgumentNotInRange(Assert_not_match_Name, 2, 3, args)
 	}
 
-	for i := range Assert_not_match_lookup_ArgumentTypes {
-		if args[i].Type() != Assert_not_match_lookup_ArgumentTypes[i] {
-			return errors.TypeMismatch(Assert_not_match_lookup_Name, i+1, Assert_not_match_lookup_ArgumentTypes[i], args[i].Type())
+	for i := range Assert_not_match_ArgumentTypes {
+		if args[i].Type() != Assert_not_match_ArgumentTypes[i] {
+			return errors.TypeMismatch(Assert_not_match_Name, i+1, Assert_not_match_ArgumentTypes[i], args[i].Type())
 		}
 	}
 
 	if len(args) == 3 {
 		if args[2].Type() != value.StringType {
-			return errors.TypeMismatch(Assert_not_match_lookup_Name, 3, value.StringType, args[2].Type())
+			return errors.TypeMismatch(Assert_not_match_Name, 3, value.StringType, args[2].Type())
 		}
 	}
 	return nil
 }
 
 func Assert_not_match(ctx *context.Context, args ...value.Value) (value.Value, error) {
-	if err := Assert_not_match_lookup_Validate(args); err != nil {
+	if err := Assert_not_match_Validate(args); err != nil {
 		return nil, errors.NewTestingError(err.Error())
 	}
 

--- a/tester/function/assert_not_strict_equal.go
+++ b/tester/function/assert_not_strict_equal.go
@@ -6,22 +6,22 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Assert_not_strict_equal_lookup_Name = "assert"
+const Assert_not_strict_equal_Name = "assert"
 
-func Assert_not_strict_equal_lookup_Validate(args []value.Value) error {
+func Assert_not_strict_equal_Validate(args []value.Value) error {
 	if len(args) < 2 || len(args) > 3 {
-		return errors.ArgumentNotInRange(Assert_not_strict_equal_lookup_Name, 2, 3, args)
+		return errors.ArgumentNotInRange(Assert_not_strict_equal_Name, 2, 3, args)
 	}
 	if len(args) == 3 {
 		if args[2].Type() != value.StringType {
-			return errors.TypeMismatch(Assert_not_strict_equal_lookup_Name, 3, value.StringType, args[2].Type())
+			return errors.TypeMismatch(Assert_not_strict_equal_Name, 3, value.StringType, args[2].Type())
 		}
 	}
 	return nil
 }
 
 func Assert_not_strict_equal(ctx *context.Context, args ...value.Value) (value.Value, error) {
-	if err := Assert_not_strict_equal_lookup_Validate(args); err != nil {
+	if err := Assert_not_strict_equal_Validate(args); err != nil {
 		return nil, errors.NewTestingError(err.Error())
 	}
 

--- a/tester/function/assert_starts_with.go
+++ b/tester/function/assert_starts_with.go
@@ -8,31 +8,31 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Assert_starts_with_lookup_Name = "assert"
+const Assert_starts_with_Name = "assert"
 
-var Assert_starts_with_lookup_ArgumentTypes = []value.Type{value.StringType, value.StringType}
+var Assert_starts_with_ArgumentTypes = []value.Type{value.StringType, value.StringType}
 
-func Assert_starts_with_lookup_Validate(args []value.Value) error {
+func Assert_starts_with_Validate(args []value.Value) error {
 	if len(args) < 2 || len(args) > 3 {
-		return errors.ArgumentNotInRange(Assert_starts_with_lookup_Name, 2, 3, args)
+		return errors.ArgumentNotInRange(Assert_starts_with_Name, 2, 3, args)
 	}
 
-	for i := range Assert_starts_with_lookup_ArgumentTypes {
-		if args[i].Type() != Assert_starts_with_lookup_ArgumentTypes[i] {
-			return errors.TypeMismatch(Assert_starts_with_lookup_Name, i+1, Assert_starts_with_lookup_ArgumentTypes[i], args[i].Type())
+	for i := range Assert_starts_with_ArgumentTypes {
+		if args[i].Type() != Assert_starts_with_ArgumentTypes[i] {
+			return errors.TypeMismatch(Assert_starts_with_Name, i+1, Assert_starts_with_ArgumentTypes[i], args[i].Type())
 		}
 	}
 
 	if len(args) == 3 {
 		if args[2].Type() != value.StringType {
-			return errors.TypeMismatch(Assert_starts_with_lookup_Name, 3, value.StringType, args[2].Type())
+			return errors.TypeMismatch(Assert_starts_with_Name, 3, value.StringType, args[2].Type())
 		}
 	}
 	return nil
 }
 
 func Assert_starts_with(ctx *context.Context, args ...value.Value) (value.Value, error) {
-	if err := Assert_starts_with_lookup_Validate(args); err != nil {
+	if err := Assert_starts_with_Validate(args); err != nil {
 		return nil, errors.NewTestingError(err.Error())
 	}
 

--- a/tester/function/assert_strict_equal.go
+++ b/tester/function/assert_strict_equal.go
@@ -6,22 +6,22 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Assert_strict_equal_lookup_Name = "assert"
+const Assert_strict_equal_Name = "assert"
 
-func Assert_strict_equal_lookup_Validate(args []value.Value) error {
+func Assert_strict_equal_Validate(args []value.Value) error {
 	if len(args) < 2 || len(args) > 3 {
-		return errors.ArgumentNotInRange(Assert_strict_equal_lookup_Name, 2, 3, args)
+		return errors.ArgumentNotInRange(Assert_strict_equal_Name, 2, 3, args)
 	}
 	if len(args) == 3 {
 		if args[2].Type() != value.StringType {
-			return errors.TypeMismatch(Assert_strict_equal_lookup_Name, 3, value.StringType, args[2].Type())
+			return errors.TypeMismatch(Assert_strict_equal_Name, 3, value.StringType, args[2].Type())
 		}
 	}
 	return nil
 }
 
 func Assert_strict_equal(ctx *context.Context, args ...value.Value) (value.Value, error) {
-	if err := Assert_strict_equal_lookup_Validate(args); err != nil {
+	if err := Assert_strict_equal_Validate(args); err != nil {
 		return nil, errors.NewTestingError(err.Error())
 	}
 

--- a/tester/function/assert_true.go
+++ b/tester/function/assert_true.go
@@ -6,23 +6,23 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Assert_true_lookup_Name = "assert"
+const Assert_true_Name = "assert"
 
-func Assert_true_lookup_Validate(args []value.Value) error {
+func Assert_true_Validate(args []value.Value) error {
 	if len(args) < 1 || len(args) > 2 {
-		return errors.ArgumentNotInRange(Assert_true_lookup_Name, 1, 2, args)
+		return errors.ArgumentNotInRange(Assert_true_Name, 1, 2, args)
 	}
 
 	if len(args) == 2 {
 		if args[1].Type() != value.StringType {
-			return errors.TypeMismatch(Assert_true_lookup_Name, 2, value.StringType, args[1].Type())
+			return errors.TypeMismatch(Assert_true_Name, 2, value.StringType, args[1].Type())
 		}
 	}
 	return nil
 }
 
 func Assert_true(ctx *context.Context, args ...value.Value) (value.Value, error) {
-	if err := Assert_true_lookup_Validate(args); err != nil {
+	if err := Assert_true_Validate(args); err != nil {
 		return nil, errors.NewTestingError(err.Error())
 	}
 

--- a/tester/function/testing_call_subroutine.go
+++ b/tester/function/testing_call_subroutine.go
@@ -7,20 +7,20 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Testing_call_subroutine_lookup_Name = "assert"
+const Testing_call_subroutine_Name = "assert"
 
-var Testing_call_subroutine_lookup_ArgumentTypes = []value.Type{value.StringType}
+var Testing_call_subroutine_ArgumentTypes = []value.Type{value.StringType}
 
-func Testing_call_subroutine_lookup_Validate(args []value.Value) error {
+func Testing_call_subroutine_Validate(args []value.Value) error {
 	if len(args) != 1 {
-		return errors.ArgumentNotEnough(Testing_call_subroutine_lookup_Name, 1, args)
+		return errors.ArgumentNotEnough(Testing_call_subroutine_Name, 1, args)
 	}
 	for i := range args {
-		if args[i].Type() != Testing_call_subroutine_lookup_ArgumentTypes[i] {
+		if args[i].Type() != Testing_call_subroutine_ArgumentTypes[i] {
 			return errors.TypeMismatch(
-				Testing_call_subroutine_lookup_Name,
+				Testing_call_subroutine_Name,
 				i+1,
-				Testing_call_subroutine_lookup_ArgumentTypes[i],
+				Testing_call_subroutine_ArgumentTypes[i],
 				args[i].Type(),
 			)
 		}
@@ -34,7 +34,7 @@ func Testing_call_subroutine(
 	args ...value.Value,
 ) (value.Value, error) {
 
-	if err := Testing_call_subroutine_lookup_Validate(args); err != nil {
+	if err := Testing_call_subroutine_Validate(args); err != nil {
 		return nil, errors.NewTestingError(err.Error())
 	}
 

--- a/tester/function/testing_fixed_time.go
+++ b/tester/function/testing_fixed_time.go
@@ -8,13 +8,11 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Testing_fixed_time_lookup_Name = "testing.fixed_time"
+const Testing_fixed_time_Name = "testing.fixed_time"
 
-var Testing_fixed_time_lookup_ArgumentTypes = []value.Type{value.StringType}
-
-func Testing_fixed_time_lookup_Validate(args []value.Value) error {
+func Testing_fixed_time_Validate(args []value.Value) error {
 	if len(args) != 1 {
-		return errors.ArgumentNotEnough(Testing_fixed_time_lookup_Name, 1, args)
+		return errors.ArgumentNotEnough(Testing_fixed_time_Name, 1, args)
 	}
 	return nil
 }
@@ -26,7 +24,7 @@ func Testing_fixed_time(
 	args ...value.Value,
 ) (value.Value, error) {
 
-	if err := Testing_fixed_time_lookup_Validate(args); err != nil {
+	if err := Testing_fixed_time_Validate(args); err != nil {
 		return nil, errors.NewTestingError(err.Error())
 	}
 
@@ -48,7 +46,7 @@ func Testing_fixed_time(
 	default:
 		return value.Null, errors.NewTestingError(
 			"First argument of %s must be INTEGER or TIME or STRING type, %s provided",
-			Testing_fixed_time_lookup_Name,
+			Testing_fixed_time_Name,
 			args[0].Type(),
 		)
 	}

--- a/tester/function/testing_override_host.go
+++ b/tester/function/testing_override_host.go
@@ -1,0 +1,39 @@
+package function
+
+import (
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/function/errors"
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+const Testing_override_host_Name = "testing.override_host"
+
+func Testing_override_host_Validate(args []value.Value) error {
+	if len(args) != 1 {
+		return errors.ArgumentNotEnough(Testing_override_host_Name, 1, args)
+	}
+	return nil
+}
+
+func Testing_override_host(
+	ctx *context.Context,
+	args ...value.Value,
+) (value.Value, error) {
+
+	if err := Testing_override_host_Validate(args); err != nil {
+		return nil, errors.NewTestingError(err.Error())
+	}
+
+	switch args[0].Type() {
+	case value.StringType:
+		override := value.Unwrap[*value.String](args[0]).Value
+		ctx.OriginalHost = override
+	default:
+		return value.Null, errors.NewTestingError(
+			"First argument of %s must be STRING type, %s provided",
+			Testing_override_host_Name,
+			args[0].Type(),
+		)
+	}
+	return value.Null, nil
+}

--- a/tester/function/testing_override_host_test.go
+++ b/tester/function/testing_override_host_test.go
@@ -1,0 +1,30 @@
+package function
+
+import (
+	"testing"
+
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+func Test_override_host(t *testing.T) {
+
+	t.Run("Override Host", func(t *testing.T) {
+		tests := []struct {
+			override value.Value
+		}{
+			{override: &value.String{Value: "example.com"}},
+		}
+
+		for _, tt := range tests {
+			c := &context.Context{}
+			_, err := Testing_override_host(c, tt.override)
+			if err != nil {
+				t.Errorf("Expected error but nil")
+			}
+			if c.OriginalHost != "example.com" {
+				t.Errorf("OriginalHost value unmatched, expect=example.com, got=%s", c.OriginalHost)
+			}
+		}
+	})
+}


### PR DESCRIPTION
Implements `testing.override_host` that aims to override the request host for each test case.

## Syntax

```vcl
sub test_vcl {
  // Calling this testing utility function then req.Host should be overriden
  testing.override_host("example.com");
}
```