### PR TITLE
Fix randomint(), randomint_seeded(), randombool(), and randombool_seeded()

### DIFF
--- a/interpreter/function/builtin/randombool.go
+++ b/interpreter/function/builtin/randombool.go
@@ -3,7 +3,6 @@
 package builtin
 
 import (
-	"math"
 	"math/rand"
 	"time"
 
@@ -41,10 +40,13 @@ func Randombool(ctx *context.Context, args ...value.Value) (value.Value, error) 
 	numerator := value.Unwrap[*value.Integer](args[0])
 	denominator := value.Unwrap[*value.Integer](args[1])
 
-	rand.Seed(time.Now().UnixNano())
-	r := rand.Int63n(math.MaxInt64)
+	if denominator.Value <= 0 {
+		return &value.Boolean{Value: false}, nil
+	}
 
-	return &value.Boolean{
-		Value: r/math.MaxInt64 < numerator.Value/denominator.Value,
-	}, nil
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	rv := r.Float64()
+	ratio := float64(numerator.Value) / float64(denominator.Value)
+
+	return &value.Boolean{Value: rv < ratio}, nil
 }

--- a/interpreter/function/builtin/randombool_seeded.go
+++ b/interpreter/function/builtin/randombool_seeded.go
@@ -3,7 +3,6 @@
 package builtin
 
 import (
-	"math"
 	"math/rand"
 
 	"github.com/ysugimoto/falco/interpreter/context"
@@ -41,10 +40,13 @@ func Randombool_seeded(ctx *context.Context, args ...value.Value) (value.Value, 
 	denominator := value.Unwrap[*value.Integer](args[1])
 	seed := value.Unwrap[*value.Integer](args[2])
 
-	rand.Seed(seed.Value)
-	r := rand.Int63n(math.MaxInt64)
+	if denominator.Value <= 0 {
+		return &value.Boolean{Value: false}, nil
+	}
 
-	return &value.Boolean{
-		Value: r/math.MaxInt64 < numerator.Value/denominator.Value,
-	}, nil
+	r := rand.New(rand.NewSource(seed.Value))
+	rv := r.Float64()
+	ratio := float64(numerator.Value) / float64(denominator.Value)
+
+	return &value.Boolean{Value: rv < ratio}, nil
 }

--- a/interpreter/function/builtin/randombool_seeded_test.go
+++ b/interpreter/function/builtin/randombool_seeded_test.go
@@ -15,13 +15,17 @@ import (
 // Reference: https://developer.fastly.com/reference/vcl/functions/randomness/randombool-seeded/
 func Test_Randombool_seeded(t *testing.T) {
 	tests := []struct {
-		n int64
-		d int64
-		s int64
+		n      int64
+		d      int64
+		s      int64
+		expect bool
 	}{
-		{n: 1, d: 10, s: 1000000},
-		{n: 3, d: 4, s: 1111111},
-		{n: 5, d: 10, s: 2222222},
+		{n: 1, d: 10, s: 1000000, expect: false},
+		{n: 1, d: 10, s: 1000006, expect: true},
+		{n: 3, d: 4, s: 1111107, expect: false},
+		{n: 3, d: 4, s: 1111119, expect: true},
+		{n: 5, d: 10, s: 2222222, expect: true},
+		{n: 5, d: 0, s: 2222222, expect: false},
 	}
 
 	for i, tt := range tests {
@@ -36,6 +40,10 @@ func Test_Randombool_seeded(t *testing.T) {
 		}
 		if ret.Type() != value.BooleanType {
 			t.Errorf("[%d] Unexpected return type, expect=STRING, got=%s", i, ret.Type())
+		}
+		v := value.Unwrap[*value.Boolean](ret)
+		if v.Value != tt.expect {
+			t.Errorf("[%d] Unexpected return value, expect=%t, got=%t", i, tt.expect, v.Value)
 		}
 	}
 }

--- a/interpreter/function/builtin/randombool_test.go
+++ b/interpreter/function/builtin/randombool_test.go
@@ -21,6 +21,7 @@ func Test_Randombool(t *testing.T) {
 		{n: 1, d: 10},
 		{n: 3, d: 4},
 		{n: 5, d: 10},
+		{n: 5, d: 0},
 	}
 
 	for i, tt := range tests {

--- a/interpreter/function/builtin/randomint.go
+++ b/interpreter/function/builtin/randomint.go
@@ -40,10 +40,10 @@ func Randomint(ctx *context.Context, args ...value.Value) (value.Value, error) {
 	from := value.Unwrap[*value.Integer](args[0])
 	to := value.Unwrap[*value.Integer](args[1])
 
-	rand.Seed(time.Now().UnixNano())
-	r := rand.Int63n(to.Value - from.Value)
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	rand_value := r.Int63n(to.Value - from.Value + 1)
 
 	return &value.Integer{
-		Value: r + from.Value,
+		Value: rand_value + from.Value,
 	}, nil
 }

--- a/interpreter/function/builtin/randomint.go
+++ b/interpreter/function/builtin/randomint.go
@@ -41,9 +41,9 @@ func Randomint(ctx *context.Context, args ...value.Value) (value.Value, error) {
 	to := value.Unwrap[*value.Integer](args[1])
 
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	rand_value := r.Int63n(to.Value - from.Value + 1)
+	rv := r.Int63n(to.Value - from.Value + 1)
 
 	return &value.Integer{
-		Value: rand_value + from.Value,
+		Value: rv + from.Value,
 	}, nil
 }

--- a/interpreter/function/builtin/randomint_seeded.go
+++ b/interpreter/function/builtin/randomint_seeded.go
@@ -41,9 +41,9 @@ func Randomint_seeded(ctx *context.Context, args ...value.Value) (value.Value, e
 	seed := value.Unwrap[*value.Integer](args[2])
 
 	r := rand.New(rand.NewSource(seed.Value))
-	rand_value := r.Int63n(to.Value - from.Value + 1)
+	rv := r.Int63n(to.Value - from.Value + 1)
 
 	return &value.Integer{
-		Value: rand_value + from.Value,
+		Value: rv + from.Value,
 	}, nil
 }

--- a/interpreter/function/builtin/randomint_seeded.go
+++ b/interpreter/function/builtin/randomint_seeded.go
@@ -40,10 +40,10 @@ func Randomint_seeded(ctx *context.Context, args ...value.Value) (value.Value, e
 	to := value.Unwrap[*value.Integer](args[1])
 	seed := value.Unwrap[*value.Integer](args[2])
 
-	rand.Seed(seed.Value)
-	r := rand.Int63n(to.Value - from.Value)
+	r := rand.New(rand.NewSource(seed.Value))
+	rand_value := r.Int63n(to.Value - from.Value + 1)
 
 	return &value.Integer{
-		Value: r + from.Value,
+		Value: rand_value + from.Value,
 	}, nil
 }

--- a/interpreter/function/builtin/randomint_seeded_test.go
+++ b/interpreter/function/builtin/randomint_seeded_test.go
@@ -15,32 +15,33 @@ import (
 // Reference: https://developer.fastly.com/reference/vcl/functions/randomness/randomint-seeded/
 func Test_Randomint_seeded(t *testing.T) {
 	tests := []struct {
-		from int64
-		to   int64
-		seed int64
+		from   int64
+		to     int64
+		expect int64
+		seed   int64
 	}{
-		{from: 0, to: 99, seed: 1000000},
-		{from: -1, to: 0, seed: 1000000},
+		{from: 0, to: 99, expect: 53, seed: 1000000},
+		{from: 0, to: 99, expect: 2, seed: 1000001},
+		{from: -1, to: 0, expect: 0, seed: 1000000},
+		{from: -1, to: 0, expect: -1, seed: 1000001},
 	}
 
 	for i, tt := range tests {
-		for j := 0; j < 10000; j++ {
-			ret, err := Randomint_seeded(
-				&context.Context{},
-				&value.Integer{Value: tt.from},
-				&value.Integer{Value: tt.to},
-				&value.Integer{Value: tt.seed},
-			)
-			if err != nil {
-				t.Errorf("[%d] Unexpected error: %s", i, err)
-			}
-			if ret.Type() != value.IntegerType {
-				t.Errorf("[%d] Unexpected return type, expect=STRING, got=%s", i, ret.Type())
-			}
-			v := value.Unwrap[*value.Integer](ret)
-			if v.Value < tt.from || v.Value > tt.to {
-				t.Errorf("[%d] Unexpected return value, value is not in range from %d to %d", i, tt.from, tt.to)
-			}
+		ret, err := Randomint_seeded(
+			&context.Context{},
+			&value.Integer{Value: tt.from},
+			&value.Integer{Value: tt.to},
+			&value.Integer{Value: tt.seed},
+		)
+		if err != nil {
+			t.Errorf("[%d] Unexpected error: %s", i, err)
+		}
+		if ret.Type() != value.IntegerType {
+			t.Errorf("[%d] Unexpected return type, expect=STRING, got=%s", i, ret.Type())
+		}
+		v := value.Unwrap[*value.Integer](ret)
+		if v.Value != tt.expect {
+			t.Errorf("[%d] Unexpected return value, expect=%d, got=%d", i, tt.expect, v.Value)
 		}
 	}
 }

--- a/interpreter/function/builtin/randomint_seeded_test.go
+++ b/interpreter/function/builtin/randomint_seeded_test.go
@@ -24,6 +24,7 @@ func Test_Randomint_seeded(t *testing.T) {
 		{from: 0, to: 99, expect: 2, seed: 1000001},
 		{from: -1, to: 0, expect: 0, seed: 1000000},
 		{from: -1, to: 0, expect: -1, seed: 1000001},
+		{from: 0, to: 0, expect: 0, seed: 0},
 	}
 
 	for i, tt := range tests {

--- a/interpreter/function/builtin/randomint_test.go
+++ b/interpreter/function/builtin/randomint_test.go
@@ -20,6 +20,7 @@ func Test_Randomint(t *testing.T) {
 	}{
 		{from: 0, to: 99},
 		{from: -1, to: 0},
+		{from: 0, to: 0},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
The [rand.Int63n(n)](https://pkg.go.dev/math/rand#Rand.Int63n) function returns an integer in the range `[0, n)`, but [randomint(from, to)](https://developer.fastly.com/reference/vcl/functions/randomness/randomint/) returns an integer in the range `[from, to]`. Therefore, we need to add one to `n` to get the full range.

I also discovered `randombool()` and `randombool_seeded() always return false because `numerator.Value/denominator.Value` is always 0 due to floor division, so I fixed that too.

Finally, I fixed several calls to the deprecated [rand.Seed()](https://pkg.go.dev/math/rand#Seed) function.