### PR TITLE
fix base64 decode related builtin function

### DIFF
--- a/interpreter/function/builtin/digest_base64_decode.go
+++ b/interpreter/function/builtin/digest_base64_decode.go
@@ -52,10 +52,8 @@ var nullByte = []byte{0}
 
 // Stop and return the point of Null-Byte found
 func terminateNullByte(decoded []byte) []byte {
-	if found := bytes.Index(decoded, nullByte); found != -1 {
-		return decoded[:found]
-	}
-	return decoded
+	before, _, _ := bytes.Cut(decoded, nullByte)
+	return before
 }
 
 // Even stopping decoding, we need to padding sign to success golang base64 decoding

--- a/interpreter/function/builtin/digest_base64_decode.go
+++ b/interpreter/function/builtin/digest_base64_decode.go
@@ -87,10 +87,9 @@ func Digest_base64_decode_removeInvalidCharacters(input string) string {
 		case b == 0x3D: // =
 			// If "=" sign found, next byte must also be "="
 			if peek, err := r.Peek(1); err != nil && peek[0] == 0x3D {
-				// If removed bytes is not multiple of 4bytes, the sign is padding
 				removed.WriteByte(b)
 				removed.WriteByte(b)
-				r.ReadByte() // skip next equal sign
+				r.ReadByte() // skip next "=" character
 				continue
 			}
 			// Otherwise, treat as invalid character, stop decoding

--- a/interpreter/function/builtin/digest_base64_decode.go
+++ b/interpreter/function/builtin/digest_base64_decode.go
@@ -3,6 +3,7 @@
 package builtin
 
 import (
+	"bytes"
 	"encoding/base64"
 
 	"github.com/ysugimoto/falco/interpreter/context"
@@ -37,10 +38,16 @@ func Digest_base64_decode(ctx *context.Context, args ...value.Value) (value.Valu
 	}
 
 	input := value.Unwrap[*value.String](args[0])
-	dec, err := base64.StdEncoding.DecodeString(input.Value)
-	if err != nil {
-		return value.Null, err
-	}
+	dec, _ := base64.StdEncoding.DecodeString(input.Value)
 
-	return &value.String{Value: string(dec)}, nil
+	return &value.String{Value: string(terminateNullByte(dec))}, nil
+}
+
+var nullByte = []byte{0}
+
+func terminateNullByte(decoded []byte) []byte {
+	if found := bytes.Index(decoded, nullByte); found != -1 {
+		return decoded[:found]
+	}
+	return decoded
 }

--- a/interpreter/function/builtin/digest_base64_decode.go
+++ b/interpreter/function/builtin/digest_base64_decode.go
@@ -3,8 +3,11 @@
 package builtin
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/base64"
+	"io"
+	"strings"
 
 	"github.com/ysugimoto/falco/interpreter/context"
 	"github.com/ysugimoto/falco/interpreter/function/errors"
@@ -38,16 +41,64 @@ func Digest_base64_decode(ctx *context.Context, args ...value.Value) (value.Valu
 	}
 
 	input := value.Unwrap[*value.String](args[0])
-	dec, _ := base64.StdEncoding.DecodeString(input.Value)
+	removed := Digest_base64_decode_removeInvalidCharacters(input.Value)
+	dec, _ := base64.StdEncoding.DecodeString(removed)
 
 	return &value.String{Value: string(terminateNullByte(dec))}, nil
 }
 
+// Base64 decoding utility functions - they are also called by digest.base64url_decode and digest.base64_decode_nopad
 var nullByte = []byte{0}
 
