### PR TITLE
Fix calling function with ident argument

### DIFF
--- a/interpreter/expression.go
+++ b/interpreter/expression.go
@@ -205,7 +205,7 @@ func (i *Interpreter) ProcessFunctionCallExpression(exp *ast.FunctionCallExpress
 			// This is because some function uses collection value like req.http.Cookie as ID type,
 			// But the processor passes *value.String as primitive value normally.
 			// In order to treat collection value inside, ensure ident argument is treated as correspond types.
-			if ident, ok := exp.Arguments[j].(*ast.Ident); !ok {
+			if ident, ok := exp.Arguments[j].(*ast.Ident); ok {
 				args[j] = &value.Ident{Value: ident.Value}
 			} else {
 				return value.Null, errors.WithStack(

--- a/interpreter/expression_test.go
+++ b/interpreter/expression_test.go
@@ -274,3 +274,14 @@ sub vcl_recv {
 		"req.http.Foo": &value.String{Value: "yes"},
 	})
 }
+
+func TestProcessFunctionCallExpressionWithIdent(t *testing.T) {
+	vcl := `
+sub vcl_recv {
+	set req.http.Foo2 = "yes";
+	set req.http.Foo = header.get(req, "Foo2");
+}`
+	assertInterpreter(t, vcl, context.RecvScope, map[string]value.Value{
+		"req.http.Foo": &value.String{Value: "yes"},
+	})
+}


### PR DESCRIPTION
Before this, calling any function that takes in an Ident argument fails, e.g.:
```
[RuntimeException] Function header.get of 0 argument must be an Ident in main at line: 11, position: 32
```

This is due to a typo in `ProcessFunctionCallExpression()` when checking the type of the argument