### PR TITLE
Additional builtin variables

### DIFF
--- a/__generator__/predefined.yml
+++ b/__generator__/predefined.yml
@@ -2161,13 +2161,13 @@ waf.php_injection_score:
   reference: "https://developer.fastly.com/reference/vcl/variables/waf/waf-php-injection-score/"
   on: [PASS, MISS, DELIVER, LOG]
   get: INTEGER
-  get: INTEGER
+  set: INTEGER
 
 waf.rce_score:
   reference: "https://developer.fastly.com/reference/vcl/variables/waf/waf-rce-score/"
   on: [PASS, MISS, DELIVER, LOG]
   get: INTEGER
-  get: INTEGER
+  set: INTEGER
 
 waf.rfi_score:
   reference: "https://developer.fastly.com/reference/vcl/variables/waf/waf-rfi-score/"

--- a/__generator__/predefined.yml
+++ b/__generator__/predefined.yml
@@ -15,6 +15,11 @@ fastly_info.h2.fingerprint:
   on: [RECV, HASH, HIT, MISS, PASS, FETCH, ERROR, DELIVER, LOG]
   get: STRING
 
+fastly_info.request_id:
+  reference: # no references for this variable seem to exist.
+  on: [RECV, HASH, DELIVER, LOG]
+  get: STRING
+
 req.backend.is_cluster:
   reference: "https://www.integralist.co.uk/posts/fastly-varnish/"
   on: [DELIVER]

--- a/__generator__/predefined.yml
+++ b/__generator__/predefined.yml
@@ -20,6 +20,11 @@ req.backend.is_cluster:
   on: [DELIVER]
   get: BOOL
 
+client.sess_timeout:
+  reference: "https://web.archive.org/web/20210306052653/https://developer.fastly.com/reference/vcl/variables/client-connection/client-sess-timeout/"
+  on: [RECV, HASH, HIT, MISS, PASS, FETCH, ERROR, DELIVER, LOG]
+  get: RTIME
+  set: RTIME
 
 ## Following variables are documented.
 backend.conn.is_tls:

--- a/__generator__/predefined.yml
+++ b/__generator__/predefined.yml
@@ -11,7 +11,7 @@ fastly_info.is_cluster_shield:
   get: BOOL
 
 fastly_info.h2.fingerprint:
-  reference: "https://www.integralist.co.uk/posts/fastly-varnish/"
+  reference: # no references for this variable seem to exist.
   on: [RECV, HASH, HIT, MISS, PASS, FETCH, ERROR, DELIVER, LOG]
   get: STRING
 

--- a/context/builtin.go
+++ b/context/builtin.go
@@ -1886,6 +1886,16 @@ func predefinedVariables() Variables {
 						Reference: "https://developer.fastly.com/reference/vcl/variables/client-connection/fastly-info-is-h3/",
 					},
 				},
