### PR TITLE
Fix assigning RTIME literal to RTIME variable

### DIFF
--- a/interpreter/assign/assign.go
+++ b/interpreter/assign/assign.go
@@ -164,9 +164,6 @@ func Assign(left, right value.Value) error {
 			rv := value.Unwrap[*value.Float](right)
 			lv.Value = time.Duration(rv.Value)
 		case value.RTimeType: // RTIME = RTIME
-			if right.IsLiteral() {
-				return errors.WithStack(fmt.Errorf("RTIME literal could not assign to RTIME"))
-			}
 			rv := value.Unwrap[*value.RTime](right)
 			lv.Value = rv.Value
 		case value.TimeType: // RTIME = TIME

--- a/interpreter/assign/assign.go
+++ b/interpreter/assign/assign.go
@@ -191,9 +191,6 @@ func Assign(left, right value.Value) error {
 			rv := value.Unwrap[*value.Float](right)
 			lv.Value = time.Unix(int64(rv.Value), 0)
 		case value.RTimeType: // TIME = RTIME
-			if right.IsLiteral() {
-				return errors.WithStack(fmt.Errorf("RTIME literal could not assign to TIME"))
-			}
 			rv := value.Unwrap[*value.RTime](right)
 			lv.Value = time.Unix(int64(rv.Value.Seconds()), 0)
 		case value.TimeType: // TIME = TIME

--- a/interpreter/assign/assign_test.go
+++ b/interpreter/assign/assign_test.go
@@ -140,7 +140,7 @@ func TestProcessAssignment(t *testing.T) {
 			{left: 1, right: &value.String{Value: "example"}, isError: true},
 			{left: 1, right: &value.String{Value: "example", Literal: true}, isError: true},
 			{left: 1, right: &value.RTime{Value: 100 * time.Second}, expect: 100 * time.Second},
-			{left: 1, right: &value.RTime{Value: 100 * time.Second, Literal: true}, expect: 0, isError: true},
+			{left: 1, right: &value.RTime{Value: 100 * time.Second, Literal: true}, expect: 100 * time.Second},
 			{left: 1, right: &value.Time{Value: now}, expect: time.Duration(now.Unix())},
 			{left: 10, right: &value.Backend{Value: &ast.BackendDeclaration{Name: &ast.Ident{Value: "foo"}}}, isError: true},
 			{left: 10, right: &value.Boolean{Value: true}, isError: true},

--- a/interpreter/assign/assign_test.go
+++ b/interpreter/assign/assign_test.go
@@ -179,7 +179,7 @@ func TestProcessAssignment(t *testing.T) {
 			{left: now, right: &value.String{Value: "example"}, isError: true},
 			{left: now, right: &value.String{Value: "example", Literal: true}, isError: true},
 			{left: now, right: &value.RTime{Value: 100 * time.Second}, expect: time.Unix(int64((100 * time.Second).Seconds()), 0)},
-			{left: now, right: &value.RTime{Value: 100 * time.Second, Literal: true}, isError: true},
+			{left: now, right: &value.RTime{Value: 100 * time.Second, Literal: true}, expect: time.Unix(int64((100 * time.Second).Seconds()), 0)},
 			{left: now, right: &value.Time{Value: now2}, expect: now2},
 			{left: now, right: &value.Backend{Value: &ast.BackendDeclaration{Name: &ast.Ident{Value: "foo"}}}, isError: true},
 			{left: now, right: &value.Boolean{Value: true}, isError: true},


### PR DESCRIPTION
Currently, trying to assign an RTIME literal to an RTIME variable (e.g. `beresp.ttl`) triggers the error "RTIME literal could not assign to RTIME". However, the linter allows this:
https://github.com/ysugimoto/falco/blob/87715d639b5e292cce09cb63a0fbdb8276f3e038/linter/operator.go#L56-L60

I double-checked using Fiddle: https://fiddle.fastly.dev/fiddle/fe4fb73d