### PR TITLE
Propagate bare returns out of nested block statements

### DIFF
--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -60,7 +60,7 @@ func assertInterpreter(t *testing.T, vcl string, scope context.Scope, assertions
 			return
 		}
 		if diff := cmp.Diff(val, v); diff != "" {
-			t.Errorf("Value asserion error, diff: %s", diff)
+			t.Errorf("Value assertion error, diff: %s", diff)
 		}
 	}
 
@@ -77,7 +77,7 @@ func assertValue(t *testing.T, name string, expect, actual value.Value) {
 		return
 	}
 	if diff := cmp.Diff(expect, actual); diff != "" {
-		t.Errorf("Value asserion error, diff: %s", diff)
+		t.Errorf("Value assertion error, diff: %s", diff)
 	}
 }
 

--- a/interpreter/state.go
+++ b/interpreter/state.go
@@ -15,6 +15,7 @@ const (
 	LOG            State = "log"
 	END            State = "end"
 	INTERNAL_ERROR State = "_internal_error_"
+	BARE_RETURN    State = "_bare_return_"
 )
 
 func (s State) String() string {
@@ -41,6 +42,8 @@ func (s State) String() string {
 		return "end"
 	case INTERNAL_ERROR:
 		return "_internal_error_"
+	case BARE_RETURN:
+		return "_bare_return_"
 	default:
 		return ""
 	}

--- a/interpreter/statement.go
+++ b/interpreter/statement.go
@@ -127,6 +127,15 @@ func (i *Interpreter) ProcessBlockStatement(statements []ast.Statement, ds Debug
 			}
 			return ERROR, DebugPass, nil
 
+		case *ast.BlockStatement:
+			state, _, err := i.ProcessBlockStatement(t.Statements, debugState)
+			if err != nil {
+				return NONE, DebugPass, errors.WithStack(err)
+			}
+			if state != NONE {
+				return state, DebugPass, nil
+			}
+
 		// Others, no effects
 		case *ast.EsiStatement:
 			// Nothing to do, actually enable ESI in origin request


### PR DESCRIPTION
Adds the ability for the statement interpreter to differentiate between a block statement that was completed without a return and one that had a bare return `return;`.  This ensures that evaluation of a subroutine will end at the bare return and not continue after the nested block statement.

Additionally adds support for handling evaluation of bare block statements.

```
sub test {
  {
    log "I wasn't executed previously";
  }
}
```

Resolves #222 