### PR TITLE
querystring functions reimplemented

### DIFF
--- a/interpreter/function/builtin/querystring_add.go
+++ b/interpreter/function/builtin/querystring_add.go
@@ -38,14 +38,6 @@ func Querystring_add(ctx *context.Context, args ...value.Value) (value.Value, er
 	u := value.Unwrap[*value.String](args[0])
 	name := value.Unwrap[*value.String](args[1])
 	val := value.Unwrap[*value.String](args[2])
-
-	query, err := shared.ParseQuery(u.Value)
-	if err != nil {
-		return value.Null, errors.New(
-			Querystring_add_Name, "Failed to parse querystring: %s, error: %s", u.Value, err.Error(),
-		)
-	}
-
-	query.Add(name.Value, val.Value)
-	return &value.String{Value: query.String()}, nil
+	result := shared.QueryStringAdd(u.Value, name.Value, val.Value)
+	return &value.String{Value: result}, nil
 }

--- a/interpreter/function/builtin/querystring_clean.go
+++ b/interpreter/function/builtin/querystring_clean.go
@@ -36,14 +36,6 @@ func Querystring_clean(ctx *context.Context, args ...value.Value) (value.Value, 
 	}
 
 	v := value.Unwrap[*value.String](args[0])
-
-	query, err := shared.ParseQuery(v.Value)
-	if err != nil {
-		return value.Null, errors.New(
-			Querystring_clean_Name, "Failed to parse url: %s, error: %s", v.Value, err.Error(),
-		)
-	}
-
-	query.Clean()
-	return &value.String{Value: query.String()}, nil
+	result := shared.QueryStringClean(v.Value)
+	return &value.String{Value: result}, nil
 }

