### PR TITLE
Add sha1 to a set of identifiers

### DIFF
--- a/context/identifilers.go
+++ b/context/identifilers.go
@@ -32,6 +32,7 @@ func builtinIdentifiers() map[string]struct{} {
 		"sha256":  {},
 		"sha384":  {},
 		"sha512":  {},
+		"sha1":    {},
 
 		// use for digest.rsa_verify function base64_method argument
 		// https://developer.fastly.com/reference/vcl/functions/cryptographic/digest-rsa-verify/


### PR DESCRIPTION
The `digest.rsa_verify` accepts ID of a hash method as a first argument. All possible value are listed in `falco` except for the `sha1` which causes linter to produce an error on inputs that use it 

```vcl
if (digest.rsa_verify(sha1, {"-----BEGIN PUBLIC KEY-----
aabbccddIieEffggHHhEXAMPLEPUBLICKEY
-----END PUBLIC KEY-----"}, req.http.payload, req.http.digest, url_nopad)) {
  set req.http.verified = "Verified";
} else {
  set req.http.verified = "Not Verified";
}
error 900;
```

used to produce a linting error