### PR TITLE
Fixed: testing.call_subroutine ignores invalid subroutine name.

### DIFF
--- a/tester/function/testing_call_subroutine.go
+++ b/tester/function/testing_call_subroutine.go
@@ -50,7 +50,7 @@ func Testing_call_subroutine(
 		state, err = i.ProcessSubroutine(sub, interpreter.DebugPass)
 		i.TestingState = state
 	} else {
-		return value.Null, errors.NewTestingError("subroutine %s not defined in VCL", name)
+		return value.Null, errors.NewTestingError("subroutine %s is not defined in VCL", name)
 	}
 	if err != nil {
 		return value.Null, errors.NewTestingError(err.Error())

--- a/tester/function/testing_call_subroutine.go
+++ b/tester/function/testing_call_subroutine.go
@@ -49,6 +49,8 @@ func Testing_call_subroutine(
 	} else if sub, ok := ctx.Subroutines[name]; ok {
 		state, err = i.ProcessSubroutine(sub, interpreter.DebugPass)
 		i.TestingState = state
+	} else {
+		return value.Null, errors.NewTestingError("subroutine %s not found in VCL", name)
 	}
 	if err != nil {
 		return value.Null, errors.NewTestingError(err.Error())

--- a/tester/function/testing_call_subroutine.go
+++ b/tester/function/testing_call_subroutine.go
@@ -50,7 +50,7 @@ func Testing_call_subroutine(
 		state, err = i.ProcessSubroutine(sub, interpreter.DebugPass)
 		i.TestingState = state
 	} else {
-		return value.Null, errors.NewTestingError("subroutine %s not found in VCL", name)
+		return value.Null, errors.NewTestingError("subroutine %s not defined in VCL", name)
 	}
 	if err != nil {
 		return value.Null, errors.NewTestingError(err.Error())


### PR DESCRIPTION
Currently an interpreter will quietly ignore the situation when nonexistent sub name is passed:
```
testing.call_subroutine("NONEXISTENT");
```
With this fix reports the following error:
```
subroutine NONEXISTENT is not defined in VCL
```
