### PR TITLE
Exit with status 1 on test failures

### DIFF
--- a/cmd/falco/main.go
+++ b/cmd/falco/main.go
@@ -368,5 +368,9 @@ func runTest(runner *Runner, rslv resolver.Resolver) error {
 	write(white, "%d total, ", totalCount)
 	writeln(white, "%d assertions", factory.Statistics.Asserts)
 
-	return nil
+	if failedCount > 0 {
+		return ErrExit
+	} else {
+		return nil
+	}
 }

--- a/cmd/falco/main.go
+++ b/cmd/falco/main.go
@@ -294,12 +294,8 @@ func runTest(runner *Runner, rslv resolver.Resolver) error {
 			writeln(red, err.Error())
 			return ErrExit
 		}
-		for _, r := range factory.Results {
-			for _, c := range r.Cases {
-				if c.Error != nil {
-					return ErrExit
-				}
-			}
+		if factory.Statistics.Fails > 0 {
+			return ErrExit
 		}
 		return nil
 	}
@@ -375,7 +371,7 @@ func runTest(runner *Runner, rslv resolver.Resolver) error {
 	write(white, "%d total, ", totalCount)
 	writeln(white, "%d assertions", factory.Statistics.Asserts)
 
-	if failedCount > 0 {
+	if factory.Statistics.Fails > 0 {
 		return ErrExit
 	} else {
 		return nil

--- a/cmd/falco/main.go
+++ b/cmd/falco/main.go
@@ -294,6 +294,13 @@ func runTest(runner *Runner, rslv resolver.Resolver) error {
 			writeln(red, err.Error())
 			return ErrExit
 		}
+		for _, r := range factory.Results {
+			for _, c := range r.Cases {
+				if c.Error != nil {
+					return ErrExit
+				}
+			}
+		}
 		return nil
 	}
 


### PR DESCRIPTION
Currently, the `lint` command will exit with status 1 if there are any failures, but the `test` command won't. I think `test` should behave the same as `lint`, because that will make it easier to integrate it into a CI tool.