### PR TITLE
Fixed handling of '%' in debugger styled output

### DIFF
--- a/debugger/colors/color.go
+++ b/debugger/colors/color.go
@@ -2,7 +2,6 @@ package colors
 
 import (
 	"fmt"
-
 	"github.com/gdamore/tcell/v2"
 )
 
@@ -14,72 +13,85 @@ var Background = tcell.GetColor("#000000")
 
 type ColorFunc func(format string, args ...any) string
 
+// Wrapper around fmt.Sprintf that catches
+// the case when no args are passed and automatically
+// prevents the first argument from being treated as format
+// thus allowing % characters to be taken literally rather than
+// interpreted as format specifiers
+func sprintf(format string, args ...any) string {
+	if len(args) == 0 {
+		return fmt.Sprintf("%s", format)
+	} else {
+		return fmt.Sprintf(format, args...)
+	}
+}
+
 // Text extensions
 func Bold(format string, args ...any) string {
-	return fmt.Sprintf("[::b]"+format+"[::-]", args...)
+	return sprintf("[::b]"+format+"[::-]", args...)
 }
 
 func Underline(format string, args ...any) string {
-	return fmt.Sprintf("[::u]"+format+"[::-]", args...)
+	return sprintf("[::u]"+format+"[::-]", args...)
 }
 
 // Text colors
 func Black(format string, args ...any) string {
-	return fmt.Sprintf("[black]"+format+"[white]", args...)
+	return sprintf("[black]"+format+"[white]", args...)
 }
 
 func Maroon(format string, args ...any) string {
-	return fmt.Sprintf("[maroon]"+format+"[white]", args...)
+	return sprintf("[maroon]"+format+"[white]", args...)
 }
 
 func Green(format string, args ...any) string {
-	return fmt.Sprintf("[green]"+format+"[white]", args...)
+	return sprintf("[green]"+format+"[white]", args...)
 }
 
 func Olive(format string, args ...any) string {
-	return fmt.Sprintf("[olive]"+format+"[white]", args...)
+	return sprintf("[olive]"+format+"[white]", args...)
 }
 
 func Navy(format string, args ...any) string {
-	return fmt.Sprintf("[navy]"+format+"[white]", args...)
+	return sprintf("[navy]"+format+"[white]", args...)
 }
 
 func Purple(format string, args ...any) string {
-	return fmt.Sprintf("[purple]"+format+"[white]", args...)
+	return sprintf("[purple]"+format+"[white]", args...)
 }
 
 func Teal(format string, args ...any) string {
-	return fmt.Sprintf("[teal]"+format+"[white]", args...)
+	return sprintf("[teal]"+format+"[white]", args...)
 }
 
 func Silver(format string, args ...any) string {
-	return fmt.Sprintf("[silver]"+format+"[white]", args...)
+	return sprintf("[silver]"+format+"[white]", args...)
 }
 
 func Gray(format string, args ...any) string {
-	return fmt.Sprintf("[gray]"+format+"[white]", args...)
+	return sprintf("[gray]"+format+"[white]", args...)
 }
 
 func Red(format string, args ...any) string {
-	return fmt.Sprintf("[red]"+format+"[white]", args...)
+	return sprintf("[red]"+format+"[white]", args...)
 }
 
 func Lime(format string, args ...any) string {
-	return fmt.Sprintf("[lime]"+format+"[white]", args...)
+	return sprintf("[lime]"+format+"[white]", args...)
 }
 
 func Yellow(format string, args ...any) string {
-	return fmt.Sprintf("[yellow]"+format+"[white]", args...)
+	return sprintf("[yellow]"+format+"[white]", args...)
 }
 
 func Blue(format string, args ...any) string {
-	return fmt.Sprintf("[blue]"+format+"[white]", args...)
+	return sprintf("[blue]"+format+"[white]", args...)
 }
 
 func Fuchsia(format string, args ...any) string {
-	return fmt.Sprintf("[fuchsia]"+format+"[white]", args...)
+	return sprintf("[fuchsia]"+format+"[white]", args...)
 }
 
 func Aqua(format string, args ...any) string {
-	return fmt.Sprintf("[aqua]"+format+"[white]", args...)
+	return sprintf("[aqua]"+format+"[white]", args...)
 }

