### PR TITLE
Implement STRING to ACL regex comparison

### DIFF
--- a/interpreter/operator/operator_regex_test.go
+++ b/interpreter/operator/operator_regex_test.go
@@ -115,6 +115,16 @@ func TestRegexOperator(t *testing.T) {
 
 	t.Run("left is STRING", func(t *testing.T) {
 		now := time.Now()
+		acl := &ast.AclDeclaration{
+			Name: &ast.Ident{Value: "example"},
+			CIDRs: []*ast.AclCidr{
+				{
+					Inverse: &ast.Boolean{Value: false},
+					IP:      &ast.IP{Value: "127.0.0.0"},
+					Mask:    &ast.Integer{Value: 16},
+				},
+			},
+		}
 		tests := []struct {
 			left    value.Value
 			right   value.Value
@@ -138,6 +148,9 @@ func TestRegexOperator(t *testing.T) {
 			{left: &value.String{Value: "example"}, right: &value.IP{Value: net.ParseIP("127.0.0.1")}, isError: true},
 			{left: &value.String{Value: "example", Literal: true}, right: &value.Integer{Value: 100}, isError: true},
 			{left: &value.String{Value: "example", Literal: true}, right: &value.Integer{Value: 100, Literal: true}, isError: true},
+			{left: &value.String{Value: "127.0.0.1"}, right: &value.Acl{Value: acl}, expect: true},
+			{left: &value.String{Value: "192.168.0.1"}, right: &value.Acl{Value: acl}, expect: false},
+			{left: &value.String{Value: "INVALID IP"}, right: &value.Acl{Value: acl}, isError: true},
 		}
 
 		for i, tt := range tests {


### PR DESCRIPTION
First off, thank you for creating this tool! It's very impressive, and fulfills a pressing need for my team.

This is the first of hopefully several PRs that I'm planning on entering. This one is simple: it implements comparison between a string and an ACL, re-using the code for IP to ACL comparisons. Before this, VCL like the following triggers the error `Invalid type comparison STRING and ACL` (taken from https://developer.fastly.com/reference/vcl/declarations/acl/):
```
  if (req.http.Fastly-Client-IP ~ ban_acl) {
    error 601 "banned-ip";
  }
```
