### PR TITLE
Support "return(pass)" in vcl_fetch

### DIFF
--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -543,7 +543,7 @@ func (i *Interpreter) ProcessFetch() error {
 	}
 
 	switch state {
-	case DELIVER, DELIVER_STALE:
+	case DELIVER, DELIVER_STALE, PASS:
 		i.Debugger.Message(fmt.Sprintf("Move state: %s -> DELIVER", i.ctx.Scope))
 		err = i.ProcessDeliver()
 	case ERROR:


### PR DESCRIPTION
Before this, calling `return(pass)` in `vcl_fetch` would trigger the error `[RuntimeException] Subroutine vcl_fetch returned unexpected state pass in FETCH`.

Per https://developer.fastly.com/reference/vcl/subroutines/fetch/, `return(pass)` should trigger a transition to `vcl_deliver`. AFAIK, the only difference between `return(pass)` and `return(deliver)` is the former creates a hit-for-pass cache object.