### PR TITLE
Fix type of client.geo.ip_override

### DIFF
--- a/interpreter/context/context.go
+++ b/interpreter/context/context.go
@@ -82,7 +82,7 @@ type Context struct {
 	StaleContents                       *value.String
 	FastlyError                         *value.String
 	ClientIdentity                      *value.String
-	ClientGeoIpOverride                 *value.Boolean
+	ClientGeoIpOverride                 *value.String
 	ClientSocketCongestionAlgorithm     *value.String
 	ClientSocketCwnd                    *value.Integer
 	ClientSocketPace                    *value.Integer
@@ -177,7 +177,7 @@ func New(options ...Option) *Context {
 		StaleIsRevalidating:                 &value.Boolean{},
 		StaleContents:                       &value.String{},
 		FastlyError:                         &value.String{},
-		ClientGeoIpOverride:                 &value.Boolean{},
+		ClientGeoIpOverride:                 &value.String{},
 		ClientSocketCongestionAlgorithm:     &value.String{Value: "cubic"},
 		ClientSocketCwnd:                    &value.Integer{Value: 60},
 		ClientSocketPace:                    &value.Integer{},


### PR DESCRIPTION
`client.geo.ip_override` is of type STRING per https://developer.fastly.com/reference/vcl/variables/geolocation/client-geo-ip-override/, not boolean. I also added some basic tests for this.