### PR TITLE
Fix segfault when testing backend from snippet

### DIFF
--- a/cmd/falco/runner_test.go
+++ b/cmd/falco/runner_test.go
@@ -194,6 +194,33 @@ func TestResolveModulesWithoutVCLExtension(t *testing.T) {
 	}
 }
 
+func TestTesterWithTerraform(t *testing.T) {
+	fileName := "../../terraform/data/terraform-valid.json"
+	rslv, f := loadFromTfJson(fileName, t)
+	c := &config.Config{
+		Linter: &config.LinterConfig{
+			VerboseWarning: true,
+		},
+		Testing: &config.TestConfig{
+			IncludePaths: []string{"../../terraform/testing/"},
+			Filter:       "*.test.vcl",
+		},
+	}
+
+	r, err := NewRunner(c, f)
+	if err != nil {
+		t.Fatalf("Unexpected runner creation error: %s", err)
+	}
+
+	res, err := r.Test(rslv[0])
+	if err != nil {
+		t.Fatalf("Unexpected Run() error: %s", err)
+	}
+	if res.Statistics.Fails > 0 || res.Statistics.Passes != 1 {
+		t.Errorf("Expected 0 failures and 1 pass, got %d failures and %d passes", res.Statistics.Fails, res.Statistics.Passes)
+	}
+}
+
 // Tests for all the example code in the repo to make sure we don't accidentally
 // break those as they are the first thing someone might try on the repo.
 

--- a/interpreter/transport.go
+++ b/interpreter/transport.go
@@ -73,8 +73,10 @@ func (i *Interpreter) createBackendRequest(ctx *icontext.Context, backend *value
 	} else {
 		if v, err := i.getBackendProperty(backend.Value.Properties, "host"); err != nil {
 			return nil, errors.WithStack(err)
-		} else {
+		} else if v != nil {
 			host = value.Unwrap[*value.String](v).Value
+		} else {
+			return nil, exception.Runtime(nil, "Failed to find host for backend %s", backend)
 		}
 	}
 

--- a/remote/entity.go
+++ b/remote/entity.go
@@ -30,8 +30,9 @@ type AccessControlEntry struct {
 }
 
 type Backend struct {
-	Name   string  `json:"name"`
-	Shield *string `json:"shield"`
+	Name    string  `json:"name"`
+	Shield  *string `json:"shield"`
+	Address *string `json:"address"`
 }
 
 type DirectorType int8

--- a/remote/fetcher.go
+++ b/remote/fetcher.go
@@ -43,8 +43,9 @@ func (f *FastlyApiFetcher) Backends() ([]*types.RemoteBackend, error) {
 	r := []*types.RemoteBackend{}
 	for _, b := range fstlyBack {
 		r = append(r, &types.RemoteBackend{
-			Name:   b.Name,
-			Shield: b.Shield,
+			Name:    b.Name,
+			Shield:  b.Shield,
+			Address: b.Address,
 		})
 	}
 	return r, nil

--- a/snippets/template.go
+++ b/snippets/template.go
@@ -17,7 +17,9 @@ acl {{ .Name }} {
 `
 
 var backendTemplate = `
-backend F_{{ .Name }} {}
+backend F_{{ .Name }} {
+	{{ if .Address }}.host = "{{.Address}}";{{ end }}
+}
 `
 
 // remote director should only have a shield type

--- a/terraform/fetcher.go
+++ b/terraform/fetcher.go
@@ -36,8 +36,9 @@ func (f *TerraformFetcher) Backends() ([]*types.RemoteBackend, error) {
 	for _, s := range f.filterService() {
 		for _, serviceBackend := range s.Backends {
 			b = append(b, &types.RemoteBackend{
-				Name:   serviceBackend.Name,
-				Shield: serviceBackend.Shield,
+				Name:    serviceBackend.Name,
+				Shield:  serviceBackend.Shield,
+				Address: serviceBackend.Address,
 			})
 		}
 	}

--- a/terraform/terraform.go
+++ b/terraform/terraform.go
@@ -42,8 +42,9 @@ type TerraformLoggingEndpoint struct {
 // TODO(davinci26): We can unmarshall all the properties from the TF file
 // and lint them to make sure they have sane values.
 type TerraformBackend struct {
-	Name   string
-	Shield *string
+	Name    string
+	Shield  *string
+	Address *string
 }
 
 type FastlyService struct {

--- a/terraform/testing/terraform-valid.test.vcl
+++ b/terraform/testing/terraform-valid.test.vcl
@@ -1,0 +1,7 @@
+// @scope: recv
+// @suite: Backend is set to "F_foo_backend"
+sub test_vcl_recv {
+  set req.http.Foo = "127.0.0.1";
+  testing.call_subroutine("vcl_recv");
+  assert.equal(req.backend, F_foo_backend);
+}

--- a/types/types.go
+++ b/types/types.go
@@ -294,8 +294,9 @@ type RemoteDictionary struct {
 // TODO(davinci26): We can unmarshall all the properties from the TF file
 // and lint them to make sure they have sane values.
 type RemoteBackend struct {
-	Name   string
-	Shield *string
+	Name    string
+	Shield  *string
+	Address *string
 }
 
 type RemoteVCL struct {


### PR DESCRIPTION
Before this change, backends that are generated from a snippet didn't have `.host` field defined, which led to a crash in `interpreter.createBackendRequest()`:
```
Fething snippets...Done.
Running tests...panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x104478ca8]

goroutine 27 [running]:
github.com/ysugimoto/falco/interpreter.(*Interpreter).createBackendRequest(0x140000847e0, 0x140001e0200?, 0x140006048a0)
	/Users/mmalone/src/go/src/github.com/ysugimoto/falco/interpreter/transport.go:77 +0x1b8
```

This adds support for defining the `.host` field for all snippet-generated backends, and better error handling for when it isn't defined.