### PR TITLE
Add assert.not_subroutine_called

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -155,34 +155,35 @@ On running tests, `falco` injects special runtime functions and variables to ass
 
 We describe them following table and examples:
 
-| Name                     | Type       | Description                                                                                  |
-|:-------------------------|:----------:|:---------------------------------------------------------------------------------------------|
-| testing.state            | STRING     | Return state which is called `return` statement in a subroutine                              |
-| testing.call_subroutine  | FUNCTION   | Call subroutine which is defined in main VCL                                                 |
-| testing.fixed_time       | FUNCTION   | Use fixed time whole the test suite                                                          |
-| testing.override_host    | FUNCTION   | Override request host with provided argument in the test case                                |
-| testing.inspect          | FUNCTION   | Inspect predefined variables for any scopes                                                  |
-| testing.table_set        | FUNCTION   | Inject value for key to main VCL table                                                       |
-| testing.table_merge      | FUNCTION   | Merge values from testing VCL table to main VCL table                                        |
-| assert                   | FUNCTION   | Assert provided expression should be true                                                    |
-| assert.true              | FUNCTION   | Assert actual value should be true                                                           |
-| assert.false             | FUNCTION   | Assert actual value should be false                                                          |
-| assert.is_notset         | FUNCTION   | Assert actual value should be NotSet                                                         |
-| assert.equal             | FUNCTION   | Assert actual value should be equal to expected value (alias of assert.strict_equal)         |
-| assert.not_equal         | FUNCTION   | Assert actual value should not be equal to expected value (alias of assert.not_strict_equal) |
-| assert.strict_equal      | FUNCTION   | Assert actual value should be equal to expected value strictly                               |
-| assert.not_strict_equal  | FUNCTION   | Assert actual value should not be equal to expected value strictly                           |
-| assert.equal_fold        | FUNCTION   | Assert actual value should be equal to with case insensitive                                 |
-| assert.match             | FUNCTION   | Assert actual string should be matched against expected regular expression                   |
-| assert.not_match         | FUNCTION   | Assert actual string should not be matches against expected regular expression               |
-| assert.contains          | FUNCTION   | Assert actual string should contain the expected string                                      |
-| assert.not_contains      | FUNCTION   | Assert actual string should not contain the expected string                                  |
-| assert.starts_with       | FUNCTION   | Assert actual string should start with expected string                                       |
-| assert.ends_with         | FUNCTION   | Assert actual string should end with expected string                                         |
-| assert.subroutine_called | FUNCTION   | Assert subroutine has called in testing subroutine (with times)                              |
-| assert.restart           | FUNCTION   | Assert restart statement has called                                                          |
-| assert.state             | FUNCTION   | Assert after state is expected one                                                           |
-| assert.error             | FUNCTION   | Assert error status code (and response) if error statement has called                        |
+| Name                         | Type       | Description                                                                                  |
+|:-----------------------------|:----------:|:---------------------------------------------------------------------------------------------|
+| testing.state                | STRING     | Return state which is called `return` statement in a subroutine                              |
+| testing.call_subroutine      | FUNCTION   | Call subroutine which is defined in main VCL                                                 |
+| testing.fixed_time           | FUNCTION   | Use fixed time whole the test suite                                                          |
+| testing.override_host        | FUNCTION   | Override request host with provided argument in the test case                                |
+| testing.inspect              | FUNCTION   | Inspect predefined variables for any scopes                                                  |
+| testing.table_set            | FUNCTION   | Inject value for key to main VCL table                                                       |
+| testing.table_merge          | FUNCTION   | Merge values from testing VCL table to main VCL table                                        |
+| assert                       | FUNCTION   | Assert provided expression should be true                                                    |
+| assert.true                  | FUNCTION   | Assert actual value should be true                                                           |
+| assert.false                 | FUNCTION   | Assert actual value should be false                                                          |
+| assert.is_notset             | FUNCTION   | Assert actual value should be NotSet                                                         |
+| assert.equal                 | FUNCTION   | Assert actual value should be equal to expected value (alias of assert.strict_equal)         |
+| assert.not_equal             | FUNCTION   | Assert actual value should not be equal to expected value (alias of assert.not_strict_equal) |
+| assert.strict_equal          | FUNCTION   | Assert actual value should be equal to expected value strictly                               |
+| assert.not_strict_equal      | FUNCTION   | Assert actual value should not be equal to expected value strictly                           |
+| assert.equal_fold            | FUNCTION   | Assert actual value should be equal to with case insensitive                                 |
+| assert.match                 | FUNCTION   | Assert actual string should be matched against expected regular expression                   |
+| assert.not_match             | FUNCTION   | Assert actual string should not be matches against expected regular expression               |
+| assert.contains              | FUNCTION   | Assert actual string should contain the expected string                                      |
+| assert.not_contains          | FUNCTION   | Assert actual string should not contain the expected string                                  |
+| assert.starts_with           | FUNCTION   | Assert actual string should start with expected string                                       |
+| assert.ends_with             | FUNCTION   | Assert actual string should end with expected string                                         |
+| assert.subroutine_called     | FUNCTION   | Assert subroutine has called in testing subroutine (with times)                              |
+| assert.not_subroutine_called | FUNCTION   | Assert subroutine has not called in testing subroutine                                       |
+| assert.restart               | FUNCTION   | Assert restart statement has called                                                          |
+| assert.state                 | FUNCTION   | Assert after state is expected one                                                           |
+| assert.error                 | FUNCTION   | Assert error status code (and response) if error statement has called                        |
 
 ----
 
