### PR TITLE
fix time default value

### DIFF
--- a/interpreter/statement_test.go
+++ b/interpreter/statement_test.go
@@ -3,6 +3,7 @@ package interpreter
 import (
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/ysugimoto/falco/ast"
 	"github.com/ysugimoto/falco/interpreter/context"
@@ -78,7 +79,9 @@ func TestDeclareStatement(t *testing.T) {
 				Name:      &ast.Ident{Value: "var.foo"},
 				ValueType: &ast.Ident{Value: "TIME"},
 			},
-			expect: &value.Time{},
+			expect: &value.Time{
+				Value: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
 		},
 		{
 			name: "ACL value declaration",

--- a/interpreter/variable/local.go
+++ b/interpreter/variable/local.go
@@ -2,6 +2,7 @@ package variable
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/ysugimoto/falco/interpreter/value"
@@ -27,7 +28,9 @@ func (v LocalVariables) Declare(name, valueType string) error {
 	case "RTIME":
 		val = &value.RTime{}
 	case "TIME":
-		val = &value.Time{}
+		val = &value.Time{
+			Value: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
+		}
 	default:
 		return errors.WithStack(fmt.Errorf(
 			"Unexpected value type: %s", valueType,

--- a/interpreter/variable/local_test.go
+++ b/interpreter/variable/local_test.go
@@ -1,0 +1,22 @@
+package variable
+
+import "testing"
+
+func TestTimeValue(t *testing.T) {
+	local := LocalVariables{}
+
+	if err := local.Declare("T", "TIME"); err != nil {
+		t.Errorf("Failed to declare TIME value")
+		return
+	}
+
+	v, err := local.Get("T")
+	if err != nil {
+		t.Errorf("Failed to get TIME value")
+		return
+	}
+	if v.String() != "Thu, 01 Jan 1970 00:00:00 GMT" {
+		t.Errorf("Time string value unmatch: expect Thu, 01 Jan 1970 00:00:00 GMT, got %s", v.String())
+		return
+	}
+}


### PR DESCRIPTION
This PR fixes `TIME` type default value.

In Go, `time.Time{}` struct is not equal GMT default time so set default time on the declaration.