--- a/debugger/colors/color.go
+++ b/debugger/colors/color.go
@@ -1,7 +1,6 @@
 package colors
 
 import (
-	"fmt"
 	"github.com/gdamore/tcell/v2"
 )
 
@@ -11,87 +10,74 @@ const (
 
 var Background = tcell.GetColor("#000000")
 
-type ColorFunc func(format string, args ...any) string
-
-// Wrapper around fmt.Sprintf that catches
-// the case when no args are passed and automatically
-// prevents the first argument from being treated as format
-// thus allowing % characters to be taken literally rather than
-// interpreted as format specifiers
-func sprintf(format string, args ...any) string {
-	if len(args) == 0 {
-		return fmt.Sprintf("%s", format)
-	} else {
-		return fmt.Sprintf(format, args...)
-	}
-}
+type ColorFunc func(text string) string
 
 // Text extensions
-func Bold(format string, args ...any) string {
-	return sprintf("[::b]"+format+"[::-]", args...)
+func Bold(text string) string {
+	return "[::b]" + text + "[::-]"
 }
 
-func Underline(format string, args ...any) string {
-	return sprintf("[::u]"+format+"[::-]", args...)
+func Underline(text string) string {
+	return "[::u]" + text + "[::-]"
 }
 
 // Text colors
-func Black(format string, args ...any) string {
-	return sprintf("[black]"+format+"[white]", args...)
+func Black(text string) string {
+	return "[black]" + text + "[white]"
 }
 
-func Maroon(format string, args ...any) string {
-	return sprintf("[maroon]"+format+"[white]", args...)
+func Maroon(text string) string {
+	return "[maroon]" + text + "[white]"
 }
 
-func Green(format string, args ...any) string {
-	return sprintf("[green]"+format+"[white]", args...)
+func Green(text string) string {
+	return "[green]" + text + "[white]"
 }
 
-func Olive(format string, args ...any) string {
-	return sprintf("[olive]"+format+"[white]", args...)
+func Olive(text string) string {
+	return "[olive]" + text + "[white]"
 }
 
-func Navy(format string, args ...any) string {
-	return sprintf("[navy]"+format+"[white]", args...)
+func Navy(text string) string {
+	return "[navy]" + text + "[white]"
 }
 
-func Purple(format string, args ...any) string {
-	return sprintf("[purple]"+format+"[white]", args...)
+func Purple(text string) string {
+	return "[purple]" + text + "[white]"
 }
 
-func Teal(format string, args ...any) string {
-	return sprintf("[teal]"+format+"[white]", args...)
+func Teal(text string) string {
+	return "[teal]" + text + "[white]"
 }
 
-func Silver(format string, args ...any) string {
-	return sprintf("[silver]"+format+"[white]", args...)
+func Silver(text string) string {
+	return "[silver]" + text + "[white]"
 }
 
-func Gray(format string, args ...any) string {
-	return sprintf("[gray]"+format+"[white]", args...)
+func Gray(text string) string {
+	return "[gray]" + text + "[white]"
 }
 
-func Red(format string, args ...any) string {
-	return sprintf("[red]"+format+"[white]", args...)
+func Red(text string) string {
+	return "[red]" + text + "[white]"
 }
 
-func Lime(format string, args ...any) string {
-	return sprintf("[lime]"+format+"[white]", args...)
+func Lime(text string) string {
+	return "[lime]" + text + "[white]"
 }
 
-func Yellow(format string, args ...any) string {
-	return sprintf("[yellow]"+format+"[white]", args...)
+func Yellow(text string) string {
+	return "[yellow]" + text + "[white]"
 }
 
-func Blue(format string, args ...any) string {
-	return sprintf("[blue]"+format+"[white]", args...)
+func Blue(text string) string {
+	return "[blue]" + text + "[white]"
 }
 
-func Fuchsia(format string, args ...any) string {
-	return sprintf("[fuchsia]"+format+"[white]", args...)
+func Fuchsia(text string) string {
+	return "[fuchsia]" + text + "[white]"
 }
 
-func Aqua(format string, args ...any) string {
-	return sprintf("[aqua]"+format+"[white]", args...)
+func Aqua(text string) string {
+	return "[aqua]" + text + "[white]"
 }

--- a/debugger/colors/color_test.go
+++ b/debugger/colors/color_test.go
@@ -8,21 +8,21 @@ func TestColorString(t *testing.T) {
 		text   string
 		expect string
 	}{
-		{color: Black, text: "foo", expect: "[black]foo[white]"},
-		{color: Maroon, text: "foo", expect: "[maroon]foo[white]"},
-		{color: Green, text: "foo", expect: "[green]foo[white]"},
-		{color: Olive, text: "foo", expect: "[olive]foo[white]"},
-		{color: Navy, text: "foo", expect: "[navy]foo[white]"},
-		{color: Purple, text: "foo", expect: "[purple]foo[white]"},
-		{color: Teal, text: "foo", expect: "[teal]foo[white]"},
-		{color: Silver, text: "foo", expect: "[silver]foo[white]"},
-		{color: Gray, text: "foo", expect: "[gray]foo[white]"},
-		{color: Red, text: "foo", expect: "[red]foo[white]"},
-		{color: Lime, text: "foo", expect: "[lime]foo[white]"},
-		{color: Yellow, text: "foo", expect: "[yellow]foo[white]"},
-		{color: Blue, text: "foo", expect: "[blue]foo[white]"},
-		{color: Fuchsia, text: "foo", expect: "[fuchsia]foo[white]"},
-		{color: Aqua, text: "foo", expect: "[aqua]foo[white]"},
+		{color: Black, text: "foo%bar", expect: "[black]foo%bar[white]"},
+		{color: Maroon, text: "foo%bar", expect: "[maroon]foo%bar[white]"},
+		{color: Green, text: "foo%bar", expect: "[green]foo%bar[white]"},
+		{color: Olive, text: "foo%bar", expect: "[olive]foo%bar[white]"},
+		{color: Navy, text: "foo%bar", expect: "[navy]foo%bar[white]"},
+		{color: Purple, text: "foo%bar", expect: "[purple]foo%bar[white]"},
+		{color: Teal, text: "foo%bar", expect: "[teal]foo%bar[white]"},
+		{color: Silver, text: "foo%bar", expect: "[silver]foo%bar[white]"},
+		{color: Gray, text: "foo%bar", expect: "[gray]foo%bar[white]"},
+		{color: Red, text: "foo%bar", expect: "[red]foo%bar[white]"},
+		{color: Lime, text: "foo%bar", expect: "[lime]foo%bar[white]"},
+		{color: Yellow, text: "foo%bar", expect: "[yellow]foo%bar[white]"},
+		{color: Blue, text: "foo%bar", expect: "[blue]foo%bar[white]"},
+		{color: Fuchsia, text: "foo%bar", expect: "[fuchsia]foo%bar[white]"},
+		{color: Aqua, text: "foo%bar", expect: "[aqua]foo%bar[white]"},
 	}
 
 	for i := range tests {
@@ -39,14 +39,14 @@ func TestStyledColor(t *testing.T) {
 		colors []ColorFunc
 		expect string
 	}{
-		{colors: []ColorFunc{Black, Bold}, expect: "[::b][black]foo[white][::-]"},
-		{colors: []ColorFunc{Black, Underline}, expect: "[::u][black]foo[white][::-]"},
-		{colors: []ColorFunc{Black, Bold, Underline}, expect: "[::u][::b][black]foo[white][::-][::-]"},
+		{colors: []ColorFunc{Black, Bold}, expect: "[::b][black]foo%bar[white][::-]"},
+		{colors: []ColorFunc{Black, Underline}, expect: "[::u][black]foo%bar[white][::-]"},
+		{colors: []ColorFunc{Black, Bold, Underline}, expect: "[::u][::b][black]foo%bar[white][::-][::-]"},
 	}
 
 	for i := range tests {
 		tt := tests[i]
-		actual := "foo"
+		actual := "foo%bar"
 		for _, c := range tt.colors {
 			actual = c(actual)
 		}


### PR DESCRIPTION
Currently if the value contains % character, the debugger styled output attempts to interpret it as a format specifier which leads to garbled output.
For example this statement:
```
  set req.http.foo = {"foo%bar"};
```
Is displayed as:
```
set req.http.foo = {"foo%!!(MISSING)b(MISSING)ar"};
```
The problem is that in the code a string value often passed as a single argument to the functions from colors package which means they are interpreted as a format specifier.
Instead of fixing the usages, the fix creates a wrapper around fmd.Sprintf which automatically detects above usage and turns it into 2 argument call:
fmt.Sprintf(someString) ==> fmtSprint("%s", someString)
