### PR TITLE
Fix testing.override_host

### DIFF
--- a/tester/function/testing_functions.go
+++ b/tester/function/testing_functions.go
@@ -50,6 +50,20 @@ func TestingFunctions(i *interpreter.Interpreter, c Counter) map[string]*ifn.Fun
 				return false
 			},
 		},
+		"testing.override_host": {
+			Scope: allScope,
+			Call: func(ctx *context.Context, args ...value.Value) (value.Value, error) {
+				unwrapped, err := unwrapIdentArguments(i, args)
+				if err != nil {
+					return value.Null, errors.WithStack(err)
+				}
+				return Testing_override_host(ctx, unwrapped...)
+			},
+			CanStatementCall: true,
+			IsIdentArgument: func(i int) bool {
+				return false
+			},
+		},
 		"testing.inspect": {
 			Scope: allScope,
 			// On this function, we don't need to unwrap ident


### PR DESCRIPTION
Currently, trying to use `testing.override_host()` in a test results in the following error:
```
$ falco test -I . default.vcl
Running tests... Done.
 FAIL  /Users/mmalone/src/go/src/github.com/ysugimoto/falco/examples/testing/default.test.vcl
  ●  [RECV]  Foo request header should contains "hoge"

    [RuntimeException] Function testing.override_host is not defined in/Users/mmalone/src/go/src/github.com/ysugimoto/falco/examples/testing/default.test.vcl at line: 5, position: 3
```

I tried writing a unit test for the `tester.Run()` method, but it's tricky due to the global variables `injectedVariable` and `builtinFunctions`. Making those part of the `Interpreter` interface would fix that.