--- a/interpreter/function/builtin/querystring_filter.go
+++ b/interpreter/function/builtin/querystring_filter.go
@@ -40,21 +40,15 @@ func Querystring_filter(ctx *context.Context, args ...value.Value) (value.Value,
 	v := value.Unwrap[*value.String](args[0])
 	names := value.Unwrap[*value.String](args[1])
 
-	query, err := shared.ParseQuery(v.Value)
-	if err != nil {
-		return value.Null, errors.New(
-			Querystring_filter_Name, "Failed to parse query: %s, error: %s", v.Value, err.Error(),
-		)
-	}
 	filterMap := make(map[string]struct{})
 	for _, f := range bytes.Split([]byte(names.Value), Querystring_filtersep_Sign) {
 		filterMap[string(f)] = struct{}{}
 	}
 
-	query.Filter(func(name string) bool {
+	result := shared.QueryStringFilter(v.Value, func(name string) bool {
 		_, ok := filterMap[name]
 		return !ok
 	})
 
-	return &value.String{Value: query.String()}, nil
+	return &value.String{Value: result}, nil
 }

--- a/interpreter/function/builtin/querystring_filter_except.go
+++ b/interpreter/function/builtin/querystring_filter_except.go
@@ -40,21 +40,15 @@ func Querystring_filter_except(ctx *context.Context, args ...value.Value) (value
 	v := value.Unwrap[*value.String](args[0])
 	names := value.Unwrap[*value.String](args[1])
 
-	query, err := shared.ParseQuery(v.Value)
-	if err != nil {
-		return value.Null, errors.New(
-			Querystring_filter_except_Name, "Failed to parse query: %s, error: %s", v.Value, err.Error(),
-		)
-	}
 	filterMap := make(map[string]struct{})
 	for _, f := range bytes.Split([]byte(names.Value), Querystring_filtersep_Sign) {
 		filterMap[string(f)] = struct{}{}
 	}
 
-	query.Filter(func(name string) bool {
+	result := shared.QueryStringFilter(v.Value, func(name string) bool {
 		_, ok := filterMap[name]
 		return ok
 	})
 
-	return &value.String{Value: query.String()}, nil
+	return &value.String{Value: result}, nil
 }

--- a/interpreter/function/builtin/querystring_globfilter.go
+++ b/interpreter/function/builtin/querystring_globfilter.go
@@ -39,13 +39,6 @@ func Querystring_globfilter(ctx *context.Context, args ...value.Value) (value.Va
 	v := value.Unwrap[*value.String](args[0])
 	name := value.Unwrap[*value.String](args[1])
 
-	query, err := shared.ParseQuery(v.Value)
-	if err != nil {
-		return value.Null, errors.New(
-			Querystring_globfilter_Name, "Failed to parse query: %s, error: %s", v.Value, err.Error(),
-		)
-	}
-
 	pattern, err := glob.Compile(name.Value)
 	if err != nil {
 		return value.Null, errors.New(
@@ -53,8 +46,8 @@ func Querystring_globfilter(ctx *context.Context, args ...value.Value) (value.Va
 		)
 	}
 
-	query.Filter(func(v string) bool {
+	result := shared.QueryStringFilter(v.Value, func(v string) bool {
 		return !pattern.Match(v)
 	})
-	return &value.String{Value: query.String()}, nil
+	return &value.String{Value: result}, nil
 }

--- a/interpreter/function/builtin/querystring_globfilter_except.go
+++ b/interpreter/function/builtin/querystring_globfilter_except.go
@@ -39,13 +39,6 @@ func Querystring_globfilter_except(ctx *context.Context, args ...value.Value) (v
 	v := value.Unwrap[*value.String](args[0])
 	name := value.Unwrap[*value.String](args[1])
 
-	query, err := shared.ParseQuery(v.Value)
-	if err != nil {
-		return value.Null, errors.New(
-			Querystring_globfilter_except_Name, "Failed to parse query: %s, error: %s", v.Value, err.Error(),
-		)
-	}
-
 	pattern, err := glob.Compile(name.Value)
 	if err != nil {
 		return value.Null, errors.New(
@@ -53,8 +46,8 @@ func Querystring_globfilter_except(ctx *context.Context, args ...value.Value) (v
 		)
 	}
 
-	query.Filter(func(v string) bool {
+	result := shared.QueryStringFilter(v.Value, func(v string) bool {
 		return pattern.Match(v)
 	})
-	return &value.String{Value: query.String()}, nil
+	return &value.String{Value: result}, nil
 }

--- a/interpreter/function/builtin/querystring_regfilter.go
+++ b/interpreter/function/builtin/querystring_regfilter.go
@@ -40,15 +40,8 @@ func Querystring_regfilter(ctx *context.Context, args ...value.Value) (value.Val
 	v := value.Unwrap[*value.String](args[0])
 	name := value.Unwrap[*value.String](args[1])
 
-	query, err := shared.ParseQuery(v.Value)
-	if err != nil {
-		return value.Null, errors.New(
-			Querystring_regfilter_Name, "Failed to parse query: %s, error: %s", v.Value, err.Error(),
-		)
-	}
-
 	var matchErr error
-	query.Filter(func(key string) bool {
+	result := shared.QueryStringFilter(v.Value, func(key string) bool {
 		matched, err := regexp.MatchString(name.Value, key)
 		if err != nil {
 			matchErr = errors.New(
@@ -61,5 +54,5 @@ func Querystring_regfilter(ctx *context.Context, args ...value.Value) (value.Val
 	if matchErr != nil {
 		return value.Null, matchErr
 	}
-	return &value.String{Value: query.String()}, nil
+	return &value.String{Value: result}, nil
 }

--- a/interpreter/function/builtin/querystring_regfilter_except.go
+++ b/interpreter/function/builtin/querystring_regfilter_except.go
@@ -40,15 +40,8 @@ func Querystring_regfilter_except(ctx *context.Context, args ...value.Value) (va
 	v := value.Unwrap[*value.String](args[0])
 	name := value.Unwrap[*value.String](args[1])
 
-	query, err := shared.ParseQuery(v.Value)
-	if err != nil {
-		return value.Null, errors.New(
-			Querystring_regfilter_except_Name, "Failed to parse query: %s, error: %s", v.Value, err.Error(),
-		)
-	}
-
 	var matchErr error
-	query.Filter(func(key string) bool {
+	result := shared.QueryStringFilter(v.Value, func(key string) bool {
 		matched, err := regexp.MatchString(name.Value, key)
 		if err != nil {
 			matchErr = errors.New(
@@ -61,5 +54,5 @@ func Querystring_regfilter_except(ctx *context.Context, args ...value.Value) (va
 	if matchErr != nil {
 		return value.Null, matchErr
 	}
-	return &value.String{Value: query.String()}, nil
+	return &value.String{Value: result}, nil
 }

--- a/interpreter/function/builtin/querystring_set.go
+++ b/interpreter/function/builtin/querystring_set.go
@@ -39,13 +39,6 @@ func Querystring_set(ctx *context.Context, args ...value.Value) (value.Value, er
 	name := value.Unwrap[*value.String](args[1])
 	val := value.Unwrap[*value.String](args[2])
 
-	query, err := shared.ParseQuery(u.Value)
-	if err != nil {
-		return value.Null, errors.New(
-			Querystring_set_Name, "Failed to parse urquery: %s, error: %s", u.Value, err.Error(),
-		)
-	}
-
-	query.Set(name.Value, val.Value)
-	return &value.String{Value: query.String()}, nil
+	result := shared.QueryStringSet(u.Value, name.Value, val.Value)
+	return &value.String{Value: result}, nil
 }

--- a/interpreter/function/builtin/querystring_sort.go
+++ b/interpreter/function/builtin/querystring_sort.go
@@ -36,13 +36,7 @@ func Querystring_sort(ctx *context.Context, args ...value.Value) (value.Value, e
 	}
 
 	u := value.Unwrap[*value.String](args[0])
-	query, err := shared.ParseQuery(u.Value)
-	if err != nil {
-		return value.Null, errors.New(
-			Querystring_sort_Name, "Failed to parse urquery: %s, error: %s", u.Value, err.Error(),
-		)
-	}
 
-	query.Sort(shared.SortAsc)
-	return &value.String{Value: query.String()}, nil
+	result := shared.QueryStringSort(u.Value, shared.SortAsc)
+	return &value.String{Value: result}, nil
 }


### PR DESCRIPTION
The behavior of this new implementation is more consistent with Fastly. 
The original falco implementation parses the original value into a structure, then manipulates it and then converts back to string representation. This has several unwanted side effects such changing key and value encoding as well as changing parameter order.
Instead of fully parsing the input string, new implementation attempts to only split it to pieces as necessary.
The premise is that split operation is fully reversible with join.
Also new implementation attempts to follow Fastly quirks. For instance in some cases (filter) '?' is automatically removed if operation result leads to empty query. In some other cases (sort) it is preserved even if query string is empty.
