### PR TITLE
STRING/IP not set expansion

### DIFF
--- a/debugger/repl.go
+++ b/debugger/repl.go
@@ -33,7 +33,7 @@ func (c *Console) evaluate(input string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	val, err := c.interpreter.ProcessExpression(exp, false)
+	val, err := c.interpreter.ProcessExpression(exp, false, false)
 	if err != nil {
 		if re, ok := err.(*exception.Exception); ok {
 			return "", fmt.Errorf(re.Message) // DO NOT diplay line and position info

--- a/examples/testing/not_set/not_set.test.vcl
+++ b/examples/testing/not_set/not_set.test.vcl
@@ -1,0 +1,819 @@
+// Note: using an unusual assert setup in these tests to ensure the results
+// of the test match the expectations without relying on the `Value.String()`
+// calls used in `assert.equal()`.
+
+// @suite: Set STRING var the result of concatenation of an unset STRING var and unset STRING var
+sub test_set_concat_unset_strings {
+  declare local var.str STRING;
+  declare local var.unset STRING;
+  set var.str = var.unset + var.unset;
+  log "concat unset strings:";
+  if (var.str == "") {
+    log "empty string (expected)"; // correct
+    assert.true(true);
+  } else if (var.str == "(null)(null)") {
+    log "(null)";
+    assert.true(false, "got: (null), expected: empty string");
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: empty string");
+  }
+}
+
+// @suite: Set STRING var the result of concatenation of a string literal and unset STRING var
+sub test_set_concat_unset_string {
+  declare local var.str STRING;
+  declare local var.unset STRING;
+  set var.str = "left" + var.unset;
+  log "concat unset string (left):";
+  if (var.str == "left") {
+    log "empty string (expected)"; // correct
+    assert.true(true);
+  } else if (var.str == "left(null)") {
+    log "(null)";
+    assert.true(false, "got: (null), expected: empty string");
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: empty string");
+  }
+  set var.str = var.unset + "right";
+  log "concat unset string (right):";
+  if (var.str == "right") {
+    log "empty string (expected)"; // correct
+    assert.true(true);
+  } else if (var.str == "(null)right") {
+    log "(null)";
+    assert.true(false, "got: (null), expected: empty string");
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: empty string");
+  }
+}
+
+// @suite: Set STRING var the result of concatenation of a string literal and unset IP var
+sub test_set_concat_unset_ip {
+  declare local var.str STRING;
+  declare local var.unset IP ;
+  set var.str = "left" + var.unset;
+  log "concat unset IP (left):";
+  if (var.str == "left") {
+    log "empty string (expected)"; // correct
+    assert.true(true);
+  } else if (var.str == "left(null)") {
+    log "(null)";
+    assert.true(false, "got: (null), expected: empty string");
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: empty string");
+  }
+  set var.str = var.unset + "right";
+  log "concat unset IP (right):";
+  if (var.str == "right") {
+    log "empty string (expected)"; // correct
+    assert.true(true);
+  } else if (var.str == "(null)right") {
+    log "(null)";
+    assert.true(false, "got: (null), expected: empty string");
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: empty string");
+  }
+}
+
+// @suite: Set STRING var the result of space concatenation of an unset STRING var and unset STRING var
+sub test_set_space_concat_unset_strings {
+  declare local var.str STRING;
+  declare local var.unset STRING;
+  set var.str = var.unset var.unset;
+  log "concat unset strings:";
+  if (var.str == "") {
+    log "empty string (expected)"; // correct
+    assert.true(true);
+  } else if (var.str == "(null)(null)") {
+    log "(null)";
+    assert.true(false, "got: (null), expected: empty string");
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: empty string");
+  }
+}
+
+// @suite: Set STRING var the result of space concatenation of a string literal and unset STRING var
+sub test_set_space_concat_unset_string {
+  declare local var.str STRING;
+  declare local var.unset STRING;
+  set var.str = "left" var.unset;
+  log "concat unset string (left):";
+  if (var.str == "left") {
+    log "empty string (expected)"; // correct
+    assert.true(true);
+  } else if (var.str == "left(null)") {
+    log "(null)";
+    assert.true(false, "got: (null), expected: empty string");
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: empty string");
+  }
+  set var.str = var.unset "right";
+  log "concat unset string (right):";
+  if (var.str == "right") {
+    log "empty string (expected)"; // correct
+    assert.true(true);
+  } else if (var.str == "(null)right") {
+    log "(null)";
+    assert.true(false, "got: (null), expected: empty string");
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: empty string");
+  }
+}
+
+// @suite: Set STRING var the result of space concatenation of a string literal and unset IP var
+sub test_set_space_concat_unset_ip {
+  declare local var.str STRING;
+  declare local var.unset IP;
+  set var.str = "left" var.unset;
+  log "concat unset IP (left):";
+  if (var.str == "left") {
+    log "empty string (expected)"; // correct
+    assert.true(true);
+  } else if (var.str == "left(null)") {
+    log "(null)";
+    assert.true(false, "got: (null), expected: empty string");
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: empty string");
+  }
+  set var.str = var.unset "right";
+  log "concat unset IP (right):";
+  if (var.str == "right") {
+    log "empty string (expected)"; // correct
+    assert.true(true);
+  } else if (var.str == "(null)right") {
+    log "(null)";
+    assert.true(false, "got: (null), expected: empty string");
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: empty string");
+  }
+}
+
+// @suite: Set STRING var the result of concatenation of a string literal and unset header
+sub test_set_concat_unset_header {
+  declare local var.str STRING;
+  set var.str = "left" + req.http.unset;
+  log "concat unset header (left):";
+  if (var.str == "left") {
+    log "empty string (expected)"; // correct
+    assert.true(true);
+  } else if (var.str == "left(null)") {
+    log "(null)";
+    assert.true(false, "got: (null), expected: empty string");
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: empty string");
+  }
+  set var.str = req.http.unset + "right";
+  log "concat unset header (right):";
+  if (var.str == "right") {
+    log "empty string (expected)"; //correct
+    assert.true(true);
+  } else if (var.str == "(null)right") {
+    log "(null)";
+    assert.true(false, "got: (null), expected: empty string");
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: empty string");
+  }
+}
+
+// @suite: Set STRING var the result of space concatenation of a string literal and unset header
+sub test_set_space_concat_unset_header {
+  declare local var.str STRING;
+  set var.str = "left" req.http.unset;
+  log "set space concat unset header (left):";
+  if (var.str == "left") {
+    log "empty string (expected)"; // correct
+    assert.true(true);
+  } else if (var.str == "left(null)") {
+    log "(null)";
+    assert.true(false, "got: (null), expected: empty string");
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: empty string");
+  }
+  set var.str = req.http.unset "right";
+  log "set space concat unset header (right):";
+  if (var.str == "right") {
+    log "empty string (expected)"; // correct
+    assert.true(true);
+  } else if (var.str == "(null)right") {
+    log "(null)";
+    assert.true(false, "got: (null), expected: empty string");
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: empty string");
+  }
+}
+
+// @suite: Set header the result of concatenation of a string literal and unset STRING var 
+sub test_set_header_concat_unset_string {
+  declare local var.unset STRING;
+  log "set header concat unset string (left):";
+  set req.http.unset_string = "left" + var.unset;
+  if (req.http.unset_string == "left") {
+    log "empty string";
+    assert.true(false, "got: empty string, expected: (null)");
+  } else if (req.http.unset_string == "left(null)") {
+    log "(null) (expected)"; // correct
+    assert.true(true);
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: (null)");
+  }
+  log "set header concat unset string (right):";
+  set req.http.unset_string = var.unset + "right";
+  if (req.http.unset_string == "right") {
+    log "empty string";
+    assert.true(false, "got: empty string, expected: (null)");
+  } else if (req.http.unset_string == "(null)right") {
+    log "(null) (expected)"; // correct
+    assert.true(true);
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: (null)");
+  }
+}
+
+// @suite: Set header the result of concatenation of a string literal and unset IP var 
+sub test_set_header_concat_unset_ip {
+  declare local var.unset IP;
+  log "set header concat unset ip (left):";
+  set req.http.unset_ip = "left" + var.unset;
+  if (req.http.unset_ip == "left") {
+    log "empty string";
+    assert.true(false, "got: empty string, expected: (null)");
+  } else if (req.http.unset_ip == "left(null)") {
+    log "(null) (expected)"; // correct
+    assert.true(true);
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: (null)");
+  }
+  log "set header concat unset ip (right):";
+  set req.http.unset_ip = var.unset + "right";
+  if (req.http.unset_ip == "right") {
+    log "empty string";
+    assert.true(false, "got: empty string, expected: (null)");
+  } else if (req.http.unset_ip == "(null)right") {
+    log "(null) (expected)"; // correct
+    assert.true(true);
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: (null)");
+  }
+}
+
+// @suite: Set header the result of concatenation of a string literal and header
+sub test_set_header_concat_unset_header {
+  log "set header concat unset header (left):";
+  set req.http.concat_unset_header = "left" + req.http.unset;
+  if (req.http.concat_unset_header == "left") {
+    log "empty string";
+    assert.true(false, "got: empty string, expected: (null)");
+  } else if (req.http.concat_unset_header == "left(null)") {
+    log "(null) (expected)"; // correct
+    assert.true(true);
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: (null)");
+  }
+  log "set header concat unset header (right):";
+  set req.http.concat_unset_header = req.http.unset + "right";
+  if (req.http.concat_unset_header == "right") {
+    log "empty string";
+    assert.true(false, "got: empty string, expected: (null)");
+  } else if (req.http.concat_unset_header == "(null)right") {
+    log "(null) (expected)"; // correct
+    assert.true(true);
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: (null)");
+  }
+}
+
+// @suite: Add header the result of concatenation of a string literal and unset header
+sub test_add_header_concat_unset_header {
+  log "add header concat unset header (left):";
+  add req.http.add_concat_unset_header_left = "left" + req.http.unset;
+  if (req.http.add_concat_unset_header_left == "left") {
+    log "empty string";
+    assert.true(false, "got: empty string, expected: (null)");
+  } else if (req.http.add_concat_unset_header_left == "left(null)") {
+    log "(null) (expected)"; // correct
+    assert.true(true);
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: (null)");
+  }
+  log "add header concat unset header (right):";
+  add req.http.add_concat_unset_header_right = req.http.unset + "right";
+  if (req.http.add_concat_unset_header_right == "right") {
+    log "empty string";
+    assert.true(false, "got: empty string, expected: (null)");
+  } else if (req.http.add_concat_unset_header_right == "(null)right") {
+    log "(null) (expected)"; // correct
+    assert.true(true);
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: (null)");
+  }
+}
+
+// @suite: Add header the result of concatenation of a string literal and unset STRING var
+sub test_add_header_concat_unset_string {
+  log "add header concat unset string (left):";
+  declare local var.unset STRING;
+  add req.http.add_concat_unset_string_left = "left" + var.unset;
+  if (req.http.add_concat_unset_string_left == "left") {
+    log "empty string";
+    assert.true(false, "got: empty string, expected: (null)");
+  } else if (req.http.add_concat_unset_string_left == "left(null)") {
+    log "(null) (expected)"; // correct
+    assert.true(true);
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: (null)");
+  }
+  log "add header concat unset string (right):";
+  add req.http.add_concat_unset_string_right = var.unset + "right";
+  if (req.http.add_concat_unset_string_right == "right") {
+    log "empty string";
+    assert.true(false, "got: empty string, expected: (null)");
+  } else if (req.http.add_concat_unset_string_right == "(null)right") {
+    log "(null) (expected)"; // correct
+    assert.true(true);
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: (null)");
+  }
+}
+
+// @suite: Add header the result of concatenation of a string literal and unset IP var
+sub test_add_header_concat_unset_ip {
+  log "add header concat unset ip (left):";
+  declare local var.unset IP;
+  add req.http.add_concat_unset_ip_left = "left" + var.unset;
+  if (req.http.add_concat_unset_ip_left == "left") {
+    log "empty string";
+    assert.true(false, "got: empty string, expected: (null)");
+  } else if (req.http.add_concat_unset_ip_left == "left(null)") {
+    log "(null) (expected)"; // correct
+    assert.true(true);
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: (null)");
+  }
+  log "add header concat unset ip (right):";
+  add req.http.add_concat_unset_ip_right = var.unset + "right";
+  if (req.http.add_concat_unset_ip_right == "right") {
+    log "empty string";
+    assert.true(false, "got: empty string, expected: (null)");
+  } else if (req.http.add_concat_unset_ip_right == "(null)right") {
+    log "(null) (expected)"; // correct
+    assert.true(true);
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: (null)");
+  }
+}
+
+// @suite: Set header an unset STRING var
+sub test_set_header_unset_string {
+  declare local var.unset STRING;
+  log "set header unset string:";
+  set req.http.unset_string = var.unset;
+  if (req.http.unset_string == "") {
+    log "empty string";
+    assert.true(false, "got: empty string, expected: (null)");
+  } else if (req.http.unset_string == "(null)") {
+    log "(null)";
+    assert.true(false, "got: (null), expected: empty string");
+  } else {
+    log "not_set (expected)"; // correct
+    assert.true(true);
+  }
+}
+
+// @suite: Set header an unset IP var
+sub test_set_header_unset_ip {
+  declare local var.unset IP;
+  log "set header unset ip:";
+  set req.http.unset_ip = var.unset;
+  if (req.http.unset_ip == "") {
+    log "empty string";
+    assert.true(false, "got: empty string, expected: (null)");
+  } else if (req.http.unset_ip == "(null)") {
+    log "(null)";
+    assert.true(false, "got: (null), expected: empty string");
+  } else if (!req.http.unset_ip) {
+    log "not_set (expected)"; // correct
+    assert.true(true);
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: not set");
+  }
+}
+
+// @suite: Set header an unset header
+sub test_set_header_unset_header {
+  log "set header unset header:";
+  set req.http.unset_header = req.http.unset_123;
+    if (req.http.unset_header == "") {
+    log "empty string";
+    assert.true(false, "got: empty string, expected: (null)");
+  } else if (req.http.unset_header == "(null)") {
+    log "(null)";
+    assert.true(false, "got: (null), expected: empty string");
+  } else if (!req.http.unset_header) {
+    log "not_set (expected)"; // correct
+    assert.true(true);
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: not set");
+  }
+}
+
+// @suite: Add header an unset header
+sub test_add_header_unset_header {
+  log "add header unset header:";
+  add req.http.unset_header = req.http.unset_123;
+    if (req.http.unset_header == "") {
+    log "empty string";
+    assert.true(false, "got: empty string, expected: (null)");
+  } else if (req.http.unset_header == "(null)") {
+    log "(null)";
+    assert.true(false, "got: (null), expected: empty string");
+  } else if (!req.http.unset_header) {
+    log "not_set (expected)"; // correct
+    assert.true(true);
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: not set");
+  }
+}
+
+// @suite: Add header an unset STRING
+sub test_add_header_unset_string {
+  log "add header unset ip:";
+  declare local var.unset STRING;
+  add req.http.unset_header = var.unset;
+    if (req.http.unset_header == "") {
+    log "empty string";
+    assert.true(false, "got: empty string, expected: (null)");
+  } else if (req.http.unset_header == "(null)") {
+    log "(null)";
+    assert.true(false, "got: (null), expected: empty string");
+  } else if (!req.http.unset_header) {
+    log "not_set (expected)"; // correct
+    assert.true(true);
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: not set");
+  }
+}
+
+// @suite: Add header an unset IP
+sub test_add_header_unset_ip {
+  log "add header unset ip:";
+  declare local var.unset IP;
+  add req.http.unset_header = var.unset;
+    if (req.http.unset_header == "") {
+    log "empty string";
+    assert.true(false, "got: empty string, expected: (null)");
+  } else if (req.http.unset_header == "(null)") {
+    log "(null)";
+    assert.true(false, "got: (null), expected: empty string");
+  } else if (!req.http.unset_header) {
+    log "not_set (expected)"; // correct
+    assert.true(true);
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: not set");
+  }
+}
+// @suite: Set STRING var an unset STRING var 
+sub test_set_string_unset_string {
+  declare local var.str STRING;
+  declare local var.unset STRING;
+  log "set local unset string:";
+  set var.str = var.unset;
+  if (var.str == "") {
+    log "empty string (expected)"; // correct
+    assert.true(true);
+  } else if (var.str == "(null)") {
+    log "(null)";
+    assert.true(false, "got: (null), expected: empty string");
+  } else if (!var.str) {
+    log "not_set";
+    assert.true(false, "got: not set, expected: empty string");
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: empty string");
+  }
+}
+
+// @suite: Set STRING var an unset IP var 
+sub test_set_string_unset_ip {
+  declare local var.str STRING;
+  declare local var.unset IP;
+  log "set local unset IP:";
+  set var.str = var.unset;
+  if (var.str == "") {
+    log "empty string (expected)"; // correct
+    assert.true(true);
+  } else if (var.str == "(null)") {
+    log "(null)";
+    assert.true(false, "got: (null), expected: empty string");
+  } else if (!var.str) {
+    log "not_set";
+    assert.true(false, "got: not set, expected: empty string");
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: empty string");
+  }
+}
+
+// @suite: Set STRING var an unset header
+sub test_set_string_unset_header {
+  declare local var.str STRING;
+  log "set local unset header:";
+  set var.str = req.http.unset;
+  if (var.str == "") {
+    log "empty string (expected)"; // correct
+    assert.true(true);
+  } else if (var.str == "(null)") {
+    log "(null)";
+    assert.true(false, "got: (null), expected: empty string");
+  } else if (!var.str) {
+    log "not_set";
+    assert.true(false, "got: not set, expected: empty string");
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: empty string");
+  }
+}
+
+// @suite: Set STRING var result of json.escape with unset STRING argument
+sub test_set_jsonescape {
+  declare local var.str STRING;
+  declare local var.unset STRING;
+  log "set local var result of json.escape with unset argument";
+  set var.str = json.escape(var.unset);
+    if (var.str == "") {
+    log "empty string (expected)"; // correct
+    assert.true(true);
+  } else if (var.str == "(null)") {
+    log "(null)";
+    assert.true(false, "got: (null), expected: empty string");
+  } else if (!var.str) {
+    log "not_set";
+    assert.true(false, "got: not set, expected: empty string");
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: empty string");
+  }
+}
+
+// @suite: Set STRING var result of regsub with unset STRING replacement argument
+sub test_set_regsub {
+  declare local var.str STRING;
+  declare local var.unset STRING;
+  log "set local var result of regsub test_with unset replacement";
+  set var.str = regsub("bar baz", "a", var.unset);
+  if (var.str == "br baz") {
+    log "empty string (expected)"; // correct
+    assert.true(true);
+  } else if (var.str == "b(null)r baz") {
+    log "(null)";
+    assert.true(false, "got: (null), expected: empty string");
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: empty string");
+  }
+}
+
+// @suite: Set STRING var result of json.escape with string concatenation argument containing an unset STRING
+sub test_concat_in_function_argument {
+  declare local var.str STRING;
+  declare local var.unset STRING;
+  log "set local var result of json.escape with concat of string and unset argument";
+  set var.str = json.escape(var.unset + "foo");
+  if (var.str == "foo") {
+    log "empty string (expected)"; // correct
+    assert.true(true);
+  } else if (var.str == "(null)foo") {
+    log "(null)";
+    assert.true(false, "got: (null), expected: empty string");
+  } else {
+    log "no match";
+    assert.true(false, "got: no match, expected: empty string");
+  }
+}
+
+// @suite: Use unset STRING variable as switch statement control
+sub test_switch_statement_unset_string {
+  log "unset string in switch control";
+  declare local var.unset STRING;
+  switch (var.unset) {
+    case "":
+      log "empty string (expected)"; // correct
+      assert.true(true);
+      break;
+    case "(null)":
+      log "(null)";
+      assert.true(false, "got: (null), expected: empty string");
+      break;
+    default:
+      log "no match";
+      assert.true(false, "got: no match, expected: empty string");
+      break;
+  }
+}
+
+// @suite: Use unset IP variable as switch statement control
+sub test_switch_statement_unset_ip {
+  log "unset ip in switch control";
+  declare local var.unset IP;
+  switch (var.unset) {
+    case "":
+      log "empty string (expected)"; // correct
+      assert.true(true);
+      break;
+    case "(null)":
+      log "(null)";
+      assert.true(false, "got: (null), expected: empty string");
+      break;
+    default:
+      log "no match";
+      assert.true(false, "got: no match, expected: empty string");
+      break;
+  }
+}
+
+
+// @suite: Use unset header as switch statement control
+sub test_switch_statement_unset_header {
+  log "unset header in switch control";
+  switch (req.http.unset) {
+    case "":
+      log "empty string (expected)"; // correct
+      assert.true(true);
+      break;
+    case "(null)":
+      log "(null)";
+      assert.true(false, "got: (null), expected: empty string");
+      break;
+    default:
+      log "no match";
+      assert.true(false, "got: no match, expected: empty string");
+      break;
+  }
+}
+
+// @suite: Unset STRING variable in if statement condition
+sub test_if_statement_unset_string {
+  log "if statement unset string condition";
+  declare local var.unset STRING;
+  if (var.unset == "") {
+    log "empty string";
+    assert.true(false, "got: empty string, expected: false");
+  } else if (var.unset == "(null)") {
+    log "(null)";
+    assert.true(false, "got: (null), expected: false");
+  } else if (!var.unset) {
+    log "false (expected)";
+    assert.true(true);
+  }
+}
+
+// @suite: Unset header in if statement condition
+sub test_if_statement_unset_header {
+  log "if statement unset header condition";
+  if (req.http.unset == "") {
+    log "empty string";
+    assert.true(false, "got: empty string, expected: false");
+  } else if (req.http.unset == "(null)") {
+    log "(null)";
+    assert.true(false, "got: (null), expected: false");
+  } else if (!req.http.unset) {
+    log "false (expected)";
+    assert.true(true);
+  }
+}
+
+// Need #249 to be able to properly validate the remaining tests.
+// For now they show in the fiddle how Fastly handles not set values
+// in log statements.
+
+// @suite: Log statement with unset STRING variable
+sub test_log_statement_unset_string {
+    log "log statement with unset string";
+
+    declare local var.unset STRING;
+
+    log "var.unset:";
+
+    log "direct ident";
+    log var.unset;
+    log "expect: (null)";
+
+    log "space concat";
+    log var.unset "foo";
+    log "expect: (null)foo";
+
+    log "+ concat";
+    log var.unset + "foo";
+    log "expect: (null)foo";
+
+    log "req.http.unset:";
+
+    log "direct ident";
+    log req.http.unset;
+    log "expect: (null)";
+
+    log "space concat";
+    log req.http.unset "foo";
+    log "expect: (null)foo";
+
+    log "+ concat";
+    log req.http.unset + "foo";
+    log "expect: (null)foo";
+}
+
+// @suite: Log statement with unset IP variable
+sub test_log_statement_unset_ip {
+    log "log statement with unset IP";
+
+    declare local var.unset IP;
+    log "var.unset:";
+
+    log "direct ident";
+    log var.unset;
+    log "expect: (null)";
+
+    log "space concat";
+    log var.unset "foo";
+    log "expect: (null)foo";
+
+    log "+ concat";
+    log var.unset + "foo";
+    log "expect: (null)foo";
+
+    log "req.http.unset:";
+
+    log "direct ident";
+    log req.http.unset;
+    log "expect: (null)";
+
+    log "space concat";
+    log req.http.unset "foo";
+    log "expect: (null)foo";
+
+    log "+ concat";
+    log req.http.unset + "foo";
+    log "expect: (null)foo";
+}
+
+// @suite: Log statement with unset header
+sub test_log_statement_unset_header {
+    log "log statement with unset header";
+
+    log "req.http.unset:";
+
+    log "direct ident";
+    log req.http.unset;
+    log "expect: (null)";
+
+    log "space concat";
+    log req.http.unset "foo";
+    log "expect: (null)foo";
+
+    log "+ concat";
+    log req.http.unset + "foo";
+    log "expect: (null)foo";
+
+    log "req.http.unset:";
+
+    log "direct ident";
+    log req.http.unset;
+    log "expect: (null)";
+
+    log "space concat";
+    log req.http.unset "foo";
+    log "expect: (null)foo";
+
+    log "+ concat";
+    log req.http.unset + "foo";
+    log "expect: (null)foo";
+}

--- a/interpreter/expression.go
+++ b/interpreter/expression.go
@@ -21,6 +21,8 @@ func expand(val value.Value) value.Value {
 		ns = v.IsNotSet
 	case *value.IP:
 		ns = v.IsNotSet
+	case *value.LenientString:
+		ns = v.IsNotSet
 	}
 	if ns {
 		return value.NullStringValue

--- a/interpreter/expression_test.go
+++ b/interpreter/expression_test.go
@@ -84,7 +84,7 @@ func TestPrefixExpression(t *testing.T) {
 
 		for _, tt := range tests {
 			ip := New(nil)
-			value, err := ip.ProcessPrefixExpression(tt.expression, tt.withCondition)
+			value, err := ip.ProcessPrefixExpression(tt.expression, tt.withCondition, false)
 			if tt.isError {
 				if err == nil {
 					t.Errorf("%s expects error but non-nil", tt.name)
@@ -171,7 +171,7 @@ func TestPrefixExpression(t *testing.T) {
 
 		for _, tt := range tests {
 			ip := New(nil)
-			value, err := ip.ProcessPrefixExpression(tt.expression, false)
+			value, err := ip.ProcessPrefixExpression(tt.expression, false, false)
 			if tt.isError {
 				if err == nil {
 					t.Errorf("%s expects error but non-nil", tt.name)

--- a/interpreter/http/headers.go
+++ b/interpreter/http/headers.go
@@ -94,6 +94,13 @@ func (h Header) Set(key string, val value.Value) {
 func (h Header) SetObject(name, key string, val value.Value) {
 	values, ok := h[textproto.CanonicalMIMEHeaderKey(name)]
 	if !ok {
+		v := copyToLenientString(val)
+		// Assigning a not set value to a header field key with length greater
+		// than 1 results in the assignment of an empty string.
+		if len(key) > 1 && v.IsNotSet {
+			v.IsNotSet = false
+			v.Values = append(v.Values, &value.String{Value: ""})
+		}
 		h[textproto.CanonicalMIMEHeaderKey(name)] = [][]HeaderItem{
 			{
 				HeaderItem{
@@ -102,7 +109,7 @@ func (h Header) SetObject(name, key string, val value.Value) {
 							&value.String{Value: key},
 						},
 					},
-					Value: copyToLenientString(val),
+					Value: v,
 				},
 			},
 		}

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -516,7 +516,7 @@ func (i *Interpreter) ProcessFetch() error {
 	firstByteTimeout := 20 * time.Second
 	for _, v := range i.ctx.Backend.Value.Properties {
 		if v.Key.Value == "first_byte_timeout" {
-			if val, err := i.ProcessExpression(v.Value, false); err == nil {
+			if val, err := i.ProcessExpression(v.Value, false, false); err == nil {
 				firstByteTimeout = value.Unwrap[*value.RTime](val).Value
 			}
 			break

--- a/interpreter/statement.go
+++ b/interpreter/statement.go
@@ -217,6 +217,8 @@ func identIsHeader(name string) bool {
 
 func (i *Interpreter) ProcessSetStatement(stmt *ast.SetStatement) error {
 	var expandNotSet bool
+	// If value being assigned is not an identifier only expand not_set STRING/IP
+	// values if the target of the assignment is a header.
 	if _, ok := stmt.Value.(*ast.Ident); !ok && identIsHeader(stmt.Ident.Value) {
 		expandNotSet = true
 	}

--- a/interpreter/statement.go
+++ b/interpreter/statement.go
@@ -207,8 +207,20 @@ func (i *Interpreter) ProcessReturnStatement(stmt *ast.ReturnStatement) State {
 	return State((*stmt.ReturnExpression).String())
 }
 
+func identIsHeader(name string) bool {
+	return strings.HasPrefix(name, "req.http.") ||
+		strings.HasPrefix(name, "bereq.http.") ||
+		strings.HasPrefix(name, "beresp.http.") ||
+		strings.HasPrefix(name, "obj.http.") ||
+		strings.HasPrefix(name, "resp.http.")
+}
+
 func (i *Interpreter) ProcessSetStatement(stmt *ast.SetStatement) error {
-	right, err := i.ProcessExpression(stmt.Value, false)
+	var expandNotSet bool
+	if _, ok := stmt.Value.(*ast.Ident); !ok && identIsHeader(stmt.Ident.Value) {
+		expandNotSet = true
+	}
+	right, err := i.ProcessExpression(stmt.Value, false, expandNotSet)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -227,20 +239,19 @@ func (i *Interpreter) ProcessSetStatement(stmt *ast.SetStatement) error {
 func (i *Interpreter) ProcessAddStatement(stmt *ast.AddStatement) error {
 	// Add statement could use only for HTTP headers.
 	// https://developer.fastly.com/reference/vcl/statements/add/
-	if !strings.Contains(stmt.Ident.Value, "req.http.") &&
-		!strings.Contains(stmt.Ident.Value, "bereq.http.") &&
-		!strings.Contains(stmt.Ident.Value, "beresp.http.") &&
-		!strings.Contains(stmt.Ident.Value, "obj.http.") &&
-		!strings.Contains(stmt.Ident.Value, "resp.http.") {
-
+	if !identIsHeader(stmt.Ident.Value) {
 		return exception.Runtime(
 			&stmt.GetMeta().Token,
 			"Add statement could not use for %s",
 			stmt.Ident.Value,
 		)
 	}
+	var expandNotSet bool
+	if _, ok := stmt.Value.(*ast.Ident); !ok {
+		expandNotSet = true
+	}
 
-	right, err := i.ProcessExpression(stmt.Value, false)
+	right, err := i.ProcessExpression(stmt.Value, false, expandNotSet)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -309,7 +320,7 @@ func (i *Interpreter) ProcessCallStatement(stmt *ast.CallStatement, ds DebugStat
 func (i *Interpreter) ProcessErrorStatement(stmt *ast.ErrorStatement) error {
 	// Possibility error code is not defined
 	if stmt.Code != nil {
-		code, err := i.ProcessExpression(stmt.Code, false)
+		code, err := i.ProcessExpression(stmt.Code, false, false)
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -320,7 +331,7 @@ func (i *Interpreter) ProcessErrorStatement(stmt *ast.ErrorStatement) error {
 	}
 	// Possibility error response is not defined
 	if stmt.Argument != nil {
-		arg, err := i.ProcessExpression(stmt.Argument, false)
+		arg, err := i.ProcessExpression(stmt.Argument, false, false)
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -353,7 +364,7 @@ func (i *Interpreter) ProcessEsiStatement(stmt *ast.EsiStatement) error {
 }
 
 func (i *Interpreter) ProcessLogStatement(stmt *ast.LogStatement) error {
-	log, err := i.ProcessExpression(stmt.Value, false)
+	log, err := i.ProcessExpression(stmt.Value, false, true)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -373,7 +384,7 @@ func (i *Interpreter) ProcessLogStatement(stmt *ast.LogStatement) error {
 }
 
 func (i *Interpreter) ProcessSyntheticStatement(stmt *ast.SyntheticStatement) error {
-	val, err := i.ProcessExpression(stmt.Value, false)
+	val, err := i.ProcessExpression(stmt.Value, false, true)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -387,7 +398,7 @@ func (i *Interpreter) ProcessSyntheticStatement(stmt *ast.SyntheticStatement) er
 }
 
 func (i *Interpreter) ProcessSyntheticBase64Statement(stmt *ast.SyntheticBase64Statement) error {
-	val, err := i.ProcessExpression(stmt.Value, false)
+	val, err := i.ProcessExpression(stmt.Value, false, false)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -447,7 +458,7 @@ func (i *Interpreter) ProcessFunctionCallStatement(stmt *ast.FunctionCallStateme
 			}
 		} else {
 			// Otherwize, make value by processing expression
-			a, err := i.ProcessExpression(stmt.Arguments[j], false)
+			a, err := i.ProcessExpression(stmt.Arguments[j], false, false)
 			if err != nil {
 				return NONE, errors.WithStack(err)
 			}
@@ -477,7 +488,7 @@ func (i *Interpreter) ProcessIfStatement(
 	isReturnAsValue bool,
 ) (value.Value, State, error) {
 	// if
-	cond, err := i.ProcessExpression(stmt.Condition, true)
+	cond, err := i.ProcessExpression(stmt.Condition, true, false)
 	if err != nil {
 		return value.Null, NONE, errors.WithStack(err)
 	}
@@ -531,7 +542,7 @@ func (i *Interpreter) ProcessIfStatement(
 		if ds != DebugStepOut {
 			ds = i.Debugger.Run(ei)
 		}
-		cond, err := i.ProcessExpression(ei.Condition, true)
+		cond, err := i.ProcessExpression(ei.Condition, true, false)
 		if err != nil {
 			return value.Null, NONE, errors.WithStack(err)
 		}
@@ -610,7 +621,7 @@ func (i *Interpreter) ProcessSwitchStatement(
 			))
 		}
 	}
-	expr, err := i.ProcessExpression(stmt.Control, false)
+	expr, err := i.ProcessExpression(stmt.Control, false, false)
 	if err != nil {
 		return value.Null, NONE, errors.WithStack(err)
 	}
@@ -668,7 +679,7 @@ func (i *Interpreter) ProcessCaseStatement(
 	if stmt.Default == offset || isFallthrough {
 		matched = true
 	} else {
-		right, err := i.ProcessExpression(stmt.Cases[offset].Test.Right, false)
+		right, err := i.ProcessExpression(stmt.Cases[offset].Test.Right, false, false)
 		if err != nil {
 			return value.Null, NONE, false, err
 		}

--- a/interpreter/subroutine.go
+++ b/interpreter/subroutine.go
@@ -192,7 +192,7 @@ func (i *Interpreter) ProcessFunctionSubroutine(sub *ast.SubroutineDeclaration, 
 }
 
 func (i *Interpreter) ProcessExpressionReturnStatement(stmt *ast.ReturnStatement) (value.Value, State, error) {
-	val, err := i.ProcessExpression(*stmt.ReturnExpression, false)
+	val, err := i.ProcessExpression(*stmt.ReturnExpression, false, false)
 	if err != nil {
 		return value.Null, NONE, errors.WithStack(err)
 	}

--- a/interpreter/value/lenient_string.go
+++ b/interpreter/value/lenient_string.go
@@ -15,9 +15,6 @@ type LenientString struct {
 
 // Typically String() method creates string with treating NotSet string as "(null)"
 func (v *LenientString) String() string {
-	if v.IsNotSet {
-		return NullString
-	}
 	var ret string
 	for i := range v.Values {
 		if s, ok := v.Values[i].(*String); ok {

--- a/interpreter/value/value.go
+++ b/interpreter/value/value.go
@@ -53,6 +53,7 @@ func (v *null) IsLiteral() bool { return false }
 func (v *null) Copy() Value     { return v }
 
 var Null = &null{}
+var NullStringValue = &String{Value: "(null)"}
 
 type Ident struct {
 	Value   string

--- a/tester/function/testing_functions.go
+++ b/tester/function/testing_functions.go
@@ -527,7 +527,7 @@ func unwrapIdentArguments(ip *interpreter.Interpreter, args []value.Value) ([]va
 			continue
 		}
 		ident := value.Unwrap[*value.Ident](args[i])
-		v, err := ip.IdentValue(ident.Value, false)
+		v, err := ip.IdentValue(ident.Value, false, false)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}


### PR DESCRIPTION
Rebase of the ProcessExpression based not_set expansion solution onto the #248 branch.

Setting this as a draft because I had to make a change to the LenientString to make the changes needed for the expression handling work correctly. With that change it largely removes half of the utility of the type which reinforces my feeling that the new type really isn't needed.