### PR TITLE
Fixed parsing of += operator

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -209,6 +209,7 @@ func (l *Lexer) NextToken() token.Token {
 		if l.peekChar() == '=' {
 			l.readChar()
 			t = newToken(token.ADDITION, l.char, line, index)
+			t.Literal = "+="
 		} else {
 			// NOTE: The "+" character is not used for arithmetic operator in VCL,
 			// just use for explicit string concatenation.

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -250,7 +250,7 @@ sub vcl_recv {
 
 		{Type: token.SET, Literal: "set"},
 		{Type: token.IDENT, Literal: "var.foo"},
-		{Type: token.ADDITION, Literal: "="},
+		{Type: token.ADDITION, Literal: "+="},
 		{Type: token.INT, Literal: "1"},
 		{Type: token.SEMICOLON, Literal: ";"},
 		{Type: token.LF, Literal: "\n"},


### PR DESCRIPTION
As it turns out "+=" operator in **set** statement is parsed to "=" as a result corresponding
code is also misinterpreted as simple assignment:
```varnish-vcl
  declare local var.number INTEGER; 
  set var.number = 3;
  set var.number += 2;
```
results in var.number value equal to 2 rather then 5