@@ -633,6 +634,22 @@ sub test_vcl {
 
     // Additionally, "auth_recv" called only once
     assert.subroutine_called("auth_recv", 1);
+}
+```
+
+----
+
+### assert.not_subroutine_called(STRING name [, STRING message])
+
+Assert subroutine has not called in testing subroutine (with times).
+
+```vcl
+sub test_vcl {
+    // Like "auth_recv" subroutine will be called in vcl_recv
+    testing.call_subroutine("vcl_recv");
+
+    // Assert "flag_recv" subroutine has not called in processing vcl_recv
+    assert.not_subroutine_called("flag_recv");
 }
 ```
 

--- a/tester/function/assert_not_subroutine_called.go
+++ b/tester/function/assert_not_subroutine_called.go
@@ -1,0 +1,49 @@
+package function
+
+import (
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/function/errors"
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+const Assert_not_subroutine_called_Name = "assert.not_subroutine_called"
+
+func Assert_not_subroutine_called_Validate(args []value.Value) error {
+	if len(args) < 1 || len(args) > 2 {
+		return errors.ArgumentNotInRange(Assert_not_subroutine_called_Name, 1, 2, args)
+	}
+
+	if args[0].Type() != value.StringType {
+		return errors.TypeMismatch(Assert_not_subroutine_called_Name, 1, value.StringType, args[0].Type())
+	}
+	return nil
+}
+
+func Assert_not_subroutine_called(ctx *context.Context, args ...value.Value) (value.Value, error) {
+	if err := Assert_not_subroutine_called_Validate(args); err != nil {
+		return nil, errors.NewTestingError(err.Error())
+	}
+
+	name := value.Unwrap[*value.String](args[0]).Value
+
+	// Check custom message
+	var message string
+	if len(args) == 2 { // (name, message)
+		if args[1].Type() != value.StringType {
+			return &value.Boolean{}, errors.NewTestingError(
+				"%s: 2nd argument must be STRING, %s provided",
+				Assert_not_subroutine_called_Name, args[1].Type(),
+			)
+		}
+		message = value.Unwrap[*value.String](args[1]).Value
+	}
+
+	_, ok := ctx.SubroutineCalls[name]
+	if ok {
+		if message != "" {
+			return &value.Boolean{}, errors.NewAssertionError(args[0], message)
+		}
+		return &value.Boolean{}, errors.NewAssertionError(args[0], "Subroutine %s is called", name)
+	}
+	return &value.Boolean{Value: true}, nil
+}

--- a/tester/function/assert_not_subroutine_called_test.go
+++ b/tester/function/assert_not_subroutine_called_test.go
@@ -1,0 +1,61 @@
+package function
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/function/errors"
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+func Test_Assert_not_subroutine_called(t *testing.T) {
+
+	tests := []struct {
+		args   []value.Value
+		err    error
+		expect *value.Boolean
+	}{
+		{
+			args: []value.Value{
+				&value.String{Value: "counter_recv_not_called"},
+			},
+			expect: &value.Boolean{Value: true},
+		},
+		{
+			args: []value.Value{
+				&value.String{Value: "counter_recv"},
+			},
+			expect: &value.Boolean{Value: false},
+			err:    &errors.AssertionError{},
+		},
+		{
+			args: []value.Value{
+				&value.String{Value: "counter_recv"},
+				&value.String{Value: "custom_message"},
+			},
+			expect: &value.Boolean{Value: false},
+			err:    &errors.AssertionError{},
+		},
+	}
+
+	for i := range tests {
+		_, err := Assert_not_subroutine_called(
+			&context.Context{
+				SubroutineCalls: map[string]int{
+					"counter_recv": 1,
+				},
+			},
+			tests[i].args...,
+		)
+		if diff := cmp.Diff(
+			tests[i].err,
+			err,
+			cmpopts.IgnoreFields(errors.AssertionError{}, "Message", "Actual"),
+			cmpopts.IgnoreFields(errors.TestingError{}, "Message"),
+		); diff != "" {
+			t.Errorf("Assert_not_subroutine_called()[%d] error: diff=%s", i, diff)
+		}
+	}
+}

--- a/tester/function/testing_functions.go
+++ b/tester/function/testing_functions.go
@@ -158,6 +158,26 @@ func assertionFunctions(i *interpreter.Interpreter, c Counter) Functions {
 				return false
 			},
 		},
+		"assert.not_subroutine_called": {
+			Scope: allScope,
+			Call: func(ctx *context.Context, args ...value.Value) (value.Value, error) {
+				unwrapped, err := unwrapIdentArguments(i, args)
+				if err != nil {
+					return value.Null, errors.WithStack(err)
+				}
+				v, err := Assert_not_subroutine_called(ctx, unwrapped...)
+				if err != nil {
+					c.Fail()
+				} else {
+					c.Pass()
+				}
+				return v, err
+			},
+			CanStatementCall: true,
+			IsIdentArgument: func(i int) bool {
+				return false
+			},
+		},
 		"assert.restart": {
 			Scope: allScope,
 			Call: func(ctx *context.Context, args ...value.Value) (value.Value, error) {


### PR DESCRIPTION
This PR will add `assert.not_subroutine_called` asserter.

* assert.not_subroutine_called Assert subroutine has not called in testing subroutine.

I have a test case where I want to verify that a function has never been called.