+				"request_id": &Object{
+					Items: map[string]*Object{},
+					Value: &Accessor{
+						Get:       types.StringType,
+						Set:       types.NeverType,
+						Unset:     false,
+						Scopes:    RECV | HASH | DELIVER | LOG,
+						Reference: "",
+					},
+				},
 				"state": &Object{
 					Items: map[string]*Object{},
 					Value: &Accessor{

--- a/context/builtin.go
+++ b/context/builtin.go
@@ -4469,7 +4469,7 @@ func predefinedVariables() Variables {
 					Items: map[string]*Object{},
 					Value: &Accessor{
 						Get:       types.IntegerType,
-						Set:       types.NeverType,
+						Set:       types.IntegerType,
 						Unset:     false,
 						Scopes:    PASS | MISS | DELIVER | LOG,
 						Reference: "https://developer.fastly.com/reference/vcl/variables/waf/waf-php-injection-score/",
@@ -4479,7 +4479,7 @@ func predefinedVariables() Variables {
 					Items: map[string]*Object{},
 					Value: &Accessor{
 						Get:       types.IntegerType,
-						Set:       types.NeverType,
+						Set:       types.IntegerType,
 						Unset:     false,
 						Scopes:    PASS | MISS | DELIVER | LOG,
 						Reference: "https://developer.fastly.com/reference/vcl/variables/waf/waf-rce-score/",

--- a/context/builtin.go
+++ b/context/builtin.go
@@ -1811,7 +1811,7 @@ func predefinedVariables() Variables {
 								Set:       types.NeverType,
 								Unset:     false,
 								Scopes:    RECV | HASH | HIT | MISS | PASS | FETCH | ERROR | DELIVER | LOG,
-								Reference: "https://www.integralist.co.uk/posts/fastly-varnish/",
+								Reference: "",
 							},
 						},
 						"is_push": &Object{

--- a/context/builtin.go
+++ b/context/builtin.go
@@ -1388,6 +1388,16 @@ func predefinedVariables() Variables {
 						Reference: "https://developer.fastly.com/reference/vcl/variables/client-connection/client-requests/",
 					},
 				},
+				"sess_timeout": &Object{
+					Items: map[string]*Object{},
+					Value: &Accessor{
+						Get:       types.RTimeType,
+						Set:       types.RTimeType,
+						Unset:     false,
+						Scopes:    RECV | HASH | HIT | MISS | PASS | FETCH | ERROR | DELIVER | LOG,
+						Reference: "https://web.archive.org/web/20210306052653/https://developer.fastly.com/reference/vcl/variables/client-connection/client-sess-timeout/",
+					},
+				},
 				"socket": &Object{
 					Items: map[string]*Object{
 						"congestion_algorithm": &Object{

--- a/interpreter/context/context.go
+++ b/interpreter/context/context.go
@@ -86,6 +86,7 @@ type Context struct {
 	ClientSocketCongestionAlgorithm     *value.String
 	ClientSocketCwnd                    *value.Integer
 	ClientSocketPace                    *value.Integer
+	ClientSessTimeout                   *value.RTime
 	EsiAllowInsideCData                 *value.Boolean
 	EnableRangeOnPass                   *value.Boolean
 	EnableSegmentedCaching              *value.Boolean
@@ -182,6 +183,7 @@ func New(options ...Option) *Context {
 		ClientSocketCongestionAlgorithm:     &value.String{Value: "cubic"},
 		ClientSocketCwnd:                    &value.Integer{Value: 60},
 		ClientSocketPace:                    &value.Integer{},
+		ClientSessTimeout:                   &value.RTime{Value: time.Minute * 10},
 		EsiAllowInsideCData:                 &value.Boolean{},
 		EnableRangeOnPass:                   &value.Boolean{},
 		EnableSegmentedCaching:              &value.Boolean{},

--- a/interpreter/context/context.go
+++ b/interpreter/context/context.go
@@ -99,7 +99,7 @@ type Context struct {
 	WafCounter                          *value.Integer
 	WafExecuted                         *value.Boolean
 	WafHttpViolationScore               *value.Integer
-	WafInbouldAnomalyScore              *value.Integer
+	WafInboundAnomalyScore              *value.Integer
 	WafLFIScore                         *value.Integer
 	WafLogData                          *value.String
 	WafLogged                           *value.Boolean
@@ -107,7 +107,7 @@ type Context struct {
 	WafPassed                           *value.Boolean
 	WafRFIScore                         *value.Integer
 	WafRuleId                           *value.Integer
-	WafSesionFixationScore              *value.Integer
+	WafSessionFixationScore             *value.Integer
 	WafSeverity                         *value.Integer
 	WafXSSScore                         *value.Integer
 	BetweenBytesTimeout                 *value.RTime
@@ -196,7 +196,7 @@ func New(options ...Option) *Context {
 		WafCounter:                          &value.Integer{},
 		WafExecuted:                         &value.Boolean{},
 		WafHttpViolationScore:               &value.Integer{},
-		WafInbouldAnomalyScore:              &value.Integer{},
+		WafInboundAnomalyScore:              &value.Integer{},
 		WafLFIScore:                         &value.Integer{},
 		WafLogData:                          &value.String{},
 		WafLogged:                           &value.Boolean{},
@@ -204,7 +204,7 @@ func New(options ...Option) *Context {
 		WafPassed:                           &value.Boolean{},
 		WafRFIScore:                         &value.Integer{},
 		WafRuleId:                           &value.Integer{},
-		WafSesionFixationScore:              &value.Integer{},
+		WafSessionFixationScore:             &value.Integer{},
 		WafSeverity:                         &value.Integer{},
 		WafXSSScore:                         &value.Integer{},
 		BetweenBytesTimeout:                 &value.RTime{},

--- a/interpreter/context/context.go
+++ b/interpreter/context/context.go
@@ -1,6 +1,8 @@
 package context
 
 import (
+	"fmt"
+	"math/rand"
 	"net/http"
 	"time"
 
@@ -73,6 +75,7 @@ type Context struct {
 	Restarts                            int
 	State                               string
 	RequestHash                         *value.String
+	RequestID                           *value.String
 	Backend                             *value.Backend
 	MaxStaleIfError                     *value.RTime
 	MaxStaleWhileRevalidate             *value.RTime
@@ -167,32 +170,38 @@ func New(options ...Option) *Context {
 		SubroutineFunctions: make(map[string]*ast.SubroutineDeclaration),
 		OverrideBackends:    make(map[string]*config.OverrideBackend),
 
-		CacheHitItem:                        nil,
-		RequestStartTime:                    time.Now(),
-		State:                               "NONE",
-		Backend:                             nil,
-		ClientIdentity:                      nil,
-		MaxStaleIfError:                     &value.RTime{Value: defaultStaleDuration},
-		MaxStaleWhileRevalidate:             &value.RTime{Value: defaultStaleDuration},
-		Stale:                               &value.Boolean{},
-		StaleIsError:                        &value.Boolean{},
-		StaleIsRevalidating:                 &value.Boolean{},
-		StaleContents:                       &value.String{},
-		FastlyError:                         &value.String{},
-		ClientGeoIpOverride:                 &value.String{},
-		ClientSocketCongestionAlgorithm:     &value.String{Value: "cubic"},
-		ClientSocketCwnd:                    &value.Integer{Value: 60},
-		ClientSocketPace:                    &value.Integer{},
-		ClientSessTimeout:                   &value.RTime{Value: time.Minute * 10},
-		EsiAllowInsideCData:                 &value.Boolean{},
-		EnableRangeOnPass:                   &value.Boolean{},
-		EnableSegmentedCaching:              &value.Boolean{},
-		EnableSSI:                           &value.Boolean{},
-		HashAlwaysMiss:                      &value.Boolean{},
-		HashIgnoreBusy:                      &value.Boolean{},
-		SegmentedCacheingBlockSize:          &value.Integer{},
-		ESILevel:                            &value.Integer{},
-		RequestHash:                         &value.String{},
+		CacheHitItem:                    nil,
+		RequestStartTime:                time.Now(),
+		State:                           "NONE",
+		Backend:                         nil,
+		ClientIdentity:                  nil,
+		MaxStaleIfError:                 &value.RTime{Value: defaultStaleDuration},
+		MaxStaleWhileRevalidate:         &value.RTime{Value: defaultStaleDuration},
+		Stale:                           &value.Boolean{},
+		StaleIsError:                    &value.Boolean{},
+		StaleIsRevalidating:             &value.Boolean{},
+		StaleContents:                   &value.String{},
+		FastlyError:                     &value.String{},
+		ClientGeoIpOverride:             &value.String{},
+		ClientSocketCongestionAlgorithm: &value.String{Value: "cubic"},
+		ClientSocketCwnd:                &value.Integer{Value: 60},
+		ClientSocketPace:                &value.Integer{},
+		ClientSessTimeout:               &value.RTime{Value: time.Minute * 10},
+		EsiAllowInsideCData:             &value.Boolean{},
+		EnableRangeOnPass:               &value.Boolean{},
+		EnableSegmentedCaching:          &value.Boolean{},
+		EnableSSI:                       &value.Boolean{},
+		HashAlwaysMiss:                  &value.Boolean{},
+		HashIgnoreBusy:                  &value.Boolean{},
+		SegmentedCacheingBlockSize:      &value.Integer{},
+		ESILevel:                        &value.Integer{},
+		RequestHash:                     &value.String{},
+
+		// The format of the request ID is not documented.
+		// Observations indicate that it is a zero padded hex representation of two
+		// 64-bit values The first 64-bits are seemingly random, the nature of the
+		// apparent randomness is unknown. The second 64-bit value is always 1.
+		RequestID:                           &value.String{Value: fmt.Sprintf("%016x0000000000000001", rand.Int63())},
 		WafAnomalyScore:                     &value.Integer{},
 		WafBlocked:                          &value.Boolean{},
 		WafCounter:                          &value.Integer{},

--- a/interpreter/context/context.go
+++ b/interpreter/context/context.go
@@ -109,6 +109,8 @@ type Context struct {
 	WafLogged                           *value.Boolean
 	WafMessage                          *value.String
 	WafPassed                           *value.Boolean
+	WafPHPInjectionScore                *value.Integer
+	WafRCEScore                         *value.Integer
 	WafRFIScore                         *value.Integer
 	WafRuleId                           *value.Integer
 	WafSessionFixationScore             *value.Integer
@@ -213,6 +215,8 @@ func New(options ...Option) *Context {
 		WafLogged:                           &value.Boolean{},
 		WafMessage:                          &value.String{},
 		WafPassed:                           &value.Boolean{},
+		WafPHPInjectionScore:                &value.Integer{},
+		WafRCEScore:                         &value.Integer{},
 		WafRFIScore:                         &value.Integer{},
 		WafRuleId:                           &value.Integer{},
 		WafSessionFixationScore:             &value.Integer{},

--- a/interpreter/variable/all.go
+++ b/interpreter/variable/all.go
@@ -110,6 +110,12 @@ func (v *AllScopeVariables) Get(s context.Scope, name string) (value.Value, erro
 		return &value.Boolean{Value: req.ProtoMajor == 3}, nil
 	case FASTLY_INFO_HOST_HEADER:
 		return &value.String{Value: v.ctx.OriginalHost}, nil
+	case FASTLY_INFO_H2_FINGERPRINT:
+		if req.ProtoMajor != 2 {
+			return &value.String{}, nil
+		}
+		// Format is undocumented, returning the value seen with the fiddle client.
+		return &value.String{Value: "|00|1:0:0:16|m,s,p,a"}, nil
 
 	// Backend is always healthy on simulator
 	case REQ_BACKEND_HEALTHY:

--- a/interpreter/variable/all.go
+++ b/interpreter/variable/all.go
@@ -100,6 +100,8 @@ func (v *AllScopeVariables) Get(s context.Scope, name string) (value.Value, erro
 	case CLIENT_PLATFORM_TVPLAYER:
 		ua := uasurfer.Parse(req.Header.Get("User-Agent"))
 		return &value.Boolean{Value: ua.DeviceType == uasurfer.DeviceTV}, nil
+	case CLIENT_SESS_TIMEOUT:
+		return v.ctx.ClientSessTimeout, nil
 	case FASTLY_INFO_EDGE_IS_TLS:
 		return &value.Boolean{Value: req.TLS != nil}, nil
 	case FASTLY_INFO_IS_H2:
@@ -655,6 +657,11 @@ func (v *AllScopeVariables) Set(s context.Scope, name, operator string, val valu
 			v.ctx.ClientIdentity = &value.String{Value: ""}
 		}
 		if err := doAssign(v.ctx.ClientIdentity, operator, val); err != nil {
+			return errors.WithStack(err)
+		}
+		return nil
+	case CLIENT_SESS_TIMEOUT:
+		if err := doAssign(v.ctx.ClientSessTimeout, operator, val); err != nil {
 			return errors.WithStack(err)
 		}
 		return nil

--- a/interpreter/variable/deliver.go
+++ b/interpreter/variable/deliver.go
@@ -237,7 +237,7 @@ func (v *DeliverScopeVariables) Get(s context.Scope, name string) (value.Value, 
 	} else if val != nil {
 		return val, nil
 	}
-	if val, err := GetFastlyInfoVairable(name); err != nil {
+	if val, err := GetFastlyInfoVariable(name); err != nil {
 		return value.Null, errors.WithStack(err)
 	} else if val != nil {
 		return val, nil

--- a/interpreter/variable/deliver.go
+++ b/interpreter/variable/deliver.go
@@ -219,6 +219,8 @@ func (v *DeliverScopeVariables) Get(s context.Scope, name string) (value.Value, 
 	// Digest ratio will return fixed value
 	case REQ_DIGEST_RATIO:
 		return &value.Float{Value: 0.4}, nil
+	case FASTLY_INFO_REQUEST_ID:
+		return v.ctx.RequestID, nil
 	}
 
 	// Look up shared variables

--- a/interpreter/variable/hash.go
+++ b/interpreter/variable/hash.go
@@ -38,6 +38,8 @@ func (v *HashScopeVariables) Get(s context.Scope, name string) (value.Value, err
 
 	case REQ_IS_PURGE:
 		return &value.Boolean{Value: v.ctx.Request.Method == PURGE}, nil
+	case FASTLY_INFO_REQUEST_ID:
+		return v.ctx.RequestID, nil
 	}
 
 	// Look up shared variables

--- a/interpreter/variable/hash.go
+++ b/interpreter/variable/hash.go
@@ -51,7 +51,7 @@ func (v *HashScopeVariables) Get(s context.Scope, name string) (value.Value, err
 	} else if val != nil {
 		return val, nil
 	}
-	if val, err := GetFastlyInfoVairable(name); err != nil {
+	if val, err := GetFastlyInfoVariable(name); err != nil {
 		return value.Null, errors.WithStack(err)
 	} else if val != nil {
 		return val, nil

--- a/interpreter/variable/log.go
+++ b/interpreter/variable/log.go
@@ -299,7 +299,7 @@ func (v *LogScopeVariables) Get(s context.Scope, name string) (value.Value, erro
 	} else if val != nil {
 		return val, nil
 	}
-	if val, err := GetFastlyInfoVairable(name); err != nil {
+	if val, err := GetFastlyInfoVariable(name); err != nil {
 		return value.Null, errors.WithStack(err)
 	} else if val != nil {
 		return val, nil

--- a/interpreter/variable/log.go
+++ b/interpreter/variable/log.go
@@ -281,6 +281,8 @@ func (v *LogScopeVariables) Get(s context.Scope, name string) (value.Value, erro
 		return &value.Integer{Value: 0}, nil
 	case SEGMENTED_CACHING_TOTAL_BLOCKS:
 		return &value.Integer{Value: 0}, nil
+	case FASTLY_INFO_REQUEST_ID:
+		return v.ctx.RequestID, nil
 	}
 
 	// Look up shared variables

--- a/interpreter/variable/predfined.go
+++ b/interpreter/variable/predfined.go
@@ -132,6 +132,7 @@ const (
 	CLIENT_PLATFORM_TVPLAYER                   = "client.platform.tvplayer"
 	CLIENT_PORT                                = "client.port"
 	CLIENT_REQUESTS                            = "client.requests"
+	CLIENT_SESS_TIMEOUT                        = "client.sess_timeout"
 	CLIENT_SOCKET_CONGESTION_ALGORITHM         = "client.socket.congestion_algorithm"
 	CLIENT_SOCKET_CWND                         = "client.socket.cwnd"
 	CLIENT_SOCKET_NEXTHOP                      = "client.socket.nexthop"

--- a/interpreter/variable/predfined.go
+++ b/interpreter/variable/predfined.go
@@ -179,6 +179,7 @@ const (
 	FASTLY_INFO_IS_CLUSTER_SHIELD              = "fastly_info.is_cluster_shield"
 	FASTLY_INFO_IS_H2                          = "fastly_info.is_h2"
 	FASTLY_INFO_IS_H3                          = "fastly_info.is_h3"
+	FASTLY_INFO_REQUEST_ID                     = "fastly_info.request_id"
 	FASTLY_INFO_STATE                          = "fastly_info.state"
 	GEOIP_AREA_CODE                            = "geoip.area_code"
 	GEOIP_CITY                                 = "geoip.city"

--- a/interpreter/variable/recv.go
+++ b/interpreter/variable/recv.go
@@ -86,7 +86,7 @@ func (v *RecvScopeVariables) Get(s context.Scope, name string) (value.Value, err
 	} else if val != nil {
 		return val, nil
 	}
-	if val, err := GetFastlyInfoVairable(name); err != nil {
+	if val, err := GetFastlyInfoVariable(name); err != nil {
 		return value.Null, errors.WithStack(err)
 	} else if val != nil {
 		return val, nil

--- a/interpreter/variable/recv.go
+++ b/interpreter/variable/recv.go
@@ -68,6 +68,8 @@ func (v *RecvScopeVariables) Get(s context.Scope, name string) (value.Value, err
 		return &value.Boolean{Value: v.ctx.Request.Method == "PURGE"}, nil
 	case SEGMENTED_CACHING_BLOCK_SIZE:
 		return v.ctx.SegmentedCacheingBlockSize, nil
+	case FASTLY_INFO_REQUEST_ID:
+		return v.ctx.RequestID, nil
 	}
 
 	// Look up shared variables

--- a/interpreter/variable/shared.go
+++ b/interpreter/variable/shared.go
@@ -184,9 +184,9 @@ func GetWafVariables(ctx *context.Context, name string) (value.Value, error) {
 	case WAF_PASSED:
 		return ctx.WafPassed, nil
 	case WAF_PHP_INJECTION_SCORE:
-		return &value.Integer{Value: 0}, nil
+		return ctx.WafPHPInjectionScore, nil
 	case WAF_RCE_SCORE:
-		return &value.Integer{Value: 0}, nil
+		return ctx.WafRCEScore, nil
 	case WAF_RFI_SCORE:
 		return ctx.WafRFIScore, nil
 	case WAF_RULE_ID:
@@ -294,7 +294,17 @@ func SetWafVariables(ctx *context.Context, name, operator string, val value.Valu
 			return true, errors.WithStack(err)
 		}
 		return true, nil
-	case WAF_FAILURES, WAF_PHP_INJECTION_SCORE, WAF_RCE_SCORE:
+	case WAF_PHP_INJECTION_SCORE:
+		if err := doAssign(ctx.WafPHPInjectionScore, operator, val); err != nil {
+			return true, errors.WithStack(err)
+		}
+		return true, nil
+	case WAF_RCE_SCORE:
+		if err := doAssign(ctx.WafRCEScore, operator, val); err != nil {
+			return true, errors.WithStack(err)
+		}
+		return true, nil
+	case WAF_FAILURES:
 		return false, errors.WithStack(fmt.Errorf(
 			"Variable %s could not set value", name,
 		))

--- a/interpreter/variable/shared.go
+++ b/interpreter/variable/shared.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-func GetFastlyInfoVairable(name string) (value.Value, error) {
+func GetFastlyInfoVariable(name string) (value.Value, error) {
 	switch name {
 	case FASTLY_INFO_H2_IS_PUSH:
 		return &value.Boolean{Value: false}, nil
@@ -101,7 +101,7 @@ func GetTCPInfoVariable(name string) (value.Value, error) {
 }
 
 // TODO: consider we need to construct TLS server manually instead of net/http server
-// Temporaly return tentative data found in Fastly fiddle
+// Temporarily return tentative data found in Fastly fiddle
 func GetTLSVariable(s *tls.ConnectionState, name string) (value.Value, error) {
 	switch name {
 	case TLS_CLIENT_CIPHER:
@@ -155,7 +155,7 @@ func GetTLSVariable(s *tls.ConnectionState, name string) (value.Value, error) {
 }
 
 // Shared WAF relation variables.
-// Note that we could not sumulate Fastly legacy waf behavior, returns fake values.
+// Note that we could not simulate Fastly legacy waf behavior, returns fake values.
 // If user write logic which corresponds to following value, process may be unexpected.
 func GetWafVariables(ctx *context.Context, name string) (value.Value, error) {
 	switch name {
@@ -172,7 +172,7 @@ func GetWafVariables(ctx *context.Context, name string) (value.Value, error) {
 	case WAF_HTTP_VIOLATION_SCORE:
 		return ctx.WafHttpViolationScore, nil
 	case WAF_INBOUND_ANOMALY_SCORE:
-		return ctx.WafInbouldAnomalyScore, nil
+		return ctx.WafInboundAnomalyScore, nil
 	case WAF_LFI_SCORE:
 		return ctx.WafLFIScore, nil
 	case WAF_LOGDATA:
@@ -192,7 +192,7 @@ func GetWafVariables(ctx *context.Context, name string) (value.Value, error) {
 	case WAF_RULE_ID:
 		return ctx.WafRuleId, nil
 	case WAF_SESSION_FIXATION_SCORE:
-		return ctx.WafSesionFixationScore, nil
+		return ctx.WafSessionFixationScore, nil
 	case WAF_SEVERITY:
 		return ctx.WafSeverity, nil
 	case WAF_XSS_SCORE:
@@ -240,7 +240,7 @@ func SetWafVariables(ctx *context.Context, name, operator string, val value.Valu
 		}
 		return true, nil
 	case WAF_INBOUND_ANOMALY_SCORE:
-		if err := doAssign(ctx.WafInbouldAnomalyScore, operator, val); err != nil {
+		if err := doAssign(ctx.WafInboundAnomalyScore, operator, val); err != nil {
 			return true, errors.WithStack(err)
 		}
 		return true, nil
@@ -280,7 +280,7 @@ func SetWafVariables(ctx *context.Context, name, operator string, val value.Valu
 		}
 		return true, nil
 	case WAF_SESSION_FIXATION_SCORE:
-		if err := doAssign(ctx.WafSesionFixationScore, operator, val); err != nil {
+		if err := doAssign(ctx.WafSessionFixationScore, operator, val); err != nil {
 			return true, errors.WithStack(err)
 		}
 		return true, nil
@@ -294,9 +294,7 @@ func SetWafVariables(ctx *context.Context, name, operator string, val value.Valu
 			return true, errors.WithStack(err)
 		}
 		return true, nil
-	case WAF_FAILURES,
-		"waf.php_injection_score",
-		"waf.rce_score":
+	case WAF_FAILURES, WAF_PHP_INJECTION_SCORE, WAF_RCE_SCORE:
 		return false, errors.WithStack(fmt.Errorf(
 			"Variable %s could not set value", name,
 		))

--- a/linter/helper.go
+++ b/linter/helper.go
@@ -42,6 +42,7 @@ var BackendProbePropertyTypes = map[string]types.Type{
 	"window":            types.IntegerType,
 	"initial":           types.IntegerType,
 	"threshold":         types.IntegerType,
+	"url":               types.StringType,
 }
 
 type DirectorProps struct {


### PR DESCRIPTION
Adds implementation for undocumented built-in variables:
* `fastly_info.h2.fingerprint`
* `fastly_info.request_id`
* `client.sess_timeout`

**Additional fixes**

* Fixes some interpreter typos related to legacy WAF.
* Fixes issue with generating set code for legacy WAF variables `waf.php_injection_score` and `waf.rce_score`.
* Adds seemingly undocumented backend probe property `.url`. It is difficult to show confirmation that this property is valid since the fiddle tool doesn't allow VCL definitions of backends so see attached screenshot.

Screenshot of Fastly console showing no errors with activated service using `.url` probe value:
![Screenshot 2024-01-22 21 57 05](https://github.com/ysugimoto/falco/assets/25832/0ed01594-148f-4b1d-888b-cf776f5a78f8)