+// Stop and return the point of Null-Byte found
 func terminateNullByte(decoded []byte) []byte {
 	if found := bytes.Index(decoded, nullByte); found != -1 {
 		return decoded[:found]
 	}
 	return decoded
+}
+
+// Even stopping decoding, we need to padding sign to success golang base64 decoding
+func base64_padding(b []byte) []byte {
+	for len(b)%4 > 0 {
+		b = append(b, 0x3D)
+	}
+	return b
+}
+
+func Digest_base64_decode_removeInvalidCharacters(input string) string {
+	removed := new(bytes.Buffer)
+	r := bufio.NewReader(strings.NewReader(input))
+
+	for {
+		b, err := r.ReadByte()
+		if err == io.EOF {
+			break
+		}
+		switch {
+		case b >= 0x41 && b <= 0x5A: // A-Z
+			removed.WriteByte(b)
+		case b >= 0x61 && b <= 0x7A: // a-z
+			removed.WriteByte(b)
+		case b >= 0x31 && b <= 0x39: // 0-9
+			removed.WriteByte(b)
+		case b == 0x2B || b == 0x2F: // + or /
+			removed.WriteByte(b)
+		case b == 0x3D: // =
+			// If "=" sign found, next byte must also be "="
+			if peek, err := r.Peek(1); err != nil && peek[0] == 0x3D {
+				// If removed bytes is not multiple of 4bytes, the sign is padding
+				removed.WriteByte(b)
+				removed.WriteByte(b)
+				r.ReadByte() // skip next equal sign
+				continue
+			}
+			// Otherwise, treat as invalid character, stop decoding
+			return string(base64_padding(removed.Bytes()))
+		default:
+			// Invalid characters, skip it
+		}
+	}
+
+	return string(base64_padding(removed.Bytes()))
 }

