### PR TITLE
tmp: suppress notset output

### DIFF
--- a/examples/testing/default_values.test.vcl
+++ b/examples/testing/default_values.test.vcl
@@ -84,7 +84,7 @@ sub test_default_local_var_recv {
     set var.is_null = false;
   }
   assert.true(var.is_null);
-  assert.not_equal(var.string, "");
+  assert.equal(var.string, "");
 }
 
 // @scope: recv

--- a/interpreter/operator/operator_concat_test.go
+++ b/interpreter/operator/operator_concat_test.go
@@ -121,6 +121,7 @@ func TestConcatOperator(t *testing.T) {
 			{left: &value.String{Value: "example"}, right: &value.Float{Value: 10.0, Literal: true}, isError: true},
 			{left: &value.String{Value: "example"}, right: &value.String{Value: "example"}, expect: "exampleexample"},
 			{left: &value.String{Value: "example"}, right: &value.String{Value: "example", Literal: true}, expect: "exampleexample"},
+			{left: &value.String{Value: "example"}, right: &value.String{IsNotSet: true}, expect: "example"},
 			{left: &value.String{Value: "example"}, right: &value.RTime{Value: 100 * time.Second}, expect: "example100.000"},
 			{left: &value.String{Value: "example"}, right: &value.RTime{Value: 100 * time.Second, Literal: true}, isError: true},
 			{left: &value.String{Value: "example"}, right: &value.Time{Value: now}, expect: "example" + now.Format(http.TimeFormat)},
@@ -128,6 +129,7 @@ func TestConcatOperator(t *testing.T) {
 			{left: &value.String{Value: "example"}, right: &value.Boolean{Value: true}, expect: "example1"},
 			{left: &value.String{Value: "example"}, right: &value.Boolean{Value: false, Literal: true}, expect: "example0"},
 			{left: &value.String{Value: "example"}, right: &value.IP{Value: net.ParseIP("127.0.0.1")}, expect: "example127.0.0.1"},
+			{left: &value.String{Value: "example"}, right: &value.IP{IsNotSet: true}, expect: "example"},
 			{left: &value.String{Value: "example", Literal: true}, right: &value.Integer{Value: 100}, expect: "example100"},
 			{left: &value.String{Value: "example", Literal: true}, right: &value.Integer{Value: 100, Literal: true}, isError: true},
 		}
@@ -362,6 +364,7 @@ func TestConcatOperator(t *testing.T) {
 			{left: &value.IP{Value: v}, right: &value.Float{Value: 10.0, Literal: true}, isError: true},
 			{left: &value.IP{Value: v}, right: &value.String{Value: "example"}, expect: "127.0.0.1example"},
 			{left: &value.IP{Value: v}, right: &value.String{Value: "example", Literal: true}, expect: "127.0.0.1example"},
+			{left: &value.IP{Value: v}, right: &value.String{IsNotSet: true}, expect: "127.0.0.1"},
 			{left: &value.IP{Value: v}, right: &value.RTime{Value: time.Second}, expect: "127.0.0.11.000"},
 			{left: &value.IP{Value: v}, right: &value.RTime{Value: time.Second, Literal: true}, isError: true},
 			{left: &value.IP{Value: v}, right: &value.Time{Value: now}, expect: "127.0.0.1" + now.Format(http.TimeFormat)},
@@ -369,6 +372,7 @@ func TestConcatOperator(t *testing.T) {
 			{left: &value.IP{Value: v}, right: &value.Boolean{Value: true}, expect: "127.0.0.11"},
 			{left: &value.IP{Value: v}, right: &value.Boolean{Value: false, Literal: true}, expect: "127.0.0.10"},
 			{left: &value.IP{Value: v}, right: &value.IP{Value: net.ParseIP("127.0.0.1")}, expect: "127.0.0.1127.0.0.1"},
+			{left: &value.IP{Value: v}, right: &value.IP{IsNotSet: true}, expect: "127.0.0.1"},
 		}
 
 		for i, tt := range tests {

--- a/interpreter/value/value.go
+++ b/interpreter/value/value.go
@@ -71,7 +71,7 @@ type String struct {
 }
 
 func (v *String) String() string {
-	// Temporaly comment out to supress not set output
+	// Temporaly comment out to suppress not set output
 	// if v.IsNotSet {
 	// 	return "(null)"
 	// }

--- a/interpreter/value/value.go
+++ b/interpreter/value/value.go
@@ -71,9 +71,10 @@ type String struct {
 }
 
 func (v *String) String() string {
-	if v.IsNotSet {
-		return "[not set]"
-	}
+	// Temporaly comment out to supress not set output
+	// if v.IsNotSet {
+	// 	return "(null)"
+	// }
 	return v.Value
 }
 func (v *String) Type() Type      { return StringType }
@@ -93,8 +94,9 @@ type IP struct {
 }
 
 func (v *IP) String() string {
+	// Temporaly return empty string if notset
 	if v.IsNotSet {
-		return "[not set]"
+		return ""
 	}
 	return v.Value.String()
 }

--- a/interpreter/value/value.go
+++ b/interpreter/value/value.go
@@ -71,7 +71,7 @@ type String struct {
 }
 
 func (v *String) String() string {
-	// Temporaly comment out to suppress not set output
+	// Temporarily comment out to suppress not set output
 	// if v.IsNotSet {
 	// 	return "(null)"
 	// }
@@ -94,7 +94,7 @@ type IP struct {
 }
 
 func (v *IP) String() string {
-	// Temporaly return empty string if notset
+	// Temporarily return empty string if notset
 	if v.IsNotSet {
 		return ""
 	}


### PR DESCRIPTION
This is a temporal fix, on the concatenation string, NotSet variable should be treated as the empty string.

However, in Fastly, sometimes NotSet string concatenation is treated as a "(null)" string.
We can see the behavior at https://fiddle.fastly.dev/fiddle/e9852716

Temporary it's okay on this behavior but to adjust Fastly properly, we may need to more fixation for this problem.