### PR TITLE
Feature/inspect variable on testing

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -161,6 +161,7 @@ We describe them following table and examples:
 | testing.call_subroutine | FUNCTION   | Call subroutine which is defined in main VCL                                                 |
 | testing.fixed_time      | FUNCTION   | Use fixed time whole the test suite                                                          |
 | testing.override_host   | FUNCTION   | Override request host with provided argument in the test case                                |
+| testing.inspect         | FUNCTION   | Inspect predefined variables for any scopes                                                  |
 | assert                  | FUNCTION   | Assert provided expression should be true                                                    |
 | assert.true             | FUNCTION   | Assert actual value should be true                                                           |
 | assert.false            | FUNCTION   | Assert actual value should be false                                                          |
@@ -242,6 +243,25 @@ sub test_vcl {
 
     // some time related assertions here
     assert.true(resp.status == 200);
+}
+```
+
+----
+
+### testing.inspect(STRING var_name)
+
+Inspect specific variable. This function has special permission that all variable value can inspect.
+
+```vcl
+// @scope: recv
+sub test_vcl {
+    // call vcl_recv Fastly reserved subroutine in RECV scope,
+    // will call error statement in this subroutine.
+    testing.call_subroutine("vcl_recv");
+
+    // Typically obj.status could not access in recv scope,
+    // but can inspect via this function.
+    assert.equal(testing.inspect("obj.status"), 400);
 }
 ```
 

--- a/examples/testing/default.test.vcl
+++ b/examples/testing/default.test.vcl
@@ -17,3 +17,12 @@ sub test_vcl_deliver {
 }
 
 
+// @scope: recv
+// @suite: Checking auth raise an error with 401 status code
+sub test_check_auth {
+  set req.http.Check-Auth = "1";
+  testing.call_subroutine("vcl_recv");
+
+  assert.equal(testing.state, "ERROR");
+  assert.equal(testing.inspect("obj.status"), 401);
+}

--- a/examples/testing/default.vcl
+++ b/examples/testing/default.vcl
@@ -37,6 +37,10 @@ sub vcl_recv {
   set req.backend = httpbin_org;
   set req.http.Foo = {" foo bar baz "};
   call custom_logger;
+
+  if (req.http.Check-Auth) {
+    error 401;
+  }
   return (lookup);
 }
 

--- a/parser/error.go
+++ b/parser/error.go
@@ -14,9 +14,13 @@ type ParseError struct {
 }
 
 func (e *ParseError) Error() string {
+	var file string
+	if e.Token.File != "" {
+		file = " at " + e.Token.File
+	}
 	return fmt.Sprintf(
-		"Parse Error: %s, line: %d, position: %d",
-		e.Message, e.Token.Line, e.Token.Position,
+		"Parse Error: %s%s, line: %d, position: %d",
+		e.Message, file, e.Token.Line, e.Token.Position,
 	)
 }
 

--- a/tester/function/assert_contains.go
+++ b/tester/function/assert_contains.go
@@ -52,7 +52,7 @@ func Assert_contains(ctx *context.Context, args ...value.Value) (value.Value, er
 		}
 		return ret, errors.NewAssertionError(
 			actual,
-			`"%s" should be contained in "%s"`,
+			`"%s" should contain "%s"`,
 			actual.Value,
 			expect.Value,
 		)

--- a/tester/function/testing_functions.go
+++ b/tester/function/testing_functions.go
@@ -56,6 +56,16 @@ func TestingFunctions(i *interpreter.Interpreter, c Counter) map[string]*ifn.Fun
 				return false
 			},
 		},
+		"testing.inspect": {
+			Scope: allScope,
+			// On this function, we don't need to unwrap ident
+			// because ident value should be looked up as predefined variables
+			Call:             Testing_inspect,
+			CanStatementCall: true,
+			IsIdentArgument: func(i int) bool {
+				return false
+			},
+		},
 		"assert": {
 			Scope: allScope,
 			Call: func(ctx *context.Context, args ...value.Value) (value.Value, error) {

--- a/tester/function/testing_inspect.go
+++ b/tester/function/testing_inspect.go
@@ -1,0 +1,78 @@
+package function
+
+import (
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/function/errors"
+	"github.com/ysugimoto/falco/interpreter/value"
+	"github.com/ysugimoto/falco/interpreter/variable"
+)
+
+const Testing_inspect_Name = "testing.inspect"
+
+func Testing_inspect_Validate(args []value.Value) error {
+	if len(args) != 1 {
+		return errors.ArgumentNotEnough(Testing_inspect_Name, 1, args)
+	}
+	return nil
+}
+
+func Testing_inspect(
+	ctx *context.Context,
+	args ...value.Value,
+) (value.Value, error) {
+
+	if err := Testing_inspect_Validate(args); err != nil {
+		return nil, errors.NewTestingError(err.Error())
+	}
+
+	if args[0].Type() != value.StringType {
+		return value.Null, errors.NewTestingError(
+			"[%s] First argument of %s must be STRING type, %s provided",
+			Testing_inspect_Name,
+			Testing_inspect_Name,
+			args[0].Type(),
+		)
+	}
+
+	id := value.Unwrap[*value.String](args[0])
+
+	// Testing specific variable getters here.
+	// obj.status and obj.response might be set on any scopes by calling error statement.
+	// So on testing, we need to reference context value directly, not referencing Object response
+	switch id.Value {
+	case variable.OBJ_STATUS:
+		return &value.Integer{Value: ctx.ObjectStatus.Value}, nil
+	case variable.OBJ_RESPONSE:
+		return &value.String{Value: ctx.ObjectResponse.Value}, nil
+	}
+
+	// Otherwise, look up for each scope variables
+	// Note that any scope variables also look up all scope variables,
+	// it is redundant but OK for now for testing
+	lookups := []variable.Variable{
+		variable.NewLogScopeVariables(ctx),
+		variable.NewErrorScopeVariables(ctx),
+		variable.NewDeliverScopeVariables(ctx),
+		variable.NewFetchScopeVariables(ctx),
+		variable.NewHashScopeVariables(ctx),
+		variable.NewMissScopeVariables(ctx),
+		variable.NewPassScopeVariables(ctx),
+		variable.NewRecvScopeVariables(ctx),
+		variable.NewAllScopeVariables(ctx),
+	}
+	var ret value.Value
+	var err error
+	for i := range lookups {
+		ret, err = lookups[i].Get(context.AnyScope, id.Value)
+
+		// If value is found in either scope, return it
+		if err == nil {
+			return ret, nil
+		}
+	}
+	return value.Null, errors.NewTestingError(
+		"[%s] Variable %s does not found or could not get",
+		Testing_inspect_Name,
+		id.Value,
+	)
+}

--- a/tester/function/testing_inspect.go
+++ b/tester/function/testing_inspect.go
@@ -60,16 +60,13 @@ func Testing_inspect(
 		variable.NewRecvScopeVariables(ctx),
 		variable.NewAllScopeVariables(ctx),
 	}
-	var ret value.Value
-	var err error
 	for i := range lookups {
-		ret, err = lookups[i].Get(context.AnyScope, id.Value)
-
 		// If value is found in either scope, return it
-		if err == nil {
+		if ret, err := lookups[i].Get(context.AnyScope, id.Value); err == nil {
 			return ret, nil
 		}
 	}
+
 	return value.Null, errors.NewTestingError(
 		"[%s] Variable %s does not found or could not get",
 		Testing_inspect_Name,

--- a/tester/function/testing_inspect_test.go
+++ b/tester/function/testing_inspect_test.go
@@ -1,0 +1,109 @@
+package function
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+func Test_inspect(t *testing.T) {
+
+	ctx := context.New()
+	ctx.Request = httptest.NewRequest(http.MethodGet, "http://localhost:3124", nil)
+	ctx.BackendRequest = ctx.Request.Clone(ctx.Request.Context())
+	ctx.BackendResponse = &http.Response{
+		StatusCode:    http.StatusOK,
+		Status:        http.StatusText(http.StatusOK),
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Header:        http.Header{},
+		Body:          io.NopCloser(strings.NewReader("OK")),
+		ContentLength: 2,
+		Close:         true,
+		Uncompressed:  false,
+		Trailer:       http.Header{},
+		Request:       ctx.BackendRequest.Clone(ctx.Request.Context()),
+	}
+	ctx.Response = &http.Response{
+		StatusCode:    http.StatusOK,
+		Status:        http.StatusText(http.StatusOK),
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Header:        http.Header{},
+		Body:          io.NopCloser(strings.NewReader("OK")),
+		ContentLength: 2,
+		Close:         true,
+		Uncompressed:  false,
+		Trailer:       http.Header{},
+		Request:       ctx.BackendRequest.Clone(ctx.Request.Context()),
+	}
+	ctx.Object = &http.Response{
+		StatusCode:    http.StatusOK,
+		Status:        http.StatusText(http.StatusOK),
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Header:        http.Header{},
+		Body:          io.NopCloser(strings.NewReader("OK")),
+		ContentLength: 2,
+		Close:         true,
+		Uncompressed:  false,
+		Trailer:       http.Header{},
+		Request:       ctx.BackendRequest.Clone(ctx.Request.Context()),
+	}
+
+	t.Run("Inspect variable", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			expect  value.Value
+			isError bool
+		}{
+			{name: "obj.status", expect: &value.Integer{Value: 500}},
+			{name: "req.http.Foo", expect: &value.String{Value: ""}},
+			{name: "some.undefined", isError: true},
+		}
+
+		for _, tt := range tests {
+			ret, err := Testing_inspect(ctx, &value.String{Value: tt.name})
+			if tt.isError {
+				if err == nil {
+					t.Errorf("Expect error but nil")
+				}
+				continue
+			}
+			if err != nil {
+				t.Errorf("Unexpected error on Testing_inspect, %s", err)
+				return
+			}
+			if diff := cmp.Diff(ret, tt.expect); diff != "" {
+				t.Errorf("return value unmatch, diff=%s", diff)
+			}
+		}
+	})
+	t.Run("Other type inspection", func(t *testing.T) {
+		tests := []struct {
+			name value.Value
+		}{
+			{name: &value.Float{Value: 0}},
+			{name: &value.Boolean{Value: false}},
+			{name: &value.IP{Value: nil}},
+			{name: &value.Backend{Value: nil}},
+			{name: &value.Acl{Value: nil}},
+		}
+
+		for _, tt := range tests {
+			_, err := Testing_inspect(ctx, tt.name)
+			if err == nil {
+				t.Errorf("Expected error but nil")
+			}
+		}
+	})
+}

--- a/tester/variable/testing.go
+++ b/tester/variable/testing.go
@@ -2,6 +2,7 @@ package variable
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/ysugimoto/falco/interpreter/context"
 	"github.com/ysugimoto/falco/interpreter/value"
@@ -20,7 +21,7 @@ type TestingVariables struct {
 func (v *TestingVariables) Get(ctx *context.Context, scope context.Scope, name string) (value.Value, error) {
 	switch name { // nolint:gocritic
 	case TESTING_STATE:
-		return ctx.ReturnState, nil
+		return &value.String{Value: strings.ToUpper(ctx.ReturnState.Value)}, nil
 	}
 
 	return nil, fmt.Errorf("Not Found")


### PR DESCRIPTION
This PR implements a new testing function of `testing.inspect`.
`testing.inspect` could retrieve any predefined variable in any scope in the test.

From interpreter reason, the argument of predefined variable name should be a string, not an ident.