--- a/interpreter/function/builtin/digest_base64_decode_test.go
+++ b/interpreter/function/builtin/digest_base64_decode_test.go
@@ -14,38 +14,58 @@ import (
 // - STRING
 // Reference: https://developer.fastly.com/reference/vcl/functions/cryptographic/digest-base64-decode/
 func Test_Digest_base64_decode(t *testing.T) {
-	ret, err := Digest_base64_decode(
-		&context.Context{},
-		&value.String{Value: "zprOsc67z47PgiDOv8+Bzq/Pg86xz4TOtQ=="},
-	)
+	tests := []struct {
+		name   string
+		input  string
+		expect string
+	}{
+		{
+			name:   "Fastly example",
+			input:  "zprOsc67z47PgiDOv8+Bzq/Pg86xz4TOtQ==",
+			expect: "Καλώς ορίσατε",
+		},
+		{
+			name:   "Includes nullbyte",
+			input:  "c29tZSBkYXRhIHdpdGggACBhbmQg77u/",
+			expect: "some data with ",
+		},
+		{
+			name:   "Skip invalid characters",
+			input:  "QU&|*#()JDRA==",
+			expect: "ABCD",
+		},
+		{
+			name:   "Stop at padding sign",
+			input:  "QU&==|*#()JDRA==",
+			expect: "A",
+		},
+		{
+			name:   "Stop at single equal sign",
+			input:  "QU&=|*#()JDRA==",
+			expect: "A",
+		},
+		{
+			name:   "Treat padding - keep padding characters",
+			input:  "YWJjZB==",
+			expect: "abcd",
+		},
+	}
 
-	if err != nil {
-		t.Errorf("Unexpected error: %s", err)
-	}
-	if ret.Type() != value.StringType {
-		t.Errorf("Unexpected return type, expect=STRING, got=%s", ret.Type())
-	}
-	v := value.Unwrap[*value.String](ret)
-	expect := "Καλώς ορίσατε"
-	if v.Value != expect {
-		t.Errorf("return value unmach, expect=%s, got=%s", expect, v.Value)
-	}
-}
+	for _, tt := range tests {
+		ret, err := Digest_base64_decode(
+			&context.Context{},
+			&value.String{Value: tt.input},
+		)
 
-func Test_Digest_base64_decode_with_nullByte(t *testing.T) {
-	ret, err := Digest_base64_decode(
-		&context.Context{},
-		&value.String{Value: "c29tZSBkYXRhIHdpdGggACBhbmQg77u/"},
-	)
-	if err != nil {
-		t.Errorf("Unexpected error: %s", err)
-	}
-	if ret.Type() != value.StringType {
-		t.Errorf("Unexpected return type, expect=STRING, got=%s", ret.Type())
-	}
-	v := value.Unwrap[*value.String](ret)
-	expect := "some data with "
-	if v.Value != expect {
-		t.Errorf("return value unmach, expect=%s, got=%s", expect, v.Value)
+		if err != nil {
+			t.Errorf("[%s] Unexpected error: %s", tt.name, err)
+		}
+		if ret.Type() != value.StringType {
+			t.Errorf("[%s] Unexpected return type, expect=STRING, got=%s", tt.name, ret.Type())
+		}
+		v := value.Unwrap[*value.String](ret)
+		if v.Value != tt.expect {
+			t.Errorf("[%s] return value unmatch, expect=%s, got=%s", tt.name, tt.expect, v.Value)
+		}
 	}
 }

--- a/interpreter/function/builtin/digest_base64_decode_test.go
+++ b/interpreter/function/builtin/digest_base64_decode_test.go
@@ -31,3 +31,21 @@ func Test_Digest_base64_decode(t *testing.T) {
 		t.Errorf("return value unmach, expect=%s, got=%s", expect, v.Value)
 	}
 }
+
+func Test_Digest_base64_decode_with_nullByte(t *testing.T) {
+	ret, err := Digest_base64_decode(
+		&context.Context{},
+		&value.String{Value: "c29tZSBkYXRhIHdpdGggACBhbmQg77u/"},
+	)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	if ret.Type() != value.StringType {
+		t.Errorf("Unexpected return type, expect=STRING, got=%s", ret.Type())
+	}
+	v := value.Unwrap[*value.String](ret)
+	expect := "some data with "
+	if v.Value != expect {
+		t.Errorf("return value unmach, expect=%s, got=%s", expect, v.Value)
+	}
+}

--- a/interpreter/function/builtin/digest_base64url_decode.go
+++ b/interpreter/function/builtin/digest_base64url_decode.go
@@ -3,7 +3,11 @@
 package builtin
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/base64"
+	"io"
+	"strings"
 
 	"github.com/ysugimoto/falco/interpreter/context"
 	"github.com/ysugimoto/falco/interpreter/function/errors"
@@ -37,7 +41,49 @@ func Digest_base64url_decode(ctx *context.Context, args ...value.Value) (value.V
 	}
 
 	input := value.Unwrap[*value.String](args[0])
-	dec, _ := base64.URLEncoding.DecodeString(input.Value)
+	removed := Digest_base64url_decode_removeInvalidCharacters(input.Value)
+	dec, _ := base64.URLEncoding.DecodeString(removed)
 
 	return &value.String{Value: string(terminateNullByte(dec))}, nil
+}
+
+func Digest_base64url_decode_removeInvalidCharacters(input string) string {
+	removed := new(bytes.Buffer)
+	r := bufio.NewReader(strings.NewReader(input))
+
+	for {
+		b, err := r.ReadByte()
+		if err == io.EOF {
+			break
+		}
+		switch {
+		case b >= 0x41 && b <= 0x5A: // A-Z
+			removed.WriteByte(b)
+		case b >= 0x61 && b <= 0x7A: // a-z
+			removed.WriteByte(b)
+		case b >= 0x31 && b <= 0x39: // 0-9
+			removed.WriteByte(b)
+		case b == 0x2B: // + should replace to -
+			removed.WriteByte(0x2D)
+		case b == 0x2F: // / should replace to _
+			removed.WriteByte(0x5F)
+		case b == 0x2D || b == 0x5F: // + or /
+			removed.WriteByte(b)
+		case b == 0x3D: // =
+			// If "=" sign found, next byte must also be "="
+			if peek, err := r.Peek(1); err != nil && peek[0] == 0x3D {
+				// If removed bytes is not multiple of 4bytes, the sign is padding
+				removed.WriteByte(b)
+				removed.WriteByte(b)
+				r.ReadByte() // skip next equal sign
+				continue
+			}
+			// Otherwise, treat as invalid character, stop decoding
+			return string(base64_padding(removed.Bytes()))
+		default:
+			// Invalid characters, skip it
+		}
+	}
+
+	return string(base64_padding(removed.Bytes()))
 }

--- a/interpreter/function/builtin/digest_base64url_decode.go
+++ b/interpreter/function/builtin/digest_base64url_decode.go
@@ -72,10 +72,9 @@ func Digest_base64url_decode_removeInvalidCharacters(input string) string {
 		case b == 0x3D: // =
 			// If "=" sign found, next byte must also be "="
 			if peek, err := r.Peek(1); err != nil && peek[0] == 0x3D {
-				// If removed bytes is not multiple of 4bytes, the sign is padding
 				removed.WriteByte(b)
 				removed.WriteByte(b)
-				r.ReadByte() // skip next equal sign
+				r.ReadByte() // skip next "=" character
 				continue
 			}
 			// Otherwise, treat as invalid character, stop decoding

--- a/interpreter/function/builtin/digest_base64url_decode.go
+++ b/interpreter/function/builtin/digest_base64url_decode.go
@@ -37,10 +37,7 @@ func Digest_base64url_decode(ctx *context.Context, args ...value.Value) (value.V
 	}
 
 	input := value.Unwrap[*value.String](args[0])
-	dec, err := base64.URLEncoding.DecodeString(input.Value)
-	if err != nil {
-		return value.Null, err
-	}
+	dec, _ := base64.URLEncoding.DecodeString(input.Value)
 
-	return &value.String{Value: string(dec)}, nil
+	return &value.String{Value: string(terminateNullByte(dec))}, nil
 }

