### PR TITLE
Allow setting bereq.http.{NAME} in miss/pass

### DIFF
--- a/interpreter/variable/fetch.go
+++ b/interpreter/variable/fetch.go
@@ -379,11 +379,9 @@ func (v *FetchScopeVariables) Set(s context.Scope, name, operator string, val va
 		return nil
 	}
 
-	if match := backendRequestHttpHeaderRegex.FindStringSubmatch(name); match != nil {
-		if err := limitations.CheckProtectedHeader(match[1]); err != nil {
-			return errors.WithStack(err)
-		}
-		setRequestHeaderValue(v.ctx.BackendRequest, match[1], val)
+	if ok, err := SetBackendRequestHeader(v.ctx, name, val); err != nil {
+		return errors.WithStack(err)
+	} else if ok {
 		return nil
 	}
 	if match := backendResponseHttpHeaderRegex.FindStringSubmatch(name); match != nil {

--- a/interpreter/variable/miss.go
+++ b/interpreter/variable/miss.go
@@ -163,6 +163,12 @@ func (v *MissScopeVariables) Set(s context.Scope, name, operator string, val val
 		return nil
 	}
 
+	if ok, err := SetBackendRequestHeader(v.ctx, name, val); err != nil {
+		return errors.WithStack(err)
+	} else if ok {
+		return nil
+	}
+
 	if ok, err := SetWafVariables(v.ctx, name, operator, val); err != nil {
 		return errors.WithStack(err)
 	} else if ok {

--- a/interpreter/variable/pass.go
+++ b/interpreter/variable/pass.go
@@ -152,6 +152,12 @@ func (v *PassScopeVariables) Set(s context.Scope, name, operator string, val val
 		return nil
 	}
 
+	if ok, err := SetBackendRequestHeader(v.ctx, name, val); err != nil {
+		return errors.WithStack(err)
+	} else if ok {
+		return nil
+	}
+
 	if ok, err := SetWafVariables(v.ctx, name, operator, val); err != nil {
 		return errors.WithStack(err)
 	} else if ok {

--- a/interpreter/variable/shared.go
+++ b/interpreter/variable/shared.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/limitations"
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
@@ -200,6 +201,17 @@ func GetWafVariables(ctx *context.Context, name string) (value.Value, error) {
 	return nil, nil
 }
 
+func SetBackendRequestHeader(ctx *context.Context, name string, val value.Value) (bool, error) {
+	if match := backendRequestHttpHeaderRegex.FindStringSubmatch(name); match != nil {
+		if err := limitations.CheckProtectedHeader(match[1]); err != nil {
+			return true, errors.WithStack(err)
+		}
+		setRequestHeaderValue(ctx.BackendRequest, match[1], val)
+		return true, nil
+	}
+	return false, nil
+
+}
 func SetWafVariables(ctx *context.Context, name, operator string, val value.Value) (bool, error) {
 	switch name {
 	case WAF_ANOMALY_SCORE:

--- a/interpreter/variable/shared.go
+++ b/interpreter/variable/shared.go
@@ -210,8 +210,8 @@ func SetBackendRequestHeader(ctx *context.Context, name string, val value.Value)
 		return true, nil
 	}
 	return false, nil
-
 }
+
 func SetWafVariables(ctx *context.Context, name, operator string, val value.Value) (bool, error) {
 	switch name {
 	case WAF_ANOMALY_SCORE:


### PR DESCRIPTION
Before this change, you could only set `bereq.http.{NAME}` in `vcl_fetch`, but Fastly allows it in `vcl_miss` and `vcl_pass` too. Source: https://developer.fastly.com/reference/vcl/variables/backend-request/bereq-http/