### PR TITLE
req.url behavior changed to represent raw url path

### DIFF
--- a/debugger/codeview/codeview.go
+++ b/debugger/codeview/codeview.go
@@ -103,7 +103,7 @@ func (c *CodeView) DrawCode(screen tcell.Screen) {
 
 	// Display server and file info
 	prefix := strings.Repeat(" ", width-len(c.file)-2)
-	fmt.Fprint(w, prefix+colors.Blue(c.file))
+	fmt.Fprint(w, prefix+colors.Blue("%s", c.file))
 
 	// Calculate max line unit
 	format := fmt.Sprintf(" %%%dd", int(math.Floor(math.Log10(float64(len(lines)))+1)))
@@ -129,7 +129,7 @@ func (c *CodeView) DrawCode(screen tcell.Screen) {
 				w,
 				"%s%s\n",
 				colors.Bold(colors.Underline("[black:silver:]"+lineNumber))+colors.Reset, // highlight line number
-				colors.Underline(" "+line.text()+suffix),                                 // with underline
+				colors.Underline(" %s%s", line.text(), suffix),                           // with underline
 			)
 		// Otherwise, simply write line
 		default:

--- a/debugger/codeview/entity.go
+++ b/debugger/codeview/entity.go
@@ -14,7 +14,7 @@ type Character struct {
 
 func (c Character) text() string {
 	if c.color != nil {
-		return c.color(c.code)
+		return c.color("%s", c.code)
 	}
 	return c.code
 }

--- a/debugger/colors/color.go
+++ b/debugger/colors/color.go
@@ -2,7 +2,6 @@ package colors
 
 import (
 	"fmt"
-
 	"github.com/gdamore/tcell/v2"
 )
 

--- a/debugger/shellview/shellview.go
+++ b/debugger/shellview/shellview.go
@@ -86,11 +86,11 @@ func (s *ShellView) HistoryDown() {
 }
 
 func (s *ShellView) CommandError(result string) {
-	s.buffers = append(s.buffers, colors.Bold(colors.Red(">> "+result)))
+	s.buffers = append(s.buffers, colors.Bold("%s", colors.Red(">> %s", result)))
 }
 
 func (s *ShellView) CommandResult(result string) {
-	s.buffers = append(s.buffers, colors.Bold(colors.Yellow(">> "+result)))
+	s.buffers = append(s.buffers, colors.Bold("%s", colors.Yellow(">> %s", result)))
 }
 
 func (s *ShellView) Draw(screen tcell.Screen) {

--- a/interpreter/function/builtin/urldecode.go
+++ b/interpreter/function/builtin/urldecode.go
@@ -3,12 +3,10 @@
 package builtin
 
 import (
-	"net/url"
-	"strings"
-
 	"github.com/ysugimoto/falco/interpreter/context"
 	"github.com/ysugimoto/falco/interpreter/function/errors"
 	"github.com/ysugimoto/falco/interpreter/value"
+	"net/url"
 )
 
 const Urldecode_Name = "urldecode"
@@ -38,18 +36,9 @@ func Urldecode(ctx *context.Context, args ...value.Value) (value.Value, error) {
 	}
 
 	input := value.Unwrap[*value.String](args[0]).Value
-	// "%" string is also encoded as "%25" so we need to decode properly
-	input = strings.ReplaceAll(input, "%25", "%")
 
-	dec, err := url.PathUnescape(input)
-	if err != nil {
-		return &value.String{IsNotSet: true}, errors.New(Urldecode_Name,
-			"Failed to urldecode string: %s", input,
-		)
-	}
-	// url.PathUnescape does not decode "+" sign to white space so we also need to call url.QueryUnescape
-	// in order to decode "+" sign into white space
-	dec, err = url.QueryUnescape(dec)
+	// fastly implementation of urldecode replaces "+" with white space in addition to %xx handling
+	dec, err := url.QueryUnescape(input)
 	if err != nil {
 		return &value.String{IsNotSet: true}, errors.New(Urldecode_Name,
 			"Failed to urldecode string: %s", input,

--- a/interpreter/function/builtin/urldecode_test.go
+++ b/interpreter/function/builtin/urldecode_test.go
@@ -20,7 +20,7 @@ func Test_Urldecode(t *testing.T) {
 		expect string
 	}{
 		{input: "hello%20world+!", expect: "hello world !"},
-		{input: "hello%2520world+!", expect: "hello world !"},
+		{input: "hello%2520world+!", expect: "hello%20world !"},
 	}
 
 	for i, tt := range tests {

--- a/interpreter/variable/all.go
+++ b/interpreter/variable/all.go
@@ -718,7 +718,7 @@ func (v *AllScopeVariables) Set(s context.Scope, name, operator string, val valu
 	case REQ_REQUEST:
 		return v.Set(s, "req.method", operator, val)
 	case REQ_URL:
-		u := v.ctx.Request.URL.Path
+		u := v.ctx.Request.URL.EscapedPath()
 		if query := v.ctx.Request.URL.RawQuery; query != "" {
 			u += "?" + query
 		}
@@ -734,7 +734,8 @@ func (v *AllScopeVariables) Set(s context.Scope, name, operator string, val valu
 			return errors.WithStack(err)
 		}
 		// Update request URLs
-		v.ctx.Request.URL.RawPath = parsed.EscapedPath()
+		v.ctx.Request.URL.RawPath = parsed.RawPath
+		v.ctx.Request.URL.Path = parsed.Path
 		v.ctx.Request.URL.RawQuery = parsed.RawQuery
 		v.ctx.Request.URL.RawFragment = parsed.RawFragment
 		return nil

--- a/interpreter/variable/all.go
+++ b/interpreter/variable/all.go
@@ -490,7 +490,7 @@ func (v *AllScopeVariables) Get(s context.Scope, name string) (value.Value, erro
 		}
 		return &value.String{Value: id}, nil
 	case REQ_TOPURL: // FIXME: what is the difference of req.url ?
-		u := req.URL.Path
+		u := req.URL.EscapedPath()
 		if v := req.URL.RawQuery; v != "" {
 			u += "?" + v
 		}
@@ -499,7 +499,7 @@ func (v *AllScopeVariables) Get(s context.Scope, name string) (value.Value, erro
 		}
 		return &value.String{Value: u}, nil
 	case REQ_URL:
-		u := req.URL.Path
+		u := req.URL.EscapedPath()
 		if v := req.URL.RawQuery; v != "" {
 			u += "?" + v
 		}
@@ -521,7 +521,7 @@ func (v *AllScopeVariables) Get(s context.Scope, name string) (value.Value, erro
 			Value: strings.TrimPrefix(ext, "."),
 		}, nil
 	case REQ_URL_PATH:
-		return &value.String{Value: req.URL.Path}, nil
+		return &value.String{Value: req.URL.EscapedPath()}, nil
 	case REQ_URL_QS:
 		return &value.String{Value: req.URL.RawQuery}, nil
 	case REQ_VCL:
@@ -734,7 +734,7 @@ func (v *AllScopeVariables) Set(s context.Scope, name, operator string, val valu
 			return errors.WithStack(err)
 		}
 		// Update request URLs
-		v.ctx.Request.URL.Path = parsed.Path
+		v.ctx.Request.URL.RawPath = parsed.EscapedPath()
 		v.ctx.Request.URL.RawQuery = parsed.RawQuery
 		v.ctx.Request.URL.RawFragment = parsed.RawFragment
 		return nil

--- a/tester/function/testing_call_subroutine.go
+++ b/tester/function/testing_call_subroutine.go
@@ -49,6 +49,8 @@ func Testing_call_subroutine(
 	} else if sub, ok := ctx.Subroutines[name]; ok {
 		state, err = i.ProcessSubroutine(sub, interpreter.DebugPass)
 		i.TestingState = state
+	} else {
+		return value.Null, errors.NewTestingError("subroutine %s not found in VCL", name)
 	}
 	if err != nil {
 		return value.Null, errors.NewTestingError(err.Error())


### PR DESCRIPTION
Fastly implementation treats req.url as a raw value while falco automatically urldecodes it
This PR implements consistent req.url behavior with fastly.
It also fixes presentation of escaped string values in the debugger