### PR TITLE
Show right port number when starting simulator

### DIFF
--- a/cmd/falco/runner.go
+++ b/cmd/falco/runner.go
@@ -454,7 +454,7 @@ func (r *Runner) Simulate(rslv resolver.Resolver) error {
 		Handler: mux,
 		Addr:    fmt.Sprintf(":%d", sc.Port),
 	}
-	writeln(green, "Simulator server starts on 0.0.0.0:3124")
+	writeln(green, "Simulator server starts on 0.0.0.0:%d", sc.Port)
 	return s.ListenAndServe()
 }
 


### PR DESCRIPTION
This fixes the startup message to show the right port if it's been customized using `.falco.yml`:
```
$ cd examples/simulator
$ echo 'simulator: { port: 5910 }' > .falco.yml
$ falco simulate -I . simulator.vcl
Simulator server starts on 0.0.0.0:5910 
```