### PR TITLE
Feat/state related asserter

### DIFF
--- a/cmd/falco/runner_test.go
+++ b/cmd/falco/runner_test.go
@@ -351,6 +351,12 @@ func TestTester(t *testing.T) {
 			filter: "*values.test.vcl",
 			passes: 16,
 		},
+		{
+			name:   "assertions test",
+			main:   "../../examples/testing/assertion.vcl",
+			filter: "*assertion.test.vcl",
+			passes: 5,
+		},
 	}
 
 	for _, tt := range tests {

--- a/examples/testing/assertion.test.vcl
+++ b/examples/testing/assertion.test.vcl
@@ -1,0 +1,24 @@
+// @scope: recv
+sub test_restart {
+  testing.call_subroutine("force_restart");
+  assert.restart();
+}
+
+// @scope: recv
+sub test_error {
+  testing.call_subroutine("force_error");
+  assert.error(800, "FORCE ERROR");
+}
+
+// @scope: recv
+sub test_call_nested {
+  testing.call_subroutine("call_nested");
+  assert.subroutine_called("nested");
+  assert.equal(req.http.Foo, "1");
+}
+
+// @scope: recv
+sub test_state_check {
+  testing.call_subroutine("vcl_recv");
+  assert.state(lookup);
+}

--- a/examples/testing/assertion.vcl
+++ b/examples/testing/assertion.vcl
@@ -1,0 +1,19 @@
+sub force_restart {
+  restart;
+}
+
+sub force_error {
+  error 800 "FORCE ERROR";
+}
+
+sub nested {
+  set req.http.Foo = "1";
+}
+
+sub call_nested {
+  call nested;
+}
+
+sub vcl_recv {
+  return(lookup);
+}

--- a/interpreter/context/context.go
+++ b/interpreter/context/context.go
@@ -135,8 +135,9 @@ type Context struct {
 
 	// For testing fields
 	// Stored subroutine return state
-	ReturnState *value.String
-	FixedTime   *time.Time
+	ReturnState     *value.String
+	FixedTime       *time.Time
+	SubroutineCalls map[string]int
 
 	// Regex captured values like "re.group.N" and local declared variables are volatile,
 	// reset this when process is outgoing for each subroutines
@@ -231,6 +232,7 @@ func New(options ...Option) *Context {
 		IsLocallyGenerated:                  &value.Boolean{},
 
 		RegexMatchedValues: make(map[string]*value.String),
+		SubroutineCalls:    make(map[string]int),
 	}
 
 	// collect options

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -32,14 +32,17 @@ type Interpreter struct {
 	cache         *cache.Cache
 	Debugger      Debugger
 	IdentResolver func(v string) value.Value
+
+	TestingState State
 }
 
 func New(options ...context.Option) *Interpreter {
 	return &Interpreter{
-		options:   options,
-		cache:     cache.New(),
-		localVars: variable.LocalVariables{},
-		Debugger:  DefaultDebugger{},
+		options:      options,
+		cache:        cache.New(),
+		localVars:    variable.LocalVariables{},
+		Debugger:     DefaultDebugger{},
+		TestingState: NONE,
 	}
 }
 

--- a/interpreter/state.go
+++ b/interpreter/state.go
@@ -1,5 +1,7 @@
 package interpreter
 
+import "strings"
+
 type State string
 
 const (
@@ -60,4 +62,11 @@ var stateMap = map[string]State{
 	"deliver_stale": DELIVER_STALE,
 	"log":           LOG,
 	"end":           END,
+}
+
+func StateFromString(s string) State {
+	if v, ok := stateMap[strings.ToLower(s)]; ok {
+		return v
+	}
+	return NONE
 }

--- a/interpreter/subroutine.go
+++ b/interpreter/subroutine.go
@@ -26,6 +26,7 @@ func (i *Interpreter) ProcessSubroutine(sub *ast.SubroutineDeclaration, ds Debug
 	defer func() {
 		i.ctx.RegexMatchedValues = make(map[string]*value.String)
 		i.localVars = variable.LocalVariables{}
+		i.ctx.SubroutineCalls[sub.Name.Value]++
 	}()
 
 	// Try to extract fastly reserved subroutine macro

--- a/tester/function/assert_contains.go
+++ b/tester/function/assert_contains.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Assert_contains_Name = "assert"
+const Assert_contains_Name = "assert.contains"
 
 var Assert_contains_ArgumentTypes = []value.Type{value.StringType, value.StringType}
 

--- a/tester/function/assert_ends_with.go
+++ b/tester/function/assert_ends_with.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Assert_ends_with_Name = "assert"
+const Assert_ends_with_Name = "assert.ends_with"
 
 var Assert_ends_with_ArgumentTypes = []value.Type{value.StringType, value.StringType}
 

--- a/tester/function/assert_equal.go
+++ b/tester/function/assert_equal.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Assert_equal_Name = "assert"
+const Assert_equal_Name = "assert.equal"
 
 func Assert_equal_Validate(args []value.Value) error {
 	if len(args) < 2 || len(args) > 3 {

--- a/tester/function/assert_error.go
+++ b/tester/function/assert_error.go
@@ -1,0 +1,94 @@
+package function
+
+import (
+	"github.com/ysugimoto/falco/interpreter"
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/function/errors"
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+const Assert_error_Name = "assert.error"
+
+var Assert_error_ArgumentTypes = []value.Type{value.IntegerType}
+
+func Assert_error_Validate(args []value.Value) error {
+	if len(args) < 1 || len(args) > 3 {
+		return errors.ArgumentNotInRange(Assert_error_Name, 1, 3, args)
+	}
+
+	for i := range Assert_error_ArgumentTypes {
+		if args[i].Type() != Assert_error_ArgumentTypes[i] {
+			return errors.TypeMismatch(Assert_error_Name, i+1, Assert_error_ArgumentTypes[i], args[i].Type())
+		}
+	}
+
+	return nil
+}
+
+func Assert_error(
+	ctx *context.Context,
+	i *interpreter.Interpreter,
+	args ...value.Value,
+) (value.Value, error) {
+
+	if err := Assert_error_Validate(args); err != nil {
+		return nil, errors.NewTestingError(err.Error())
+	}
+
+	// extract arguments
+	var message string
+	if len(args) == 3 {
+		message = value.Unwrap[*value.String](args[2]).Value
+	}
+
+	// First, check state moves to ERROR internally
+	if i.TestingState != interpreter.ERROR {
+		if message == "" {
+			return &value.Boolean{}, errors.NewAssertionError(
+				&value.String{Value: i.TestingState.String()},
+				"State does not move to ERROR, current state is %s",
+				i.TestingState.String(),
+			)
+		}
+		return &value.Boolean{}, errors.NewAssertionError(
+			&value.String{Value: i.TestingState.String()},
+			message,
+		)
+	}
+
+	// status code check
+	code := value.Unwrap[*value.Integer](args[0]).Value
+	if ctx.ObjectStatus.Value != code {
+		if message == "" {
+			return &value.Boolean{}, errors.NewAssertionError(
+				ctx.ObjectStatus,
+				"Error response code mismatch: expects %d, got %d",
+				code, ctx.ObjectStatus.Value,
+			)
+		}
+		return &value.Boolean{}, errors.NewAssertionError(
+			ctx.ObjectStatus,
+			message,
+		)
+	}
+
+	// response string check
+	if len(args) > 1 {
+		response := value.Unwrap[*value.String](args[1]).Value
+		if ctx.ObjectResponse.Value != response {
+			if message == "" {
+				return &value.Boolean{}, errors.NewAssertionError(
+					ctx.ObjectResponse,
+					"Error response text mismatch: expects %s, got %s",
+					response, ctx.ObjectResponse.Value,
+				)
+			}
+			return &value.Boolean{}, errors.NewAssertionError(
+				ctx.ObjectResponse,
+				message,
+			)
+		}
+	}
+
+	return &value.Boolean{Value: true}, nil
+}

--- a/tester/function/assert_error_test.go
+++ b/tester/function/assert_error_test.go
@@ -1,0 +1,122 @@
+package function
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/ysugimoto/falco/interpreter"
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/function/errors"
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+func Test_Assert_error(t *testing.T) {
+
+	tests := []struct {
+		args   []value.Value
+		ip     *interpreter.Interpreter
+		ctx    *context.Context
+		err    error
+		expect *value.Boolean
+	}{
+		{
+			args: []value.Value{
+				&value.Integer{Value: 900},
+			},
+			ip: &interpreter.Interpreter{
+				TestingState: interpreter.ERROR,
+			},
+			ctx: &context.Context{
+				ObjectStatus: &value.Integer{Value: 900},
+			},
+			expect: &value.Boolean{Value: true},
+		},
+		{
+			args: []value.Value{
+				&value.Integer{Value: 900},
+				&value.String{Value: "Fastly Internal."},
+			},
+			ip: &interpreter.Interpreter{
+				TestingState: interpreter.ERROR,
+			},
+			ctx: &context.Context{
+				ObjectStatus:   &value.Integer{Value: 900},
+				ObjectResponse: &value.String{Value: "Fastly Internal."},
+			},
+			expect: &value.Boolean{Value: true},
+		},
+		{
+			args: []value.Value{
+				&value.Integer{Value: 900},
+				&value.String{Value: "Fastly Internal."},
+				&value.String{Value: "custom message"},
+			},
+			ip: &interpreter.Interpreter{
+				TestingState: interpreter.ERROR,
+			},
+			ctx: &context.Context{
+				ObjectStatus:   &value.Integer{Value: 900},
+				ObjectResponse: &value.String{Value: "Fastly Internal."},
+			},
+			expect: &value.Boolean{Value: true},
+		},
+		{
+			args: []value.Value{
+				&value.Integer{Value: 900},
+			},
+			ip: &interpreter.Interpreter{
+				TestingState: interpreter.RESTART,
+			},
+			ctx: &context.Context{
+				ObjectStatus: &value.Integer{Value: 900},
+			},
+			expect: &value.Boolean{Value: false},
+			err:    &errors.AssertionError{},
+		},
+		{
+			args: []value.Value{
+				&value.Integer{Value: 900},
+			},
+			ip: &interpreter.Interpreter{
+				TestingState: interpreter.ERROR,
+			},
+			ctx: &context.Context{
+				ObjectStatus: &value.Integer{Value: 901},
+			},
+			expect: &value.Boolean{Value: false},
+			err:    &errors.AssertionError{},
+		},
+		{
+			args: []value.Value{
+				&value.Integer{Value: 900},
+				&value.String{Value: "Unexpected"},
+			},
+			ip: &interpreter.Interpreter{
+				TestingState: interpreter.ERROR,
+			},
+			ctx: &context.Context{
+				ObjectStatus:   &value.Integer{Value: 900},
+				ObjectResponse: &value.String{Value: "Fastly Internal."},
+			},
+			expect: &value.Boolean{Value: false},
+			err:    &errors.AssertionError{},
+		},
+	}
+
+	for i := range tests {
+		_, err := Assert_error(
+			tests[i].ctx,
+			tests[i].ip,
+			tests[i].args...,
+		)
+		if diff := cmp.Diff(
+			tests[i].err,
+			err,
+			cmpopts.IgnoreFields(errors.AssertionError{}, "Message", "Actual"),
+			cmpopts.IgnoreFields(errors.TestingError{}, "Message"),
+		); diff != "" {
+			t.Errorf("Assert_error()[%d] error: diff=%s", i, diff)
+		}
+	}
+}

--- a/tester/function/assert_false.go
+++ b/tester/function/assert_false.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Assert_false_Name = "assert"
+const Assert_false_Name = "assert.false"
 
 func Assert_false_Validate(args []value.Value) error {
 	if len(args) < 1 || len(args) > 2 {
@@ -28,8 +28,8 @@ func Assert_false(ctx *context.Context, args ...value.Value) (value.Value, error
 
 	// Check custom message
 	var message string
-	if len(args) == 3 {
-		message = value.Unwrap[*value.String](args[2]).Value
+	if len(args) == 2 {
+		message = value.Unwrap[*value.String](args[1]).Value
 	} else {
 		message = "Value should be false"
 	}

--- a/tester/function/assert_match.go
+++ b/tester/function/assert_match.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Assert_match_Name = "assert"
+const Assert_match_Name = "assert.match"
 
 var Assert_match_ArgumentTypes = []value.Type{value.StringType, value.StringType}
 

--- a/tester/function/assert_not_contains.go
+++ b/tester/function/assert_not_contains.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Assert_not_contains_Name = "assert"
+const Assert_not_contains_Name = "assert.not_contains"
 
 var Assert_not_contains_ArgumentTypes = []value.Type{value.StringType, value.StringType}
 

--- a/tester/function/assert_not_equal.go
+++ b/tester/function/assert_not_equal.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Assert_not_equal_Name = "assert"
+const Assert_not_equal_Name = "assert.not_equal"
 
 func Assert_not_equal_Validate(args []value.Value) error {
 	if len(args) < 2 || len(args) > 3 {

--- a/tester/function/assert_not_match.go
+++ b/tester/function/assert_not_match.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Assert_not_match_Name = "assert"
+const Assert_not_match_Name = "assert.not_match"
 
 var Assert_not_match_ArgumentTypes = []value.Type{value.StringType, value.StringType}
 

--- a/tester/function/assert_not_strict_equal.go
+++ b/tester/function/assert_not_strict_equal.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Assert_not_strict_equal_Name = "assert"
+const Assert_not_strict_equal_Name = "assert.not_strict_equal"
 
 func Assert_not_strict_equal_Validate(args []value.Value) error {
 	if len(args) < 2 || len(args) > 3 {

--- a/tester/function/assert_restart.go
+++ b/tester/function/assert_restart.go
@@ -1,0 +1,47 @@
+package function
+
+import (
+	"github.com/ysugimoto/falco/interpreter"
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/function/errors"
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+const Assert_restart_Name = "assert.restart"
+
+func Assert_restart_Validate(args []value.Value) error {
+	if len(args) > 1 {
+		return errors.ArgumentMustEmpty(Assert_restart_Name, args)
+	}
+
+	if len(args) == 1 {
+		if args[0].Type() != value.StringType {
+			return errors.TypeMismatch(Assert_restart_Name, 1, value.StringType, args[0].Type())
+		}
+	}
+
+	return nil
+}
+
+func Assert_restart(
+	ctx *context.Context,
+	i *interpreter.Interpreter,
+	args ...value.Value,
+) (value.Value, error) {
+
+	if err := Assert_restart_Validate(args); err != nil {
+		return nil, errors.NewTestingError(err.Error())
+	}
+
+	var message string
+	if len(args) == 1 {
+		message = value.Unwrap[*value.String](args[0]).Value
+	} else {
+		message = "restart should be called in subroutine"
+	}
+
+	if i.TestingState != interpreter.RESTART {
+		return &value.Boolean{}, errors.NewAssertionError(&value.String{Value: ""}, message)
+	}
+	return &value.Boolean{Value: true}, nil
+}

--- a/tester/function/assert_restart_test.go
+++ b/tester/function/assert_restart_test.go
@@ -1,0 +1,54 @@
+package function
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/ysugimoto/falco/interpreter"
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/function/errors"
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+func Test_Assert_restart(t *testing.T) {
+
+	tests := []struct {
+		args   []value.Value
+		ip     *interpreter.Interpreter
+		err    error
+		expect *value.Boolean
+	}{
+		{
+			args: []value.Value{},
+			ip: &interpreter.Interpreter{
+				TestingState: interpreter.ERROR,
+			},
+			expect: &value.Boolean{Value: false},
+			err:    &errors.AssertionError{},
+		},
+		{
+			args: []value.Value{},
+			ip: &interpreter.Interpreter{
+				TestingState: interpreter.RESTART,
+			},
+			expect: &value.Boolean{Value: true},
+		},
+	}
+
+	for i := range tests {
+		_, err := Assert_restart(
+			&context.Context{},
+			tests[i].ip,
+			tests[i].args...,
+		)
+		if diff := cmp.Diff(
+			tests[i].err,
+			err,
+			cmpopts.IgnoreFields(errors.AssertionError{}, "Message", "Actual"),
+			cmpopts.IgnoreFields(errors.TestingError{}, "Message"),
+		); diff != "" {
+			t.Errorf("Assert_restart()[%d] error: diff=%s", i, diff)
+		}
+	}
+}

--- a/tester/function/assert_starts_with.go
+++ b/tester/function/assert_starts_with.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Assert_starts_with_Name = "assert"
+const Assert_starts_with_Name = "assert.starts_with"
 
 var Assert_starts_with_ArgumentTypes = []value.Type{value.StringType, value.StringType}
 

--- a/tester/function/assert_state.go
+++ b/tester/function/assert_state.go
@@ -1,0 +1,55 @@
+package function
+
+import (
+	"fmt"
+
+	"github.com/ysugimoto/falco/interpreter"
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/function/errors"
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+const Assert_state_Name = "assert.state"
+
+var Assert_state_ArgumentTypes = []value.Type{value.IdentType}
+
+func Assert_state_Validate(args []value.Value) error {
+	if len(args) > 2 {
+		return errors.ArgumentNotInRange(Assert_state_Name, 1, 2, args)
+	}
+
+	for i := range Assert_state_ArgumentTypes {
+		if args[i].Type() != Assert_state_ArgumentTypes[i] {
+			return errors.TypeMismatch(Assert_state_Name, i+1, Assert_state_ArgumentTypes[i], args[i].Type())
+		}
+	}
+
+	return nil
+}
+
+func Assert_state(
+	ctx *context.Context,
+	i *interpreter.Interpreter,
+	args ...value.Value,
+) (value.Value, error) {
+
+	if err := Assert_state_Validate(args); err != nil {
+		return nil, errors.NewTestingError(err.Error())
+	}
+
+	state := value.Unwrap[*value.Ident](args[0])
+	expect := interpreter.StateFromString(state.Value)
+
+	var message string
+	if len(args) == 2 {
+		message = value.Unwrap[*value.String](args[0]).Value
+	} else {
+		message = fmt.Sprintf(
+			"state should be moved to %s, got %s",
+			expect,
+			i.TestingState,
+		)
+	}
+
+	return assert(state, expect.String(), i.TestingState.String(), message)
+}

--- a/tester/function/assert_state_test.go
+++ b/tester/function/assert_state_test.go
@@ -1,0 +1,58 @@
+package function
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/ysugimoto/falco/interpreter"
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/function/errors"
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+func Test_Assert_state(t *testing.T) {
+
+	tests := []struct {
+		args   []value.Value
+		ip     *interpreter.Interpreter
+		err    error
+		expect *value.Boolean
+	}{
+		{
+			args: []value.Value{
+				&value.Ident{Value: "error"},
+			},
+			ip: &interpreter.Interpreter{
+				TestingState: interpreter.ERROR,
+			},
+			expect: &value.Boolean{Value: true},
+		},
+		{
+			args: []value.Value{
+				&value.Ident{Value: "error"},
+			},
+			ip: &interpreter.Interpreter{
+				TestingState: interpreter.LOOKUP,
+			},
+			expect: &value.Boolean{Value: false},
+			err:    &errors.AssertionError{},
+		},
+	}
+
+	for i := range tests {
+		_, err := Assert_state(
+			&context.Context{},
+			tests[i].ip,
+			tests[i].args...,
+		)
+		if diff := cmp.Diff(
+			tests[i].err,
+			err,
+			cmpopts.IgnoreFields(errors.AssertionError{}, "Message", "Actual"),
+			cmpopts.IgnoreFields(errors.TestingError{}, "Message"),
+		); diff != "" {
+			t.Errorf("Assert_state()[%d] error: diff=%s", i, diff)
+		}
+	}
+}

--- a/tester/function/assert_strict_equal.go
+++ b/tester/function/assert_strict_equal.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Assert_strict_equal_Name = "assert"
+const Assert_strict_equal_Name = "assert.strict_equal"
 
 func Assert_strict_equal_Validate(args []value.Value) error {
 	if len(args) < 2 || len(args) > 3 {

--- a/tester/function/assert_subroutine_called.go
+++ b/tester/function/assert_subroutine_called.go
@@ -1,0 +1,82 @@
+package function
+
+import (
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/function/errors"
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+const Assert_subroutine_called_Name = "assert.subroutine_called"
+
+func Assert_subroutine_called_Validate(args []value.Value) error {
+	if len(args) < 1 || len(args) > 3 {
+		return errors.ArgumentNotInRange(Assert_subroutine_called_Name, 1, 3, args)
+	}
+
+	if args[0].Type() != value.StringType {
+		return errors.TypeMismatch(Assert_subroutine_called_Name, 1, value.StringType, args[0].Type())
+	}
+	return nil
+}
+
+func Assert_subroutine_called(ctx *context.Context, args ...value.Value) (value.Value, error) {
+	if err := Assert_subroutine_called_Validate(args); err != nil {
+		return nil, errors.NewTestingError(err.Error())
+	}
+
+	name := value.Unwrap[*value.String](args[0]).Value
+
+	// Check custom message
+	var message string
+	var times int64 = 1
+	var prural string
+	switch len(args) {
+	case 3: // (name, times, message)
+		times = value.Unwrap[*value.Integer](args[1]).Value
+		if times > 1 {
+			prural = "s"
+		}
+		message = value.Unwrap[*value.String](args[2]).Value
+	case 2: // (name, times or message)
+		switch args[1].Type() {
+		case value.IntegerType:
+			times = value.Unwrap[*value.Integer](args[1]).Value
+			if times > 1 {
+				prural = "s"
+			}
+		case value.StringType:
+			message = value.Unwrap[*value.String](args[1]).Value
+		default:
+			return &value.Boolean{}, errors.NewTestingError(
+				"%s: 2nd argument must be INTEGER or STRING, %s provided",
+				Assert_subroutine_called_Name, args[1].Type(),
+			)
+		}
+	}
+
+	call, ok := ctx.SubroutineCalls[name]
+	if !ok {
+		if message != "" {
+			return &value.Boolean{}, errors.NewAssertionError(args[0], message)
+		}
+		return &value.Boolean{}, errors.NewAssertionError(args[0], "Subroutine %s is not called", name)
+	}
+	if int64(call) != times {
+		var cp string
+		if call > 1 {
+			cp = "s"
+		}
+		if message != "" {
+			return &value.Boolean{}, errors.NewAssertionError(
+				&value.Integer{Value: int64(call)},
+				message,
+			)
+		}
+		return &value.Boolean{}, errors.NewAssertionError(
+			&value.Integer{Value: int64(call)},
+			"Subroutine %s should be called %d time%s but actual called %d time%s",
+			name, times, prural, call, cp,
+		)
+	}
+	return &value.Boolean{Value: true}, nil
+}

--- a/tester/function/assert_subroutine_called_test.go
+++ b/tester/function/assert_subroutine_called_test.go
@@ -1,0 +1,85 @@
+package function
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/function/errors"
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+func Test_Assert_subroutine_called(t *testing.T) {
+
+	tests := []struct {
+		args   []value.Value
+		err    error
+		expect *value.Boolean
+	}{
+		{
+			args: []value.Value{
+				&value.String{Value: "counter_recv"},
+			},
+			expect: &value.Boolean{Value: true},
+		},
+		{
+			args: []value.Value{
+				&value.String{Value: "counter_recv_not_called"},
+			},
+			expect: &value.Boolean{Value: false},
+			err:    &errors.AssertionError{},
+		},
+		{
+			args: []value.Value{
+				&value.String{Value: "counter_recv_not_called"},
+				&value.String{Value: "custom_message"},
+			},
+			expect: &value.Boolean{Value: false},
+			err:    &errors.AssertionError{},
+		},
+		{
+			args: []value.Value{
+				&value.String{Value: "counter_recv"},
+				&value.Integer{Value: 1},
+			},
+			expect: &value.Boolean{Value: true},
+		},
+		{
+			args: []value.Value{
+				&value.String{Value: "counter_recv"},
+				&value.Integer{Value: 2},
+			},
+			expect: &value.Boolean{Value: false},
+			err:    &errors.AssertionError{},
+		},
+		{
+			args: []value.Value{
+				&value.String{Value: "counter_recv"},
+				&value.Integer{Value: 2},
+				&value.String{Value: "custom_message"},
+			},
+			expect: &value.Boolean{Value: false},
+			err:    &errors.AssertionError{},
+		},
+	}
+
+	for i := range tests {
+		_, err := Assert_subroutine_called(
+			&context.Context{
+				SubroutineCalls: map[string]int{
+					"counter_recv": 1,
+				},
+			},
+			tests[i].args...,
+		)
+		if diff := cmp.Diff(
+			tests[i].err,
+			err,
+			cmpopts.IgnoreFields(errors.AssertionError{}, "Message", "Actual"),
+			cmpopts.IgnoreFields(errors.TestingError{}, "Message"),
+		); diff != "" {
+			t.Errorf("Assert_subroutine_called()[%d] error: diff=%s", i, diff)
+		}
+	}
+}

--- a/tester/function/assert_true.go
+++ b/tester/function/assert_true.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Assert_true_Name = "assert"
+const Assert_true_Name = "assert.true"
 
 func Assert_true_Validate(args []value.Value) error {
 	if len(args) < 1 || len(args) > 2 {
@@ -28,8 +28,8 @@ func Assert_true(ctx *context.Context, args ...value.Value) (value.Value, error)
 
 	// Check custom message
 	var message string
-	if len(args) == 3 {
-		message = value.Unwrap[*value.String](args[2]).Value
+	if len(args) == 2 {
+		message = value.Unwrap[*value.String](args[1]).Value
 	} else {
 		message = "Value should be true"
 	}

--- a/tester/function/testing_call_subroutine.go
+++ b/tester/function/testing_call_subroutine.go
@@ -48,6 +48,7 @@ func Testing_call_subroutine(
 		// Scoped subroutine
 	} else if sub, ok := ctx.Subroutines[name]; ok {
 		state, err = i.ProcessSubroutine(sub, interpreter.DebugPass)
+		i.TestingState = state
 	}
 	if err != nil {
 		return value.Null, errors.NewTestingError(err.Error())

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -240,7 +240,7 @@ func (t *Tester) setupInterpreter(defs *tf.Definiions) *interpreter.Interpreter 
 		} else if _, ok := defs.Tables[val]; ok {
 			return &value.Ident{Value: val, Literal: true}
 		} else if s := interpreter.StateFromString(val); s != interpreter.NONE {
-			// Some assertion uses interpreter state so we need to resolve state ident like look in testing VCL
+			// Some assertion uses interpreter state so we need to resolve state ident like "lookup" in testing VCL
 			return &value.Ident{Value: s.String()}
 		}
 		return nil

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -239,6 +239,9 @@ func (t *Tester) setupInterpreter(defs *tf.Definiions) *interpreter.Interpreter 
 			return v
 		} else if _, ok := defs.Tables[val]; ok {
 			return &value.Ident{Value: val, Literal: true}
+		} else if s := interpreter.StateFromString(val); s != interpreter.NONE {
+			// Some assertion uses interpreter state so we need to resolve state ident like look in testing VCL
+			return &value.Ident{Value: s.String()}
 		}
 		return nil
 	}


### PR DESCRIPTION
This PR implements some `state` assertion functions:

- `assert.subroutine_called` Assert subroutine has called in testing subroutine (with times)
- `assert.restart`  Assert restart statement has called
- `assert.state`  Assert after state is expected one
- `assert.error` Assert error status code (and response) if an error statement has called

Above functions are useful for state-related testings, nested subroutine has called or not, restarted, what state to move, and how error statement has called with status code and response (optional).