### PR TITLE
Value returns from switch and bare block statements

### DIFF
--- a/interpreter/subroutine.go
+++ b/interpreter/subroutine.go
@@ -44,6 +44,7 @@ func (i *Interpreter) ProcessSubroutine(sub *ast.SubroutineDeclaration, ds Debug
 	return state, err
 }
 
+// nolint: gocognit
 func (i *Interpreter) ProcessFunctionSubroutine(sub *ast.SubroutineDeclaration, ds DebugState) (value.Value, State, error) {
 	i.process.Flows = append(i.process.Flows, process.NewFlow(i.ctx, sub))
 
@@ -90,6 +91,16 @@ func (i *Interpreter) ProcessFunctionSubroutine(sub *ast.SubroutineDeclaration, 
 		// case *ast.GotoDestinationStatement:
 		// 	err = i.ProcessGotoDesticationStatement(t)
 		// Probably change status statements
+		case *ast.BlockStatement:
+			var val value.Value
+			var state State
+			val, state, _, err = i.ProcessBlockStatement(t.Statements, ds, true)
+			if val != value.Null {
+				return val, NONE, nil
+			}
+			if state != NONE {
+				return value.Null, state, nil
+			}
 		case *ast.FunctionCallStatement:
 			var state State
 			// Enable breakpoint if current debug state is step-in

--- a/interpreter/subroutine.go
+++ b/interpreter/subroutine.go
@@ -124,8 +124,12 @@ func (i *Interpreter) ProcessFunctionSubroutine(sub *ast.SubroutineDeclaration, 
 				return value.Null, state, nil
 			}
 		case *ast.SwitchStatement:
+			var val value.Value
 			var state State
-			state, err = i.ProcessSwitchStatement(t, debugState)
+			val, state, err = i.ProcessSwitchStatement(t, debugState, true)
+			if val != value.Null {
+				return val, NONE, nil
+			}
 			if state != NONE {
 				return value.Null, state, nil
 			}

--- a/interpreter/subroutine.go
+++ b/interpreter/subroutine.go
@@ -176,7 +176,7 @@ func (i *Interpreter) ProcessFunctionSubroutine(sub *ast.SubroutineDeclaration, 
 
 	return value.Null, NONE, exception.Runtime(
 		&sub.GetMeta().Token,
-		"Functioncal subroutine %s did not return any values",
+		"Functional subroutine %s did not return any values",
 		sub.Name.Value,
 	)
 }
@@ -189,7 +189,7 @@ func (i *Interpreter) ProcessExpressionReturnStatement(stmt *ast.ReturnStatement
 	if !val.IsLiteral() {
 		return value.Null, NONE, exception.Runtime(
 			&stmt.GetMeta().Token,
-			"Functioncal subroutine only can return value only accepts a literal value",
+			"Functional subroutine only can return value only accepts a literal value",
 		)
 	}
 

--- a/interpreter/subroutine_test.go
+++ b/interpreter/subroutine_test.go
@@ -8,26 +8,91 @@ import (
 )
 
 func TestFunctionSubroutine(t *testing.T) {
+	tests := []struct {
+		name       string
+		vcl        string
+		assertions map[string]value.Value
+	}{
+		{
+			name: "Functional subroutine returns a value",
+			vcl: `sub compute INTEGER {
+				return 2;
+			}
 
-	// ref: https://github.com/ysugimoto/falco/issues/241
-	t.Run("Functional subroutine returns a value", func(t *testing.T) {
-		input := `
-sub compute INTEGER {
-  if (true) {
-    return 2;
-  }
-  return 3;
-}
+			sub vcl_recv {
+				declare local var.myint INTEGER;
+				set var.myint = compute();
+				set req.http.X-Int-Value = var.myint;
+			}
+			`,
+			assertions: map[string]value.Value{
+				"req.http.X-Int-Value": &value.String{Value: "2"},
+			},
+		},
+		{
+			// ref: https://github.com/ysugimoto/falco/issues/241
+			name: "Functional subroutine returns a value from if",
+			vcl: `sub compute INTEGER {
+				if (true) {
+					return 2;
+				}
+				return 3;
+			}
 
-sub vcl_recv {
-  declare local var.myint INTEGER;
-  set var.myint = compute();
-  set req.http.X-Int-Value = var.myint;
-}
-`
-		assertInterpreter(t, input, context.RecvScope, map[string]value.Value{
-			"req.http.X-Int-Value": &value.String{Value: "2"},
-		}, false)
+			sub vcl_recv {
+				declare local var.myint INTEGER;
+				set var.myint = compute();
+				set req.http.X-Int-Value = var.myint;
+			}
+			`,
+			assertions: map[string]value.Value{
+				"req.http.X-Int-Value": &value.String{Value: "2"},
+			},
+		},
+		{
+			name: "Functional subroutine returns a value from switch",
+			vcl: `sub compute INTEGER {
+				switch (true) {
+				default:
+					return 2;
+					break;
+				}
+				return 3;
+			}
 
-	})
+			sub vcl_recv {
+				declare local var.myint INTEGER;
+				set var.myint = compute();
+				set req.http.X-Int-Value = var.myint;
+			}
+			`,
+			assertions: map[string]value.Value{
+				"req.http.X-Int-Value": &value.String{Value: "2"},
+			},
+		},
+		{
+			name: "Functional subroutine returns a value from bare block",
+			vcl: `sub compute INTEGER {
+				{
+					return 2;
+				}
+			}
+
+			sub vcl_recv {
+				declare local var.myint INTEGER;
+				set var.myint = compute();
+				set req.http.X-Int-Value = var.myint;
+			}
+			`,
+			assertions: map[string]value.Value{
+				"req.http.X-Int-Value": &value.String{Value: "2"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertInterpreter(t, tt.vcl, context.RecvScope, tt.assertions, false)
+		})
+	}
 }


### PR DESCRIPTION
Fix missing support for value returns from switch statements and bare block statements.

Related to #242 and #241 