### PR TITLE
fixed double decoding in urldecode

### DIFF
--- a/interpreter/function/builtin/urldecode.go
+++ b/interpreter/function/builtin/urldecode.go
@@ -3,12 +3,10 @@
 package builtin
 
 import (
-	"net/url"
-	"strings"
-
 	"github.com/ysugimoto/falco/interpreter/context"
 	"github.com/ysugimoto/falco/interpreter/function/errors"
 	"github.com/ysugimoto/falco/interpreter/value"
+	"net/url"
 )
 
 const Urldecode_Name = "urldecode"
@@ -38,18 +36,7 @@ func Urldecode(ctx *context.Context, args ...value.Value) (value.Value, error) {
 	}
 
 	input := value.Unwrap[*value.String](args[0]).Value
-	// "%" string is also encoded as "%25" so we need to decode properly
-	input = strings.ReplaceAll(input, "%25", "%")
-
-	dec, err := url.PathUnescape(input)
-	if err != nil {
-		return &value.String{IsNotSet: true}, errors.New(Urldecode_Name,
-			"Failed to urldecode string: %s", input,
-		)
-	}
-	// url.PathUnescape does not decode "+" sign to white space so we also need to call url.QueryUnescape
-	// in order to decode "+" sign into white space
-	dec, err = url.QueryUnescape(dec)
+	dec, err := url.QueryUnescape(input)
 	if err != nil {
 		return &value.String{IsNotSet: true}, errors.New(Urldecode_Name,
 			"Failed to urldecode string: %s", input,

--- a/interpreter/function/builtin/urldecode.go
+++ b/interpreter/function/builtin/urldecode.go
@@ -3,10 +3,11 @@
 package builtin
 
 import (
+	"net/url"
+
 	"github.com/ysugimoto/falco/interpreter/context"
 	"github.com/ysugimoto/falco/interpreter/function/errors"
 	"github.com/ysugimoto/falco/interpreter/value"
-	"net/url"
 )
 
 const Urldecode_Name = "urldecode"

--- a/interpreter/function/builtin/urldecode_test.go
+++ b/interpreter/function/builtin/urldecode_test.go
@@ -20,7 +20,7 @@ func Test_Urldecode(t *testing.T) {
 		expect string
 	}{
 		{input: "hello%20world+!", expect: "hello world !"},
-		{input: "hello%2520world+!", expect: "hello world !"},
+		{input: "hello%2520world+!", expect: "hello%20world !"},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
Current falco implementation of `urldecode` essentially applies url decoding twice, once by applying `url.PathUnescape` and then by calling `url.QueryUnescape`. In addition `%25` (escaped "%") gets yet another extra decoding.

[Fastly documentation](https://developer.fastly.com/reference/vcl/functions/strings/urldecode/) of urldecode is a bit misleading:

>    For example, urldecode({"hello%20world+!"}); and urldecode("hello%2520world+!"); will both return "hello world !".

This makes an impression that both %20 and %2520 should be decoded to space character
However in reality it means to demonstrate is that two different string literals "..." and {"..."} are interpreted differently. In the second example %25 is decoded to '%' by the paraser leading to the same original value passed to urldecode as in the first example.

The confusion is also likely caused by misinterpreting of quoted literals in falco which is apparently fixed in [PR-256](https://github.com/ysugimoto/falco/pull/256)