### PR TITLE
Fix tester/simulator when shielding used

### DIFF
--- a/interpreter/director.go
+++ b/interpreter/director.go
@@ -25,6 +25,7 @@ const (
 	DIRECTORTYPE_HASH     = "hash"
 	DIRECTORTYPE_CLIENT   = "client"
 	DIRECTORTYPE_CHASH    = "chash"
+	DIRECTORTYPE_SHIELD   = "shield"
 )
 
 var (
@@ -167,7 +168,8 @@ func (i *Interpreter) getDirectorConfig(d *ast.DirectorDeclaration) (*value.Dire
 		DIRECTORTYPE_FALLBACK,
 		DIRECTORTYPE_HASH,
 		DIRECTORTYPE_CLIENT,
-		DIRECTORTYPE_CHASH:
+		DIRECTORTYPE_CHASH,
+		DIRECTORTYPE_SHIELD:
 		conf.Type = d.DirectorType.Value
 	default:
 		return nil, exception.Runtime(
@@ -218,7 +220,7 @@ func (i *Interpreter) getDirectorConfig(d *ast.DirectorDeclaration) (*value.Dire
 		}
 	}
 
-	if len(conf.Backends) == 0 {
+	if len(conf.Backends) == 0 && d.DirectorType.Value != DIRECTORTYPE_SHIELD {
 		return nil, exception.Runtime(
 			&d.GetMeta().Token,
 			"At least one backend must be specified in director '%s'",

--- a/interpreter/director_test.go
+++ b/interpreter/director_test.go
@@ -89,6 +89,25 @@ director test random {
 	}
 }
 
+func TestGetDirectorConfigShield(t *testing.T) {
+	director := "director test shield { }"
+	ip, err := createTestInterpreter(director)
+	if err != nil {
+		t.Errorf("Failed to create interpreter: %s", err)
+	}
+	d := ip.ctx.Backends["test"].Director
+
+	expect := &value.DirectorConfig{
+		Quorum:  0,
+		Retries: 0,
+		Name:    "test",
+		Type:    "shield",
+	}
+	if diff := cmp.Diff(expect, d, cmpopts.IgnoreFields(value.Backend{}, "Healthy")); diff != "" {
+		t.Errorf("getDirectorConfig returns diff: %s", diff)
+	}
+}
+
 func TestRandomDirector(t *testing.T) {
 	director := `
 director test random {


### PR DESCRIPTION
The changes in 39d728808a527605bf5944b95cd1f70fb224d113 are causing the following error when testing/simulating a service that uses shielding:
```
At least one backend must be specified in director 'ssl_shield_this_is_a_shield' in Remote.Director:ssl_shield_this_is_a_shield
```

This fixes the interpreter to stop giving that error, like the linter is already doing.