### PR TITLE
implement table manipulation testing functions

### DIFF
--- a/cmd/falco/runner.go
+++ b/cmd/falco/runner.go
@@ -475,10 +475,8 @@ func (r *Runner) Test(rslv resolver.Resolver) (*tester.TestFactory, error) {
 		options = append(options, icontext.WithOverrideHost(tc.OverrideHost))
 	}
 
-	i := interpreter.New(options...)
 	r.message(white, "Running tests...")
-	i.Debugger = tester.NewDebugger()
-	factory, err := tester.New(tc, i).Run(r.config.Commands.At(1))
+	factory, err := tester.New(tc, options).Run(r.config.Commands.At(1))
 	if err != nil {
 		writeln(red, " Failed.")
 		writeln(red, "Failed to run test: %s", err.Error())

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -162,6 +162,8 @@ We describe them following table and examples:
 | testing.fixed_time      | FUNCTION   | Use fixed time whole the test suite                                                          |
 | testing.override_host   | FUNCTION   | Override request host with provided argument in the test case                                |
 | testing.inspect         | FUNCTION   | Inspect predefined variables for any scopes                                                  |
+| testing.table_set       | FUNCTION   | Inject value for key to main VCL table                                                       |
+| testing.table_merge     | FUNCTION   | Merge values from testing VCL table to main VCL table                                        |
 | assert                  | FUNCTION   | Assert provided expression should be true                                                    |
 | assert.true             | FUNCTION   | Assert actual value should be true                                                           |
 | assert.false            | FUNCTION   | Assert actual value should be false                                                          |
@@ -263,6 +265,53 @@ sub test_vcl {
     // Typically obj.status could not access in recv scope,
     // but can inspect via this function.
     assert.equal(testing.inspect("obj.status"), 400);
+}
+```
+
+----
+
+### testing.table_set(ID table, STRING key, STRING value)
+
+Inject value for key to main VCL table.
+
+```vcl
+// @scope: recv
+sub test_vcl {
+    // Inject table value
+    testing.table_set(example_dict, "foo", "bar");
+
+    // call vcl_recv Fastly reserved subroutine in RECV scope,
+    // will call error statement in this subroutine.
+    testing.call_subroutine("vcl_recv");
+
+    // Assert injected value
+    assert.equal(table.lookup(example_dict, "foo", ""), "bar");
+}
+```
+
+----
+
+### testing.table_merge(ID base, ID merge)
+
+Merge values from testing VCL table to main VCL table.
+
+```vcl
+
+table merge_dict {
+    "foo": "bar",
+}
+
+// @scope: recv
+sub test_vcl {
+    // Merge table value
+    testing.table_merge(example_dict, merge_dict);
+
+    // call vcl_recv Fastly reserved subroutine in RECV scope,
+    // will call error statement in this subroutine.
+    testing.call_subroutine("vcl_recv");
+
+    // Assert injected value
+    assert.equal(table.lookup(example_dict, "foo", ""), "bar");
 }
 ```
 

--- a/examples/testing/table_manipulation.test.vcl
+++ b/examples/testing/table_manipulation.test.vcl
@@ -1,0 +1,19 @@
+table test_example {
+  "foo": "bar"
+}
+
+// @scope: recv
+sub test_table_set {
+  testing.table_set(example, "foo", "bar");
+
+  testing.call_subroutine("vcl_recv");
+  assert.equal(req.http.Foo, "bar");
+}
+
+// @scope: recv
+sub test_table_merge {
+  testing.table_merge(example, test_example);
+
+  testing.call_subroutine("vcl_recv");
+  assert.equal(req.http.Foo, "bar");
+}

--- a/examples/testing/table_manipulation.vcl
+++ b/examples/testing/table_manipulation.vcl
@@ -1,0 +1,6 @@
+// Will be set via testing function
+table example {}
+
+sub vcl_recv {
+  set req.http.Foo = table.lookup(example, "foo", "");
+}

--- a/interpreter/expression.go
+++ b/interpreter/expression.go
@@ -15,6 +15,14 @@ import (
 )
 
 func (i *Interpreter) IdentValue(val string, withCondition bool) (value.Value, error) {
+	// Extra lookups identity - call additional ident finder if defined
+	// This feature is implemented for testing, typically we do not use for interpreter working
+	if i.IdentFinder != nil {
+		if v := i.IdentFinder(val); v != nil {
+			return v, nil
+		}
+	}
+
 	if v, ok := i.ctx.Backends[val]; ok {
 		return v, nil
 	} else if v, ok := i.ctx.Acls[val]; ok {

--- a/interpreter/expression.go
+++ b/interpreter/expression.go
@@ -17,8 +17,8 @@ import (
 func (i *Interpreter) IdentValue(val string, withCondition bool) (value.Value, error) {
 	// Extra lookups identity - call additional ident finder if defined
 	// This feature is implemented for testing, typically we do not use for interpreter working
-	if i.IdentFinder != nil {
-		if v := i.IdentFinder(val); v != nil {
+	if i.IdentResolver != nil {
+		if v := i.IdentResolver(val); v != nil {
 			return v, nil
 		}
 	}

--- a/interpreter/function/function.go
+++ b/interpreter/function/function.go
@@ -29,14 +29,9 @@ func Exists(scope context.Scope, name string) (*Function, error) {
 	return fn, nil
 }
 
-func Inject(fns map[string]*Function) error {
+func Inject(fns map[string]*Function) {
+	// Always override existing functions
 	for key, fn := range fns {
-		if _, ok := builtinFunctions[key]; ok {
-			return errors.WithStack(
-				fmt.Errorf("Function %s already defiend and could not override", key),
-			)
-		}
 		builtinFunctions[key] = fn
 	}
-	return nil
 }

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -27,10 +27,11 @@ type Interpreter struct {
 
 	options []context.Option
 
-	ctx      *context.Context
-	process  *process.Process
-	cache    *cache.Cache
-	Debugger Debugger
+	ctx         *context.Context
+	process     *process.Process
+	cache       *cache.Cache
+	Debugger    Debugger
+	IdentFinder func(v string) value.Value
 }
 
 func New(options ...context.Option) *Interpreter {

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -27,11 +27,11 @@ type Interpreter struct {
 
 	options []context.Option
 
-	ctx         *context.Context
-	process     *process.Process
-	cache       *cache.Cache
-	Debugger    Debugger
-	IdentFinder func(v string) value.Value
+	ctx           *context.Context
+	process       *process.Process
+	cache         *cache.Cache
+	Debugger      Debugger
+	IdentResolver func(v string) value.Value
 }
 
 func New(options ...context.Option) *Interpreter {

--- a/interpreter/testing.go
+++ b/interpreter/testing.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/interpreter/value"
 )
 
 const testBackendResponseBody = "falco_test_response"
@@ -15,6 +17,28 @@ func (i *Interpreter) TestProcessInit(r *http.Request) error {
 	var err error
 	if err = i.ProcessInit(r); err != nil {
 		return errors.WithStack(err)
+	}
+
+	// If backend is not defined in main VCL, set default or virual backend
+	if len(i.ctx.Backends) > 0 {
+		// pick first backend
+		for _, v := range i.ctx.Backends {
+			i.ctx.Backend = v
+			break
+		}
+	} else {
+		// Set virtual backend
+		i.ctx.Backend = &value.Backend{
+			Value: &ast.BackendDeclaration{
+				Name: &ast.Ident{Value: "falco_testing_backend"},
+				Properties: []*ast.BackendProperty{
+					{
+						Key:   &ast.Ident{Value: "host"},
+						Value: &ast.String{Value: "http://localhost:3124"},
+					},
+				},
+			},
+		}
 	}
 
 	// On testing process, all request/response variables should be set initially

--- a/interpreter/testing.go
+++ b/interpreter/testing.go
@@ -19,18 +19,11 @@ func (i *Interpreter) TestProcessInit(r *http.Request) error {
 		return errors.WithStack(err)
 	}
 
-	// If backend is not defined in main VCL, set default or virual backend
-	if len(i.ctx.Backends) > 0 {
-		// pick first backend
-		for _, v := range i.ctx.Backends {
-			i.ctx.Backend = v
-			break
-		}
-	} else {
-		// Set virtual backend
+	// If backend is not defined in main VCL, set virual backend
+	if i.ctx.Backend == nil {
 		i.ctx.Backend = &value.Backend{
 			Value: &ast.BackendDeclaration{
-				Name: &ast.Ident{Value: "falco_testing_backend"},
+				Name: &ast.Ident{Value: "falco_local_backend"},
 				Properties: []*ast.BackendProperty{
 					{
 						Key:   &ast.Ident{Value: "host"},

--- a/tester/function/testing_table_merge.go
+++ b/tester/function/testing_table_merge.go
@@ -1,0 +1,88 @@
+package function
+
+import (
+	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/function/errors"
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+const Testing_table_merge_Name = "testing.table_merge"
+
+var Testing_table_merge_ArgumentTypes = []value.Type{value.IdentType, value.IdentType}
+
+func Testing_table_merge_Validate(args []value.Value) error {
+	if len(args) != 2 {
+		return errors.ArgumentNotEnough(Testing_table_merge_Name, 3, args)
+	}
+
+	for i := range Testing_table_merge_ArgumentTypes {
+		if args[i].Type() != Testing_table_merge_ArgumentTypes[i] {
+			return errors.TypeMismatch(
+				Testing_table_merge_Name, i+1, Testing_table_merge_ArgumentTypes[i], args[i].Type(),
+			)
+		}
+	}
+	return nil
+}
+
+func Testing_table_merge(
+	ctx *context.Context,
+	defs *Definiions,
+	args ...value.Value,
+) (value.Value, error) {
+
+	if err := Testing_table_merge_Validate(args); err != nil {
+		return nil, errors.NewTestingError(err.Error())
+	}
+
+	baseTable := value.Unwrap[*value.Ident](args[0]).Value
+	base, baseOK := ctx.Tables[baseTable]
+	if !baseOK {
+		return value.Null, errors.NewTestingError("table %s not found in VCL", baseTable)
+	}
+	mergeTable := value.Unwrap[*value.Ident](args[1]).Value
+	merge, mergeOK := defs.Tables[mergeTable]
+	if !mergeOK {
+		return value.Null, errors.NewTestingError("table %s not found in testing VCL", mergeTable)
+	}
+	if err := Testing_table_merge_CompareType(base, merge); err != nil {
+		return value.Null, err
+	}
+
+	// Merge table fields
+	for i := range merge.Properties {
+		Testing_table_MergeProperty(base, merge.Properties[i])
+	}
+
+	return value.Null, nil
+}
+
+func Testing_table_merge_CompareType(base, merge *ast.TableDeclaration) error {
+	baseType := "STRING" // nolint: goconst
+	if base.ValueType != nil {
+		baseType = base.ValueType.Value
+	}
+	mergeType := "STRING" // nolint: goconst
+	if merge.ValueType != nil {
+		mergeType = merge.ValueType.Value
+	}
+
+	if baseType != mergeType {
+		return errors.NewTestingError("table type mismatch. merge %s type into %s", mergeType, baseType)
+	}
+	return nil
+}
+
+func Testing_table_MergeProperty(base *ast.TableDeclaration, prop *ast.TableProperty) {
+	for i := range base.Properties {
+		// Check the same field name and replace it if found
+		if base.Properties[i].Key.Value == prop.Key.Value {
+			base.Properties[i] = prop
+			return
+		}
+	}
+
+	// Append property
+	base.Properties = append(base.Properties, prop)
+}

--- a/tester/function/testing_table_merge_test.go
+++ b/tester/function/testing_table_merge_test.go
@@ -1,0 +1,208 @@
+package function
+
+import (
+	"testing"
+
+	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/value"
+	"github.com/ysugimoto/falco/lexer"
+	"github.com/ysugimoto/falco/parser"
+)
+
+func Test_table_merge(t *testing.T) {
+
+	t.Run("Enable merge table (append)", func(t *testing.T) {
+		main := `
+table example {
+  "foo": "bar",
+}
+`
+		test := `
+table test_example {
+  "dog": "bark",
+}
+`
+		vcl, err := parser.New(lexer.NewFromString(main)).ParseVCL()
+		if err != nil {
+			t.Errorf("Parse error for main VCL: %s", err)
+		}
+		table := vcl.Statements[0].(*ast.TableDeclaration)
+		c := &context.Context{
+			Tables: map[string]*ast.TableDeclaration{
+				table.Name.Value: table,
+			},
+		}
+		testVCL, err := parser.New(lexer.NewFromString(test)).ParseVCL()
+		if err != nil {
+			t.Errorf("Parse error for test VCL: %s", err)
+		}
+		testTable := testVCL.Statements[0].(*ast.TableDeclaration)
+		_, err = Testing_table_merge(
+			c,
+			&Definiions{
+				Tables: map[string]*ast.TableDeclaration{
+					testTable.Name.Value: testTable,
+				},
+			},
+			&value.Ident{Value: "example"},
+			&value.Ident{Value: "test_example"},
+		)
+		if err != nil {
+			t.Errorf("Error should be nil, got: %s", err)
+			return
+		}
+		if len(table.Properties) != 2 {
+			t.Errorf("Table property must have 2 properties, got: %d", len(table.Properties))
+			return
+		}
+		prop := table.Properties[1]
+		if prop.Key.Value != "dog" {
+			t.Errorf("Appended table prop key should be dog, got: %s", prop.Key.Value)
+			return
+		}
+		v := prop.Value.(*ast.String).Value
+		if v != "bark" {
+			t.Errorf("Appended table prop value should be bark, got: %s", v)
+			return
+		}
+	})
+	t.Run("Enable set table property (replace)", func(t *testing.T) {
+		main := `
+table example {
+  "foo": "bar",
+}
+`
+		test := `
+table test_example {
+  "foo": "baz",
+}
+`
+		vcl, err := parser.New(lexer.NewFromString(main)).ParseVCL()
+		if err != nil {
+			t.Errorf("Parse error for main VCL: %s", err)
+		}
+		table := vcl.Statements[0].(*ast.TableDeclaration)
+		c := &context.Context{
+			Tables: map[string]*ast.TableDeclaration{
+				table.Name.Value: table,
+			},
+		}
+		testVCL, err := parser.New(lexer.NewFromString(test)).ParseVCL()
+		if err != nil {
+			t.Errorf("Parse error for test VCL: %s", err)
+		}
+		testTable := testVCL.Statements[0].(*ast.TableDeclaration)
+		_, err = Testing_table_merge(
+			c,
+			&Definiions{
+				Tables: map[string]*ast.TableDeclaration{
+					testTable.Name.Value: testTable,
+				},
+			},
+			&value.Ident{Value: "example"},
+			&value.Ident{Value: "test_example"},
+		)
+		if err != nil {
+			t.Errorf("Error should be nil, got: %s", err)
+			return
+		}
+		if len(table.Properties) != 1 {
+			t.Errorf("Table property must have 1 properties, got: %d", len(table.Properties))
+			return
+		}
+		prop := table.Properties[0]
+		if prop.Key.Value != "foo" {
+			t.Errorf("Appended table prop key should be foo, got: %s", prop.Key.Value)
+			return
+		}
+		v := prop.Value.(*ast.String).Value
+		if v != "baz" {
+			t.Errorf("Appended table prop value should be baz, got: %s", v)
+			return
+		}
+	})
+
+	t.Run("Error on vcl table not found", func(t *testing.T) {
+		c := &context.Context{}
+		_, err := Testing_table_merge(
+			c,
+			&Definiions{
+				Tables: map[string]*ast.TableDeclaration{},
+			},
+			&value.Ident{Value: "example"},
+			&value.Ident{Value: "test_example"},
+		)
+		if err == nil {
+			t.Errorf("Should return error if table not found, got nil")
+		}
+	})
+	t.Run("Error on test vcl table not found", func(t *testing.T) {
+		main := `
+table example {
+  "foo": "bar",
+}
+`
+		vcl, err := parser.New(lexer.NewFromString(main)).ParseVCL()
+		if err != nil {
+			t.Errorf("Parse error for main VCL: %s", err)
+		}
+		table := vcl.Statements[0].(*ast.TableDeclaration)
+		c := &context.Context{
+			Tables: map[string]*ast.TableDeclaration{
+				table.Name.Value: table,
+			},
+		}
+		_, err = Testing_table_merge(
+			c,
+			&Definiions{
+				Tables: map[string]*ast.TableDeclaration{},
+			},
+			&value.Ident{Value: "example"},
+			&value.Ident{Value: "test_example"},
+		)
+		if err == nil {
+			t.Errorf("Should return error if table not found, got nil")
+		}
+	})
+	t.Run("Error on both table type is not STRING", func(t *testing.T) {
+		main := `
+table example INTEGER {
+  "foo": 100,
+}
+`
+		test := `
+table test_example STRING {
+  "foo": "bar",
+}
+`
+		vcl, err := parser.New(lexer.NewFromString(main)).ParseVCL()
+		if err != nil {
+			t.Errorf("Parse error for main VCL: %s", err)
+		}
+		table := vcl.Statements[0].(*ast.TableDeclaration)
+		c := &context.Context{
+			Tables: map[string]*ast.TableDeclaration{
+				table.Name.Value: table,
+			},
+		}
+		testVCL, err := parser.New(lexer.NewFromString(test)).ParseVCL()
+		if err != nil {
+			t.Errorf("Parse error for test VCL: %s", err)
+		}
+		testTable := testVCL.Statements[0].(*ast.TableDeclaration)
+		_, err = Testing_table_merge(
+			c,
+			&Definiions{
+				Tables: map[string]*ast.TableDeclaration{
+					testTable.Name.Value: testTable,
+				},
+			},
+			&value.Ident{Value: "example"},
+			&value.Ident{Value: "test_example"},
+		)
+		if err == nil {
+			t.Errorf("Should return error if table type mismatched, got nil")
+		}
+	})
+}

--- a/tester/function/testing_table_set.go
+++ b/tester/function/testing_table_set.go
@@ -1,0 +1,78 @@
+package function
+
+import (
+	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/function/errors"
+	"github.com/ysugimoto/falco/interpreter/value"
+	"github.com/ysugimoto/falco/token"
+)
+
+const Testing_table_set_Name = "testing.table_set"
+
+var Testing_table_set_ArgumentTypes = []value.Type{value.IdentType, value.StringType, value.StringType}
+
+func Testing_table_set_Validate(args []value.Value) error {
+	if len(args) != 3 {
+		return errors.ArgumentNotEnough(Testing_table_set_Name, 3, args)
+	}
+
+	for i := range Testing_table_set_ArgumentTypes {
+		if args[i].Type() != Testing_table_set_ArgumentTypes[i] {
+			return errors.TypeMismatch(
+				Testing_table_set_Name, i+1, Testing_table_set_ArgumentTypes[i], args[i].Type(),
+			)
+		}
+	}
+	return nil
+}
+
+func Testing_table_set(
+	ctx *context.Context,
+	args ...value.Value,
+) (value.Value, error) {
+
+	if err := Testing_table_set_Validate(args); err != nil {
+		return nil, errors.NewTestingError(err.Error())
+	}
+
+	tableName := value.Unwrap[*value.Ident](args[0]).Value
+	// Check table existence
+	v, ok := ctx.Tables[tableName]
+	if !ok {
+		return value.Null, errors.NewTestingError("table %s not found in VCL", tableName)
+	}
+	// Currently this function supports for STRING table,
+	// common usecase for private edge dictionary.
+	if v.ValueType != nil && v.ValueType.Value != "STRING" {
+		return value.Null, errors.NewTestingError(
+			"value type mismatch for table %s: expects %s, got %s",
+			tableName,
+			v.ValueType.Value,
+			string(args[2].Type()),
+		)
+	}
+
+	// Set Table value with virtual AST
+	key := value.Unwrap[*value.String](args[1]).Value
+	val := value.Unwrap[*value.String](args[2]).Value
+	Testing_table_MergeProperty(v, &ast.TableProperty{
+		Meta: &ast.Meta{
+			Token: token.Null, // Null token for virtual AST
+		},
+		Key: &ast.String{
+			Meta: &ast.Meta{
+				Token: token.Token{Type: token.STRING, Literal: key},
+			},
+			Value: key,
+		},
+		Value: &ast.String{
+			Meta: &ast.Meta{
+				Token: token.Token{Type: token.STRING, Literal: val},
+			},
+			Value: val,
+		},
+	})
+
+	return value.Null, nil
+}

--- a/tester/function/testing_table_set_test.go
+++ b/tester/function/testing_table_set_test.go
@@ -1,0 +1,136 @@
+package function
+
+import (
+	"testing"
+
+	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/value"
+	"github.com/ysugimoto/falco/lexer"
+	"github.com/ysugimoto/falco/parser"
+)
+
+func Test_table_set(t *testing.T) {
+
+	t.Run("Enable set table property (append)", func(t *testing.T) {
+		main := `
+table example {
+  "foo": "bar",
+}
+`
+		vcl, err := parser.New(lexer.NewFromString(main)).ParseVCL()
+		if err != nil {
+			t.Errorf("Parse error for main VCL: %s", err)
+		}
+		table := vcl.Statements[0].(*ast.TableDeclaration)
+		c := &context.Context{
+			Tables: map[string]*ast.TableDeclaration{
+				table.Name.Value: table,
+			},
+		}
+		_, err = Testing_table_set(
+			c,
+			&value.Ident{Value: "example"},
+			&value.String{Value: "dog"},
+			&value.String{Value: "bark"},
+		)
+		if err != nil {
+			t.Errorf("Error should be nil, got: %s", err)
+			return
+		}
+		if len(table.Properties) != 2 {
+			t.Errorf("Table property must have 2 properties, got: %d", len(table.Properties))
+			return
+		}
+		prop := table.Properties[1]
+		if prop.Key.Value != "dog" {
+			t.Errorf("Appended table prop key should be dog, got: %s", prop.Key.Value)
+			return
+		}
+		v := prop.Value.(*ast.String).Value
+		if v != "bark" {
+			t.Errorf("Appended table prop value should be bark, got: %s", v)
+			return
+		}
+	})
+	t.Run("Enable set table property (replace)", func(t *testing.T) {
+		main := `
+table example {
+  "foo": "bar",
+}
+`
+		vcl, err := parser.New(lexer.NewFromString(main)).ParseVCL()
+		if err != nil {
+			t.Errorf("Parse error for main VCL: %s", err)
+		}
+		table := vcl.Statements[0].(*ast.TableDeclaration)
+		c := &context.Context{
+			Tables: map[string]*ast.TableDeclaration{
+				table.Name.Value: table,
+			},
+		}
+		_, err = Testing_table_set(
+			c,
+			&value.Ident{Value: "example"},
+			&value.String{Value: "foo"},
+			&value.String{Value: "baz"},
+		)
+		if err != nil {
+			t.Errorf("Error should be nil, got: %s", err)
+			return
+		}
+		if len(table.Properties) != 1 {
+			t.Errorf("Table property must have 1 properties, got: %d", len(table.Properties))
+			return
+		}
+		prop := table.Properties[0]
+		if prop.Key.Value != "foo" {
+			t.Errorf("Appended table prop key should be foo, got: %s", prop.Key.Value)
+			return
+		}
+		v := prop.Value.(*ast.String).Value
+		if v != "baz" {
+			t.Errorf("Appended table prop value should be baz, got: %s", v)
+			return
+		}
+	})
+
+	t.Run("Error on table not found", func(t *testing.T) {
+		c := &context.Context{}
+		_, err := Testing_table_set(
+			c,
+			&value.Ident{Value: "example"},
+			&value.String{Value: "dog"},
+			&value.String{Value: "bark"},
+		)
+		if err == nil {
+			t.Errorf("Should return error if table not found, got nil")
+		}
+	})
+	t.Run("Error on table type is not STRING", func(t *testing.T) {
+		main := `
+table example INTEGER {
+  "foo": 100,
+}
+`
+		vcl, err := parser.New(lexer.NewFromString(main)).ParseVCL()
+		if err != nil {
+			t.Errorf("Parse error for main VCL: %s", err)
+		}
+		table := vcl.Statements[0].(*ast.TableDeclaration)
+		c := &context.Context{
+			Tables: map[string]*ast.TableDeclaration{
+				table.Name.Value: table,
+			},
+		}
+		_, err = Testing_table_set(
+			c,
+			&value.Ident{Value: "example"},
+			&value.String{Value: "dog"},
+			&value.String{Value: "bark"},
+		)
+		if err == nil {
+			t.Errorf("Should return error if table type mismatched, got nil")
+		}
+	})
+}


### PR DESCRIPTION
Fixes #199 

This PR implements a couple of testing functions:

- `testing.table_set()` - sets table value for key in main VCL 
- `testing.table_merge()` - merge table declarations in main VCL from testing VCL

Also, tweak the testing process that sets a virtual backend if the main VCL does not have any backend declarations.

