### PR TITLE
User defined function fixes

### DIFF
--- a/__generator__/interpreter.go
+++ b/__generator__/interpreter.go
@@ -330,7 +330,7 @@ var typeMap = map[string]string{
 	"TABLE":   "value.IdentType",
 	"STRING":  "value.StringType",
 	"IP":      "value.IpType",
-	"BOOLEAN": "value.BooleanType",
+	"BOOL":    "value.BooleanType",
 	"INTEGER": "value.IntegerType",
 	"FLOAT":   "value.FloatType",
 	"RTIME":   "value.RTimeType",

--- a/interpreter/expression_test.go
+++ b/interpreter/expression_test.go
@@ -321,6 +321,17 @@ func TestProcessExpression(t *testing.T) {
 			},
 			isError: false,
 		},
+		{
+			name: "User defined function call expression",
+			vcl: `sub bool_fn BOOL { return true; }
+				sub vcl_recv {
+					set req.http.foo = bool_fn();
+				}`,
+			assertions: map[string]value.Value{
+				"req.http.foo": &value.String{Value: "1"},
+			},
+			isError: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/interpreter/statement.go
+++ b/interpreter/statement.go
@@ -349,20 +349,12 @@ func (i *Interpreter) ProcessSyntheticBase64Statement(stmt *ast.SyntheticBase64S
 }
 
 func (i *Interpreter) ProcessFunctionCallStatement(stmt *ast.FunctionCallStatement, ds DebugState) (State, error) {
-	if sub, ok := i.ctx.SubroutineFunctions[stmt.Function.Value]; ok {
-		if len(stmt.Arguments) > 0 {
-			return NONE, exception.Runtime(
-				&stmt.GetMeta().Token,
-				"Function subroutine %s could not accept any arguments",
-				stmt.Function.Value,
-			)
-		}
-		// Functional subroutine may change status
-		_, s, err := i.ProcessFunctionSubroutine(sub, ds)
-		if err != nil {
-			return s, errors.WithStack(err)
-		}
-		return s, nil
+	if _, ok := i.ctx.SubroutineFunctions[stmt.Function.Value]; ok {
+		return NONE, exception.Runtime(
+			&stmt.GetMeta().Token,
+			"User defined function %s cannot be called as a statement",
+			stmt.Function.Value,
+		)
 	}
 
 	// Builtin function will not change any state

--- a/interpreter/statement.go
+++ b/interpreter/statement.go
@@ -386,7 +386,7 @@ func (i *Interpreter) ProcessFunctionCallStatement(stmt *ast.FunctionCallStateme
 			// This is because some function uses collection value like req.http.Cookie as ID type,
 			// But the processor passes *value.String as primitive value normally.
 			// In order to treat collection value inside, enthruse with the function logic how value is treated as correspond types.
-			if ident, ok := stmt.Arguments[j].(*ast.Ident); !ok {
+			if ident, ok := stmt.Arguments[j].(*ast.Ident); ok {
 				args[j] = &value.Ident{Value: ident.Value}
 			} else {
 				return NONE, exception.Runtime(

--- a/interpreter/value/value.go
+++ b/interpreter/value/value.go
@@ -20,7 +20,7 @@ const (
 	IntegerType Type = "INTEGER"
 	FloatType   Type = "FLOAT"
 	StringType  Type = "STRING"
-	BooleanType Type = "BOOLEAN"
+	BooleanType Type = "BOOL"
 	RTimeType   Type = "RTIME"
 	TimeType    Type = "TIME"
 	IpType      Type = "IP"

--- a/linter/helper.go
+++ b/linter/helper.go
@@ -116,7 +116,6 @@ var ValueTypeMap = map[string]types.Type{
 	"BACKEND": types.BackendType,
 	"IP":      types.IPType,
 	"STRING":  types.StringType,
-	"ID":      types.IDType,
 	"RTIME":   types.RTimeType,
 	"TIME":    types.TimeType,
 }

--- a/linter/helper.go
+++ b/linter/helper.go
@@ -108,18 +108,6 @@ var DirectorPropertyTypes = map[string]DirectorProps{
 	},
 }
 
-var ValueTypeMap = map[string]types.Type{
-	"INTEGER": types.IntegerType,
-	"FLOAT":   types.FloatType,
-	"BOOL":    types.BoolType,
-	"ACL":     types.AclType,
-	"BACKEND": types.BackendType,
-	"IP":      types.IPType,
-	"STRING":  types.StringType,
-	"RTIME":   types.RTimeType,
-	"TIME":    types.TimeType,
-}
-
 func isAlphaNumeric(r rune) bool {
 	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_'
 }

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -443,7 +443,7 @@ func (l *Linter) factoryRootDeclarations(statements []ast.Statement, ctx *contex
 			if t.ValueType == nil {
 				table.ValueType = types.StringType // default as STRING (e.g. Edge Dictionary)
 			} else {
-				v, ok := ValueTypeMap[t.ValueType.Value]
+				v, ok := types.ValueTypeMap[t.ValueType.Value]
 				if !ok {
 					l.Error(UndefinedTableType(
 						t.ValueType.GetMeta(), t.Name.Value, t.ValueType.Value,
@@ -473,7 +473,7 @@ func (l *Linter) factoryRootDeclarations(statements []ast.Statement, ctx *contex
 					l.Error(err.Match(SUBROUTINE_INVALID_RETURN_TYPE))
 				}
 
-				returnType, ok := ValueTypeMap[t.ReturnType.Value]
+				returnType, ok := types.ValueTypeMap[t.ReturnType.Value]
 				if !ok {
 					err := &LintError{
 						Severity: ERROR,
@@ -760,7 +760,7 @@ func (l *Linter) lintTableDeclaration(decl *ast.TableDeclaration, ctx *context.C
 	var valueType types.Type
 	if decl.ValueType == nil {
 		valueType = types.StringType
-	} else if v, ok := ValueTypeMap[decl.ValueType.Value]; ok {
+	} else if v, ok := types.ValueTypeMap[decl.ValueType.Value]; ok {
 		valueType = v
 	}
 
@@ -813,7 +813,7 @@ func (l *Linter) lintSubRoutineDeclaration(decl *ast.SubroutineDeclaration, ctx 
 	scope := getSubroutineCallScope(decl)
 	var cc *context.Context
 	if decl.ReturnType != nil {
-		returnType := ValueTypeMap[decl.ReturnType.Value]
+		returnType := types.ValueTypeMap[decl.ReturnType.Value]
 		cc = ctx.UserDefinedFunctionScope(decl.Name.Value, scope, returnType)
 	} else {
 		cc = ctx.Scope(scope)
@@ -987,7 +987,7 @@ func (l *Linter) lintDeclareStatement(stmt *ast.DeclareStatement, ctx *context.C
 		l.Error(err.Match(DECLARE_STATEMENT_SYNTAX))
 	}
 
-	vt, ok := ValueTypeMap[stmt.ValueType.Value]
+	vt, ok := types.ValueTypeMap[stmt.ValueType.Value]
 	if !ok {
 		err := &LintError{
 			Severity: ERROR,

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -480,7 +480,7 @@ sub baz {
 	declare local var.item2 INTEGER;
 	declare local var.item3 FLOAT;
 	declare local var.item4 IP;
-	declare local var.item5 ID;
+	declare local var.item5 BOOL;
 	declare local var.item6 ACL;
 	declare local var.item7 BACKEND;
 
@@ -488,7 +488,7 @@ sub baz {
 	set var.item2 = 1;
 	set var.item3 = 1.0;
 	set var.item4 = std.ip("192.168.0.1", "192.168.0.2");
-	set var.item5 = always;
+	set var.item5 = true;
 	set var.item6 = foo;
 	set var.item7 = bar;
 

--- a/tester/function/assert_equal_fold_test.go
+++ b/tester/function/assert_equal_fold_test.go
@@ -165,7 +165,7 @@ func Test_Assert_equal_fold(t *testing.T) {
 		}
 	})
 
-	t.Run("BOOLEAN", func(t *testing.T) {
+	t.Run("BOOL", func(t *testing.T) {
 		v := &value.Boolean{Value: true}
 		tests := []testSuite{
 			{compare: value.Null, err: assertionError},

--- a/tester/function/assert_equal_test.go
+++ b/tester/function/assert_equal_test.go
@@ -170,7 +170,7 @@ func Test_Assert_equal(t *testing.T) {
 		}
 	})
 
-	t.Run("BOOLEAN", func(t *testing.T) {
+	t.Run("BOOL", func(t *testing.T) {
 		v := &value.Boolean{Value: true}
 		tests := []testSuite{
 			{compare: value.Null, err: assertionError},

--- a/tester/function/assert_not_equal_test.go
+++ b/tester/function/assert_not_equal_test.go
@@ -164,7 +164,7 @@ func Test_Assert_not_equal(t *testing.T) {
 		}
 	})
 
-	t.Run("BOOLEAN", func(t *testing.T) {
+	t.Run("BOOL", func(t *testing.T) {
 		v := &value.Boolean{Value: true}
 		tests := []testSuite{
 			{compare: value.Null, err: assertionError},

--- a/types/types.go
+++ b/types/types.go
@@ -42,6 +42,18 @@ const (
 	ReqBackendType Type = 0x100000000010000
 )
 
+var ValueTypeMap = map[string]Type{
+	"INTEGER": IntegerType,
+	"FLOAT":   FloatType,
+	"BOOL":    BoolType,
+	"ACL":     AclType,
+	"BACKEND": BackendType,
+	"IP":      IPType,
+	"STRING":  StringType,
+	"RTIME":   RTimeType,
+	"TIME":    TimeType,
+}
+
 func (t Type) String() string {
 	switch t {
 	case NeverType:


### PR DESCRIPTION
## Unable to call user defined functions

The primary issue this PR addresses is the fact that currently user defined functions with return values can't be called in tests or in the simulator. The interpreter returns an error `Function <name> is not defined`.

### Example

`main.vcl`
```
backend dummy {
    .host = "localhost";
}

// @scope: recv
sub bool_fn BOOL {
    return true;
}

sub vcl_recv {
    set req.http.foo = "0";
    if (bool_fn()) {
        set req.http.foo = "1";
    }
}
```

`main.test.vcl`
```
// @scope: recv
sub test {
    testing.call_subroutine("vcl_recv");
    assert.equal(req.http.foo, "1");
}
```

`falco test main.vcl`
```
Running tests... Done.
 FAIL  main.test.vcl
  ●  [RECV] test

    Function bool_fn is not defined

    1| sub test {
    2|     testing.call_subroutine("vcl_recv");
    3|     assert.equal(req.http.foo, "1");

0 passed, 1 failed, 1 total, 0 assertions
```

While fixing this issue I discovered some related issues with function handling.

## Additional fixes

### Boolean values stored with type name inconsistent with VCL BOOL

Returning a bool value from a function with a BOOL return type caused a runtime exception due to the mismatch between the return type name `BOOL` and the bool value type name `BOOLEAN`.

```
[RuntimeException] Invalid return type, expects=BOOL, but got=BOOLEAN in main.vcl at line: 7, position: 5
```

### Builtin functions with ID arguments

Builtin functions that take an ID as their first argument failed when statement called.

```
sub vcl_recv {
    header.set(req, "foo", "bar");
}
```

```
[RuntimeException] Function header.set of 0 argument must be an Ident in main.vcl at line: 11, position: 5
```

### User defined functions cannot be statement called

VCL does not permit user defined functions to have VOID return type and so they can't be statement called.

```
sub foo BOOL { return true; }
sub vcl_recv {
    foo(); // should be an error
}
```

https://fiddle.fastly.dev/fiddle/c0c4010b

### ID is not a value type

VCL does not allow the ID type to be used as a variable or function return type.

```
sub foo ID { return req; } // should be an error
sub vcl_recv {
    declare local var.bar ID; // should be an error
    var.bar = req;
}
```

https://fiddle.fastly.dev/fiddle/e07db67d

