### PR TITLE
Allow assigning a backend to a string

### DIFF
--- a/interpreter/assign/assign.go
+++ b/interpreter/assign/assign.go
@@ -134,9 +134,6 @@ func Assign(left, right value.Value) error {
 			rv := value.Unwrap[*value.Time](right)
 			lv.Value = rv.Value.Format(http.TimeFormat)
 		case value.BackendType: // STRING = BACKEND
-			if right.IsLiteral() {
-				return errors.WithStack(fmt.Errorf("BACKEND identifier could not assign to STRING"))
-			}
 			rv := value.Unwrap[*value.Backend](right)
 			lv.Value = rv.Value.Name.Value
 		case value.BooleanType: // STRING = BOOL

--- a/interpreter/assign/assign_test.go
+++ b/interpreter/assign/assign_test.go
@@ -105,6 +105,7 @@ func TestProcessAssignment(t *testing.T) {
 			{left: "left", right: &value.String{Value: "example"}, expect: "example"},
 			{left: "left", right: &value.String{Value: "example", Literal: true}, expect: "example"},
 			{left: "left", right: &value.Backend{Value: &ast.BackendDeclaration{Name: &ast.Ident{Value: "foo"}}}, expect: "foo"},
+			{left: "left", right: &value.Backend{Value: &ast.BackendDeclaration{Name: &ast.Ident{Value: "foo"}}, Literal: true}, expect: "foo"},
 			{left: "left", right: &value.Boolean{Value: true}, expect: "1"},
 			{left: "left", right: &value.Boolean{Value: false, Literal: true}, expect: "0"},
 			{left: "left", right: &value.IP{Value: net.ParseIP("127.0.0.1")}, expect: "127.0.0.1"},


### PR DESCRIPTION
The following code:
```
set req.backend = httpbin_org;
declare local var.backend STRING;
set var.backend = req.backend;
```

will trigger the error `Failed to assign value to var.backend, BACKEND identifier could not assign to STRING` when testing/simulating, but this is allowed by Fastly, and is a common workaround to allow doing regex matching on a backend.