--- a/interpreter/function/builtin/digest_base64url_decode_test.go
+++ b/interpreter/function/builtin/digest_base64url_decode_test.go
@@ -69,21 +69,3 @@ func Test_Digest_base64url_decode(t *testing.T) {
 		}
 	}
 }
-
-// func Test_Digest_base64url_decode_with_nullByte(t *testing.T) {
-// 	ret, err := Digest_base64_decode(
-// 		&context.Context{},
-// 		&value.String{Value: "c29tZSBkYXRhIHdpdGggACBhbmQg77u/"},
-// 	)
-// 	if err != nil {
-// 		t.Errorf("Unexpected error: %s", err)
-// 	}
-// 	if ret.Type() != value.StringType {
-// 		t.Errorf("Unexpected return type, expect=STRING, got=%s", ret.Type())
-// 	}
-// 	v := value.Unwrap[*value.String](ret)
-// 	expect := "some data with "
-// 	if v.Value != expect {
-// 		t.Errorf("return value unmach, expect=%s, got=%s", expect, v.Value)
-// 	}
-// }

--- a/interpreter/function/builtin/digest_base64url_decode_test.go
+++ b/interpreter/function/builtin/digest_base64url_decode_test.go
@@ -14,38 +14,76 @@ import (
 // - STRING
 // Reference: https://developer.fastly.com/reference/vcl/functions/cryptographic/digest-base64url-decode/
 func Test_Digest_base64url_decode(t *testing.T) {
-	ret, err := Digest_base64url_decode(
-		&context.Context{},
-		&value.String{Value: "zprOsc67z47PgiDOv8-Bzq_Pg86xz4TOtQ=="},
-	)
+	tests := []struct {
+		name   string
+		input  string
+		expect string
+	}{
+		{
+			name:   "Fastly example",
+			input:  "zprOsc67z47PgiDOv8-Bzq_Pg86xz4TOtQ==",
+			expect: "Καλώς ορίσατε",
+		},
+		{
+			name:   "Includes nullbyte",
+			input:  "c29tZSBkYXRhIHdpdGggACBhbmQg77u/",
+			expect: "some data with ",
+		},
+		{
+			name:   "Skip invalid characters",
+			input:  "QU&|*#()JDRA==",
+			expect: "ABCD",
+		},
+		{
+			name:   "Stop at padding sign",
+			input:  "QU&==|*#()JDRA==",
+			expect: "A",
+		},
+		{
+			name:   "Stop at single equal sign",
+			input:  "QU&=|*#()JDRA==",
+			expect: "A",
+		},
+		{
+			name:   "Treat padding - keep padding characters",
+			input:  "YWJjZB==",
+			expect: "abcd",
+		},
+	}
 
-	if err != nil {
-		t.Errorf("Unexpected error: %s", err)
-	}
-	if ret.Type() != value.StringType {
-		t.Errorf("Unexpected return type, expect=STRING, got=%s", ret.Type())
-	}
-	v := value.Unwrap[*value.String](ret)
-	expect := "Καλώς ορίσατε"
-	if v.Value != expect {
-		t.Errorf("return value unmach, expect=%s, got=%s", expect, v.Value)
+	for _, tt := range tests {
+		ret, err := Digest_base64url_decode(
+			&context.Context{},
+			&value.String{Value: tt.input},
+		)
+
+		if err != nil {
+			t.Errorf("[%s] Unexpected error: %s", tt.name, err)
+		}
+		if ret.Type() != value.StringType {
+			t.Errorf("[%s] Unexpected return type, expect=STRING, got=%s", tt.name, ret.Type())
+		}
+		v := value.Unwrap[*value.String](ret)
+		if v.Value != tt.expect {
+			t.Errorf("[%s] return value unmatch, expect=%s, got=%s", tt.name, tt.expect, v.Value)
+		}
 	}
 }
 
-func Test_Digest_base64url_decode_with_nullByte(t *testing.T) {
-	ret, err := Digest_base64_decode(
-		&context.Context{},
-		&value.String{Value: "c29tZSBkYXRhIHdpdGggACBhbmQg77u/"},
-	)
-	if err != nil {
-		t.Errorf("Unexpected error: %s", err)
-	}
-	if ret.Type() != value.StringType {
-		t.Errorf("Unexpected return type, expect=STRING, got=%s", ret.Type())
-	}
-	v := value.Unwrap[*value.String](ret)
-	expect := "some data with "
-	if v.Value != expect {
-		t.Errorf("return value unmach, expect=%s, got=%s", expect, v.Value)
-	}
-}
+// func Test_Digest_base64url_decode_with_nullByte(t *testing.T) {
+// 	ret, err := Digest_base64_decode(
+// 		&context.Context{},
+// 		&value.String{Value: "c29tZSBkYXRhIHdpdGggACBhbmQg77u/"},
+// 	)
+// 	if err != nil {
+// 		t.Errorf("Unexpected error: %s", err)
+// 	}
+// 	if ret.Type() != value.StringType {
+// 		t.Errorf("Unexpected return type, expect=STRING, got=%s", ret.Type())
+// 	}
+// 	v := value.Unwrap[*value.String](ret)
+// 	expect := "some data with "
+// 	if v.Value != expect {
+// 		t.Errorf("return value unmach, expect=%s, got=%s", expect, v.Value)
+// 	}
+// }

--- a/interpreter/function/builtin/digest_base64url_decode_test.go
+++ b/interpreter/function/builtin/digest_base64url_decode_test.go
@@ -31,3 +31,21 @@ func Test_Digest_base64url_decode(t *testing.T) {
 		t.Errorf("return value unmach, expect=%s, got=%s", expect, v.Value)
 	}
 }
+
+func Test_Digest_base64url_decode_with_nullByte(t *testing.T) {
+	ret, err := Digest_base64_decode(
+		&context.Context{},
+		&value.String{Value: "c29tZSBkYXRhIHdpdGggACBhbmQg77u/"},
+	)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	if ret.Type() != value.StringType {
+		t.Errorf("Unexpected return type, expect=STRING, got=%s", ret.Type())
+	}
+	v := value.Unwrap[*value.String](ret)
+	expect := "some data with "
+	if v.Value != expect {
+		t.Errorf("return value unmach, expect=%s, got=%s", expect, v.Value)
+	}
+}

--- a/interpreter/function/builtin/digest_base64url_nopad_decode_test.go
+++ b/interpreter/function/builtin/digest_base64url_nopad_decode_test.go
@@ -14,56 +14,58 @@ import (
 // - STRING
 // Reference: https://developer.fastly.com/reference/vcl/functions/cryptographic/digest-base64url-nopad-decode/
 func Test_Digest_base64url_nopad_decode(t *testing.T) {
-	ret, err := Digest_base64url_nopad_decode(
-		&context.Context{},
-		&value.String{Value: "zprOsc67z47PgiDOv8-Bzq_Pg86xz4TOtQ"},
-	)
+	tests := []struct {
+		name   string
+		input  string
+		expect string
+	}{
+		{
+			name:   "Fastly example",
+			input:  "zprOsc67z47PgiDOv8-Bzq_Pg86xz4TOtQ",
+			expect: "Καλώς ορίσατε",
+		},
+		{
+			name:   "Includes nullbyte",
+			input:  "c29tZSBkYXRhIHdpdGggACBhbmQg77u/",
+			expect: "some data with ",
+		},
+		{
+			name:   "Skip invalid characters",
+			input:  "QU&|*#()JDRA==",
+			expect: "ABCD",
+		},
+		{
+			name:   "Skip padding sign",
+			input:  "QU&==|*#()JDRA==",
+			expect: "ABCD",
+		},
+		{
+			name:   "Skip single equal sign",
+			input:  "QU&=|*#()JDRA==",
+			expect: "ABCD",
+		},
+		{
+			name:   "Skip padding sign",
+			input:  "YWJjZB==",
+			expect: "abcd",
+		},
+	}
 
-	if err != nil {
-		t.Errorf("Unexpected error: %s", err)
-	}
-	if ret.Type() != value.StringType {
-		t.Errorf("Unexpected return type, expect=STRING, got=%s", ret.Type())
-	}
-	v := value.Unwrap[*value.String](ret)
-	expect := "Καλώς ορίσατε"
-	if v.Value != expect {
-		t.Errorf("return value unmach, expect=%s, got=%s", expect, v.Value)
-	}
-}
+	for _, tt := range tests {
+		ret, err := Digest_base64url_nopad_decode(
+			&context.Context{},
+			&value.String{Value: tt.input},
+		)
 
-func Test_Digest_base64url_nopad_decode_with_nullByte(t *testing.T) {
-	ret, err := Digest_base64_decode(
-		&context.Context{},
-		&value.String{Value: "c29tZSBkYXRhIHdpdGggACBhbmQg77u/"},
-	)
-	if err != nil {
-		t.Errorf("Unexpected error: %s", err)
-	}
-	if ret.Type() != value.StringType {
-		t.Errorf("Unexpected return type, expect=STRING, got=%s", ret.Type())
-	}
-	v := value.Unwrap[*value.String](ret)
-	expect := "some data with "
-	if v.Value != expect {
-		t.Errorf("return value unmach, expect=%s, got=%s", expect, v.Value)
-	}
-}
-
-func Test_Digest_base64url_nopad_decode_with_padding_sign(t *testing.T) {
-	ret, err := Digest_base64_decode(
-		&context.Context{},
-		&value.String{Value: "YWJjZA=YWJ"},
-	)
-	if err != nil {
-		t.Errorf("Unexpected error: %s", err)
-	}
-	if ret.Type() != value.StringType {
-		t.Errorf("Unexpected return type, expect=STRING, got=%s", ret.Type())
-	}
-	v := value.Unwrap[*value.String](ret)
-	expect := "abc"
-	if v.Value != expect {
-		t.Errorf("return value unmach, expect=%s, got=%s", expect, v.Value)
+		if err != nil {
+			t.Errorf("[%s] Unexpected error: %s", tt.name, err)
+		}
+		if ret.Type() != value.StringType {
+			t.Errorf("[%s] Unexpected return type, expect=STRING, got=%s", tt.name, ret.Type())
+		}
+		v := value.Unwrap[*value.String](ret)
+		if v.Value != tt.expect {
+			t.Errorf("[%s] return value unmatch, expect=%s, got=%s", tt.name, tt.expect, v.Value)
+		}
 	}
 }

--- a/interpreter/function/builtin/digest_base64url_nopad_decode_test.go
+++ b/interpreter/function/builtin/digest_base64url_nopad_decode_test.go
@@ -31,3 +31,39 @@ func Test_Digest_base64url_nopad_decode(t *testing.T) {
 		t.Errorf("return value unmach, expect=%s, got=%s", expect, v.Value)
 	}
 }
+
+func Test_Digest_base64url_nopad_decode_with_nullByte(t *testing.T) {
+	ret, err := Digest_base64_decode(
+		&context.Context{},
+		&value.String{Value: "c29tZSBkYXRhIHdpdGggACBhbmQg77u/"},
+	)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	if ret.Type() != value.StringType {
+		t.Errorf("Unexpected return type, expect=STRING, got=%s", ret.Type())
+	}
+	v := value.Unwrap[*value.String](ret)
+	expect := "some data with "
+	if v.Value != expect {
+		t.Errorf("return value unmach, expect=%s, got=%s", expect, v.Value)
+	}
+}
+
+func Test_Digest_base64url_nopad_decode_with_padding_sign(t *testing.T) {
+	ret, err := Digest_base64_decode(
+		&context.Context{},
+		&value.String{Value: "YWJjZA=YWJ"},
+	)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	if ret.Type() != value.StringType {
+		t.Errorf("Unexpected return type, expect=STRING, got=%s", ret.Type())
+	}
+	v := value.Unwrap[*value.String](ret)
+	expect := "abc"
+	if v.Value != expect {
+		t.Errorf("return value unmach, expect=%s, got=%s", expect, v.Value)
+	}
+}


### PR DESCRIPTION
Fixes #255

Fastly terminates null-byte on a decoded string in base64 decoding functions:

- `digest.base64_decode`
- `digest.base64url_decode`
- `digest.base64url_decode_nopad`

Additionally, `digest.base64url_decode_nopad` also stops decoding when a padding sign (`=`) is found.
This PR follows Fastly behavior that describes the [documentation](https://www.fastly.com/documentation/reference/vcl/functions/cryptographic/digest-base64-decode/#padding).