### PR TITLE
Consistency fix with Fastly: querysting fixed to URL encode keys and …

### DIFF
--- a/interpreter/function/shared/querystring.go
+++ b/interpreter/function/shared/querystring.go
@@ -142,9 +142,9 @@ func (q *QueryStrings) String() string {
 			buf.WriteString(key)
 		} else {
 			for j := range v.Value {
-				buf.WriteString(key)
+				buf.WriteString(url.PathEscape(key))
 				buf.WriteString("=")
-				buf.WriteString(url.QueryEscape(v.Value[j]))
+				buf.WriteString(url.PathEscape(v.Value[j]))
 				if j != len(v.Value)-1 {
 					buf.WriteString("&")
 				}

--- a/interpreter/function/shared/querystring_test.go
+++ b/interpreter/function/shared/querystring_test.go
@@ -287,3 +287,56 @@ func TestQueryStringsSort(t *testing.T) {
 		}
 	}
 }
+
+func TestQueryStringsString(t *testing.T) {
+	tests := []struct {
+		input  *QueryStrings
+		expect string
+	}{
+		{
+			input: &QueryStrings{
+				Prefix: "/foo",
+				Items: []*QueryString{
+					{
+						Key:   "a&b",
+						Value: []string{"c&d"},
+					},
+				},
+			},
+			expect: "/foo?a&b=c&d",
+		},
+		{
+			input: &QueryStrings{
+				Prefix: "/foo",
+				Items: []*QueryString{
+					{
+						Key:   "a",
+						Value: []string{"b"},
+					},
+					{
+						Key:   "a",
+						Value: []string{"c"},
+					},
+				},
+			},
+			expect: "/foo?a=b&a=c",
+		},
+		{
+			input: &QueryStrings{
+				Prefix: "",
+				Items: []*QueryString{
+					{
+						Key:   "a b",
+						Value: []string{"c d"},
+					},
+				},
+			},
+			expect: "?a%20b=c%20d",
+		},
+	}
+	for i, test := range tests {
+		if diff := cmp.Diff(test.expect, test.input.String()); diff != "" {
+			t.Errorf("[%d] Result unmatch: diff=: %s", i, diff)
+		}
+	}
+}


### PR DESCRIPTION
…encode space with '%20' rather then '+'

falco implementation of querystring does not urlencode query parameter names which can produce invalid urls
Also falco implementation encodes space character with '+' which is inconsistent with Fastly. Fastly use %20 for space encoding.
