### PR TITLE
Don't generate error for ratelimit functions

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -3,9 +3,14 @@
 The following table describes built-in functions that will return tentative values.
 Will be updated when we find or implement a way to get accurate values.
 
-| Function                                       | Tentative Value/behavior               |
-|:----------------------------------------------:|:----------------------------------------:|
-| *fastly.hash(key, seed, from, to)*             | returns originaly calculated hahs string |
-| *h2.push(resource [, as])*                     | Ignore variadic arguments of "as"        |
-| *resp.tarpit(interval_s [, chunk_size_bytes])* | No effect due to not support tarpitting  |
-| *early_hints(resource [, resources...])*       | No effect due to not support h2 and h3   |
+| Function                                                                                              | Tentative Value/behavior                        |
+|:-----------------------------------------------------------------------------------------------------:|:-----------------------------------------------:|
+| *fastly.hash(key, seed, from, to)*                                                                    | Returns originaly calculated hash string        |
+| *h2.push(resource [, as])*                                                                            | Ignore variadic arguments of "as"               |
+| *resp.tarpit(interval_s [, chunk_size_bytes])*                                                        | No effect due to not support tarpitting         |
+| *early_hints(resource [, resources...])*                                                              | No effect due to not support h2 and h3          |
+| *ratelimit.check_rate(entry, rc, delta, window, limit, pb, ttl)*                                      | Returns `false` due to no rate limiting support |
+| *ratelimit.check_rates(entry, rc1, delta1, window1, limit1, rc2, delta2, windows2, limit2, pb, ttl)*  | Returns `false` due to no rate limiting support |
+| *ratelimit.penaltybox_add(pb, entry, ttl)*                                                            | No effect due to no rate limiting support       |
+| *ratelimit.penaltybox_has(pb, entry)*                                                                 | Returns `false` due to no rate limiting support |
+| *ratelimit.ratecounter_increment(rc, entry, delta)*                                                   | Returns `0` due to no rate limiting support     |

--- a/interpreter/function/builtin/ratelimit_check_rate.go
+++ b/interpreter/function/builtin/ratelimit_check_rate.go
@@ -34,6 +34,6 @@ func Ratelimit_check_rate(ctx *context.Context, args ...value.Value) (value.Valu
 		return value.Null, err
 	}
 
-	// Need to be implemented
-	return value.Null, errors.NotImplemented("ratelimit.check_rate")
+	// TODO: Needs to be implemented
+	return &value.Boolean{Value: false}, nil
 }

--- a/interpreter/function/builtin/ratelimit_check_rates.go
+++ b/interpreter/function/builtin/ratelimit_check_rates.go
@@ -34,6 +34,6 @@ func Ratelimit_check_rates(ctx *context.Context, args ...value.Value) (value.Val
 		return value.Null, err
 	}
 
-	// Need to be implemented
-	return value.Null, errors.NotImplemented("ratelimit.check_rates")
+	// TODO: Needs to be implemented
+	return &value.Boolean{Value: false}, nil
 }

--- a/interpreter/function/builtin/ratelimit_penaltybox_add.go
+++ b/interpreter/function/builtin/ratelimit_penaltybox_add.go
@@ -34,6 +34,6 @@ func Ratelimit_penaltybox_add(ctx *context.Context, args ...value.Value) (value.
 		return value.Null, err
 	}
 
-	// Need to be implemented
-	return value.Null, errors.NotImplemented("ratelimit.penaltybox_add")
+	// TODO: Needs to be implemented
+	return value.Null, nil
 }

--- a/interpreter/function/builtin/ratelimit_penaltybox_has.go
+++ b/interpreter/function/builtin/ratelimit_penaltybox_has.go
@@ -34,6 +34,6 @@ func Ratelimit_penaltybox_has(ctx *context.Context, args ...value.Value) (value.
 		return value.Null, err
 	}
 
-	// Need to be implemented
-	return value.Null, errors.NotImplemented("ratelimit.penaltybox_has")
+	// TODO: Needs to be implemented
+	return &value.Boolean{Value: false}, nil
 }

--- a/interpreter/function/builtin/ratelimit_ratecounter_increment.go
+++ b/interpreter/function/builtin/ratelimit_ratecounter_increment.go
@@ -34,6 +34,6 @@ func Ratelimit_ratecounter_increment(ctx *context.Context, args ...value.Value) 
 		return value.Null, err
 	}
 
-	// Need to be implemented
-	return value.Null, errors.NotImplemented("ratelimit.ratecounter_increment")
+	// TODO: Needs to be implemented
+	return &value.Integer{Value: 0}, nil
 }


### PR DESCRIPTION
Currently, calling any of the `ratelimit.*` functions triggers the error `[ratelimit.*] Not implemented`. This means it's impossible to unit test any code that calls one of those functions. Other unimplemented functions (e.g. `resp.tarpit()`) instead return some default value, which is better behavior IMO, so I did the same thing here.