### PR TITLE
Fix backend  not found in director

### DIFF
--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -136,29 +136,37 @@ func (i *Interpreter) ProcessInit(r *http.Request) error {
 }
 
 func (i *Interpreter) ProcessDeclarations(statements []ast.Statement) error {
-	// Process root declarations and statements
+	// Process root declarations and statements.
+	// Must process backends first because they're referenced by directors.
+	// https://developer.fastly.com/reference/vcl/declarations/
 	for _, stmt := range statements {
-		// Call debugger
+		t, ok := stmt.(*ast.BackendDeclaration)
+		if !ok {
+			continue
+		}
 		i.Debugger.Run(stmt)
+		h := &atomic.Bool{}
+		h.Store(true)
+		// Determine default backend
+		if i.ctx.Backend == nil {
+			i.ctx.Backend = &value.Backend{Value: t, Literal: true, Healthy: h}
+		}
+		if _, ok := i.ctx.Backends[t.Name.Value]; ok {
+			return exception.Runtime(&t.Token, "Backend %s is duplicated", t.Name.Value)
+		}
+		i.ctx.Backends[t.Name.Value] = &value.Backend{Value: t, Literal: true, Healthy: h}
+	}
 
+	for _, stmt := range statements {
 		switch t := stmt.(type) {
 		case *ast.AclDeclaration:
+			i.Debugger.Run(stmt)
 			if _, ok := i.ctx.Acls[t.Name.Value]; ok {
 				return exception.Runtime(&t.Token, "ACL %s is duplicated", t.Name.Value)
 			}
 			i.ctx.Acls[t.Name.Value] = &value.Acl{Value: t, Literal: true}
-		case *ast.BackendDeclaration:
-			h := &atomic.Bool{}
-			h.Store(true)
-			// Determine default backend
-			if i.ctx.Backend == nil {
-				i.ctx.Backend = &value.Backend{Value: t, Literal: true, Healthy: h}
-			}
-			if _, ok := i.ctx.Backends[t.Name.Value]; ok {
-				return exception.Runtime(&t.Token, "Backend %s is duplicated", t.Name.Value)
-			}
-			i.ctx.Backends[t.Name.Value] = &value.Backend{Value: t, Literal: true, Healthy: h}
 		case *ast.DirectorDeclaration:
+			i.Debugger.Run(stmt)
 			// Director should treat as backend
 			if _, ok := i.ctx.Backends[t.Name.Value]; ok {
 				return exception.Runtime(&t.Token, "Director %s is duplicated in backend definition", t.Name.Value)
@@ -169,11 +177,13 @@ func (i *Interpreter) ProcessDeclarations(statements []ast.Statement) error {
 			}
 			i.ctx.Backends[t.Name.Value] = &value.Backend{Director: dc, Literal: true}
 		case *ast.TableDeclaration:
+			i.Debugger.Run(stmt)
 			if _, ok := i.ctx.Tables[t.Name.Value]; ok {
 				return exception.Runtime(&t.Token, "Table %s is duplicated", t.Name.Value)
 			}
 			i.ctx.Tables[t.Name.Value] = t
 		case *ast.SubroutineDeclaration:
+			i.Debugger.Run(stmt)
 			if t.ReturnType != nil {
 				if _, ok := i.ctx.SubroutineFunctions[t.Name.Value]; ok {
 					return exception.Runtime(&t.Token, "Subroutine %s is duplicated", t.Name.Value)
@@ -196,11 +206,13 @@ func (i *Interpreter) ProcessDeclarations(statements []ast.Statement) error {
 			// Other custom user subroutine could not be duplicated
 			return exception.Runtime(&t.Token, "Subroutine %s is duplicated", t.Name.Value)
 		case *ast.PenaltyboxDeclaration:
+			i.Debugger.Run(stmt)
 			if _, ok := i.ctx.Penaltyboxes[t.Name.Value]; ok {
 				return exception.Runtime(&t.Token, "Penaltybox %s is duplicated", t.Name.Value)
 			}
 			i.ctx.Penaltyboxes[t.Name.Value] = t
 		case *ast.RatecounterDeclaration:
+			i.Debugger.Run(stmt)
 			if _, ok := i.ctx.Ratecounters[t.Name.Value]; ok {
 				return exception.Runtime(&t.Token, "Ratecounter %s is duplicated", t.Name.Value)
 			}

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/ysugimoto/falco/ast"
 	"github.com/ysugimoto/falco/interpreter/context"
 	"github.com/ysugimoto/falco/interpreter/value"
 	"github.com/ysugimoto/falco/resolver"
@@ -70,5 +71,52 @@ func assertValue(t *testing.T, name string, expect, actual value.Value) {
 	}
 	if diff := cmp.Diff(expect, actual); diff != "" {
 		t.Errorf("Value asserion error, diff: %s", diff)
+	}
+}
+
+func TestProcessDeclarations(t *testing.T) {
+	ip := New()
+	ip.ctx = context.New()
+	err := ip.ProcessDeclarations([]ast.Statement{
+		&ast.DirectorDeclaration{
+			Name:         &ast.Ident{Value: "director_example"},
+			DirectorType: &ast.Ident{Value: "client"},
+			Properties: []ast.Expression{
+				&ast.DirectorProperty{
+					Key:   &ast.Ident{Value: "quorum"},
+					Value: &ast.String{Value: "20%"},
+				},
+				&ast.DirectorBackendObject{
+					Values: []*ast.DirectorProperty{
+						{
+							Key:   &ast.Ident{Value: "backend"},
+							Value: &ast.Ident{Value: "backend_example"},
+						},
+						{
+							Key:   &ast.Ident{Value: "weight"},
+							Value: &ast.Integer{Value: 1},
+						},
+					},
+				},
+			},
+		},
+		&ast.BackendDeclaration{
+			Name: &ast.Ident{Value: "backend_example"},
+			Properties: []*ast.BackendProperty{
+				{
+					Key:   &ast.Ident{Value: "host"},
+					Value: &ast.String{Value: "example.com"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Errorf("%+v\n", err)
+	}
+	if _, ok := ip.ctx.Backends["backend_example"]; !ok {
+		t.Errorf("Failed to find backend_example in backends: %v\n", ip.ctx.Backends)
+	}
+	if _, ok := ip.ctx.Backends["director_example"]; !ok {
+		t.Errorf("Failed to find director_example in backends: %v\n", ip.ctx.Backends)
 	}
 }


### PR DESCRIPTION
This should fix https://github.com/ysugimoto/falco/issues/196, or at least one of the causes of these errors. The problem is that `ProcessDeclarations()` method parses the declarations in order, and if a `director` declaration references a `backend` declaration that's defined later, it'll trigger `backend 'F_Custom_backend' is not found`. The fix is to have `ProcessDeclarations()` do two passes: the first to process backends and the second for everything else.