### PR TITLE
Header field / subfield rework experiment

### DIFF
--- a/interpreter/function/builtin/subfield.go
+++ b/interpreter/function/builtin/subfield.go
@@ -3,11 +3,10 @@
 package builtin
 
 import (
-	"strings"
-
 	"github.com/ysugimoto/falco/interpreter/context"
 	"github.com/ysugimoto/falco/interpreter/function/errors"
 	"github.com/ysugimoto/falco/interpreter/value"
+	"github.com/ysugimoto/falco/interpreter/variable"
 )
 
 const Subfield_Name = "subfield"
@@ -49,15 +48,5 @@ func Subfield(ctx *context.Context, args ...value.Value) (value.Value, error) {
 		}
 	}
 
-	for _, v := range strings.Split(subject, separator) {
-		kv := strings.SplitN(v, "=", 2)
-		if kv[0] != field {
-			continue
-		}
-		if len(kv) > 1 {
-			return &value.String{Value: kv[1]}, nil
-		}
-		return &value.String{Value: ""}, nil
-	}
-	return &value.String{Value: ""}, nil
+	return variable.GetField(subject, field, separator), nil
 }

--- a/interpreter/function/builtin/subfield_test.go
+++ b/interpreter/function/builtin/subfield_test.go
@@ -25,6 +25,8 @@ func Test_Subfield(t *testing.T) {
 		{input: "foo=bar,lorem=ipsum", field: "foo", expect: "bar"},
 		{input: "foo=bar&lorem=ipsum", field: "foo", sep: "&", expect: "bar"},
 		{input: "foo=bar&lorem=ipsum", field: "foo", sep: "%", expect: "bar&lorem=ipsum"},
+		{input: `foo="bar,lorem=ipsum",fiz=buz`, field: "lorem", expect: `ipsum"`},
+		{input: `foo="bar,lorem=ipsum",fiz=buz`, field: "foo", expect: `bar,lorem=ipsum`},
 	}
 
 	for i, tt := range tests {

--- a/interpreter/value/value.go
+++ b/interpreter/value/value.go
@@ -37,6 +37,16 @@ func Unwrap[T ValueTypes](v Value) T {
 	return ret
 }
 
+func IsNotSet(val Value) bool {
+	switch v := val.(type) {
+	case *String:
+		return v.IsNotSet
+	case *IP:
+		return v.IsNotSet
+	}
+	return false
+}
+
 type Value interface {
 	Type() Type
 	String() string

--- a/interpreter/variable/field.go
+++ b/interpreter/variable/field.go
@@ -1,0 +1,104 @@
+package variable
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+// Pattern extrapolated from Fastly behavior.
+const pattern = `(?i)(?:^|%s)\s*%s(?:(?:\s+)?=(?:\s+)?((?:(?:"(?:(?:\\")|[^"])+)?")|(?:(?:[^%s\s]+)?)))?(?:%s|$|\s+)`
+
+// Escape and inject key / separator into pattern.
+func compilePattern(key, sep string) (*regexp.Regexp, error) {
+	if sep == "" {
+		sep = ","
+	}
+	sep = regexp.QuoteMeta(sep)
+	re, err := regexp.Compile(fmt.Sprintf(pattern, sep, regexp.QuoteMeta(key), sep, sep))
+	return re, err
+}
+
+// Extract field value from the provided string.
+func GetField(subject, key, sep string) *value.String {
+	re, err := compilePattern(key, sep)
+	if err != nil {
+		return &value.String{IsNotSet: true}
+	}
+
+	match := re.FindStringSubmatch(subject)
+	if len(match) == 0 {
+		return &value.String{IsNotSet: true}
+	}
+	val := match[1]
+
+	// Due to fastly behavior with header values that do not conform to RFC-8941
+	// we don't always want to strip quotes.
+	if strings.HasPrefix(val, "\"") {
+		val = strings.Trim(val, "\"")
+	}
+	return &value.String{Value: val}
+}
+
+// Remove field key from the provided string.
+func unsetField(subject, key, sep string) string {
+	if sep == "" {
+		sep = ","
+	}
+	re, err := compilePattern(key, sep)
+	if err != nil {
+		return subject
+	}
+
+	loc := re.FindStringIndex(subject)
+	if len(loc) == 0 {
+		return subject
+	} else if loc[0] == 0 { // found at the beginning of the header drop trailing separator
+		return subject[loc[1]:]
+	} else if string(subject[loc[1]-1]) == sep { // found in the middle drop trailing separator
+		return subject[:loc[0]] + subject[loc[1]-1:]
+	}
+	// found at the end drop leading separator
+	return subject[:loc[0]]
+}
+
+// Set field key in the provided string.
+func setField(subject, key string, val value.Value, sep string) string {
+	if sep == "" {
+		sep = ","
+	}
+	// When setting a field fastly will look for the first matching key in the
+	// string and remove it. The new value is then added at the end.
+	// NOTE: If there is more than one matching field key only the first one
+	// is removed.
+	subject = unsetField(subject, key, sep)
+	var kv string
+
+	if value.IsNotSet(val) {
+		// Fastly has a bug with how it handles setting a field on an unset
+		// header. If the field key length is 1 the field is not set, however
+		// for keys of length >1 it sets the key with no value.
+		if subject == "" && len(key) == 1 {
+			return subject
+		}
+		kv = key
+	} else {
+		sVal := val.String()
+		// Double quotes are added for values containing whitespace or any of
+		// these characters.
+		// = @ ( ) [ ] { } ? / \\ ; : ' < > ,
+		if regexp.MustCompile(`[\s=@()\[\]{}?/\\;:'<>,]`).MatchString(sVal) {
+			escaped := strings.Replace(sVal, `"`, `\"`, -1)
+			// Fastly truncates values at newlines after quoting the value.
+			sVal, _, _ = strings.Cut(`"`+escaped+`"`, "\n")
+		}
+		kv = fmt.Sprintf("%s=%s", key, sVal)
+	}
+
+	if subject == "" {
+		return kv
+	}
+	return subject + sep + kv
+}

--- a/interpreter/variable/field_test.go
+++ b/interpreter/variable/field_test.go
@@ -1,0 +1,130 @@
+package variable
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+func TestGetField(t *testing.T) {
+	tests := []struct {
+		input  string
+		field  string
+		sep    string
+		expect string
+		notSet bool
+	}{
+		{input: "", field: "a", notSet: true},
+		{input: "a=1", field: "a", expect: "1"},
+		{input: "a=(1 2)", field: "a", expect: "(1"},
+		{input: "a=(1)", field: "a", expect: "(1)"},
+		{input: "a=1,b=2", field: "a", expect: "1"},
+		{input: "a=1,b=2", field: "b", expect: "2"},
+		{input: "a=1 ,  b=2", field: "a", expect: "1"},
+		{input: "a=1 ,  b=2", field: "b", expect: "2"},
+		{input: "a=1	,	b=2", field: "a", expect: "1"},
+		{input: "a=1	,	b=2", field: "b", expect: "2"},
+		{input: "     a=1 ,  b=2", field: "a", expect: "1"},
+		{input: "     a=1 ,  b=2", field: "b", expect: "2"},
+		{input: "a=1, b= 2", field: "a", expect: "1"},
+		{input: "a=1, b= 2", field: "b", expect: "2"},
+		{input: "a=1\nb=2", field: "a", expect: "1"},
+		{input: "a=1\nb=2", field: "b", notSet: true},
+		{input: "a=1, b, c=3", field: "a", expect: "1"},
+		{input: "a=1, b, c=3", field: "b", expect: ""},
+		{input: "a=1, b, c=3", field: "c", expect: "3"},
+		{input: "a, b, c", field: "a", expect: ""},
+		{input: "a, b, c", field: "a", expect: ""},
+		{input: "a, b, c", field: "a", expect: ""},
+		{input: "a, b=2", field: "a", expect: ""},
+		{input: "a, b=2", field: "b", expect: "2"},
+		{input: "a=1, b", field: "a", expect: "1"},
+		{input: "a=1, b", field: "b", expect: ""},
+		{input: "a=1, b;foo=9, c=3", field: "a", expect: "1"},
+		{input: "a=1, b;foo=9, c=3", field: "b", notSet: true},
+		{input: "a=1, b;foo=9, c=3", field: "c", expect: "3"},
+		{input: "a=1, b=?1;foo=9, c=3", field: "a", expect: "1"},
+		{input: "a=1, b=?1;foo=9, c=3", field: "b", expect: "?1;foo=9"},
+		{input: "a=1, b=?1;foo=9, c=3", field: "c", expect: "3"},
+		{input: "a=1, b=2,", field: "a", expect: "1"},
+		{input: "a=1, b=2,", field: "b", expect: "2"},
+		{input: "a=1,,b=2,", field: "a", expect: "1"},
+		{input: "a=1,,b=2,", field: "b", expect: "2"},
+		{input: "a=1,b=2,a=3", field: "a", expect: "1"},
+		{input: "a=1,b=2,a=3", field: "b", expect: "2"},
+		{input: "a=1,1b=2,a=1", field: "a", expect: "1"},
+		{input: "a=1,1b=2,a=1", field: "1b", expect: "2"},
+		{input: "a=1,B=2,a=1", field: "a", expect: "1"},
+		{input: "a=1,B=2,a=1", field: "b", expect: "2"},
+		{input: "a=1,B=2,a=1", field: "B", expect: "2"},
+		{input: "a=1,b!=2,a=1", field: "a", expect: "1"},
+		{input: "a=1,b!=2,a=1", field: "b", notSet: true},
+		{input: `a=1,b="a,c=asdf",d=asdf`, field: "a", expect: "1"},
+		{input: `a=1,b="a,c=asdf",d=asdf`, field: "b", expect: "a,c=asdf"},
+		{input: `a=1,b="a,c=asdf",d=asdf`, field: "c", expect: `asdf"`},
+		{input: `a=1,b="a,c=asdf",d=asdf`, field: "d", expect: "asdf"},
+		{input: `a=c\,adf,b=asdf`, field: "a", expect: `c\`},
+		{input: `a=c\,adf,b=asdf`, field: "c", notSet: true},
+		{input: `a=c\,adf,b=asdf`, field: "adf", expect: ""},
+		{input: `a=c\,adf,b=asdf`, field: "b", expect: "asdf"},
+	}
+
+	for i, tt := range tests {
+		ret := GetField(tt.input, tt.field, tt.sep)
+		if diff := cmp.Diff(&value.String{Value: tt.expect, IsNotSet: tt.notSet}, ret); diff != "" {
+			t.Errorf("[%d] Return value unmatch, diff=%s", i, diff)
+		}
+	}
+}
+
+func TestUnsetField(t *testing.T) {
+	tests := []struct {
+		input  string
+		field  string
+		sep    string
+		expect string
+	}{
+		{input: "a=1", field: "a", expect: ""},
+		{input: "a", field: "a", expect: ""},
+		{input: "a=1,b=2,c=3", field: "a", expect: "b=2,c=3"},
+		{input: "a=1,b=2,c=3", field: "b", expect: "a=1,c=3"},
+		{input: "a=1,b=2,c=3", field: "c", expect: "a=1,b=2"},
+		{input: `a="b,c=2",d=3`, field: "c", expect: `a="b,d=3`},
+	}
+
+	for i, tt := range tests {
+		ret := unsetField(tt.input, tt.field, tt.sep)
+		if diff := cmp.Diff(tt.expect, ret); diff != "" {
+			t.Errorf("[%d] Return value unmatch, diff=%s", i, diff)
+			return
+		}
+	}
+}
+
+func TestSetField(t *testing.T) {
+	tests := []struct {
+		input  string
+		field  string
+		value  string
+		sep    string
+		expect string
+	}{
+		{input: "a=1", field: "a", value: "2", expect: "a=2"},
+		{input: "a=1,b=2,c=3", field: "a", value: "4", expect: "b=2,c=3,a=4"},
+		{input: "a=1,b=2,c=3", field: "b", value: "4", expect: "a=1,c=3,b=4"},
+		{input: "a=1,b=2,c=3", field: "c", value: "4", expect: "a=1,b=2,c=4"},
+		{input: "a=1,a=2,a=3", field: "a", value: "4", expect: "a=2,a=3,a=4"},
+		{input: "a,b=2,c=3", field: "a", value: "4", expect: "b=2,c=3,a=4"},
+		{input: "", field: "a", value: " ", expect: `a=" "`},
+		{input: `a="b,c=2",d=3`, field: "c", value: "4", expect: `a="b,d=3,c=4`},
+	}
+
+	for i, tt := range tests {
+		ret := setField(tt.input, tt.field, &value.String{Value: tt.value}, tt.sep)
+		if diff := cmp.Diff(tt.expect, ret); diff != "" {
+			t.Errorf("[%d] Return value unmatch, diff=%s", i, diff)
+			return
+		}
+	}
+}


### PR DESCRIPTION
Creating this draft PR to make discussion about different approaches to handling header fields easier.

Using the current approach, and in the proposed changes in #248, we have of storing fields in a structured format is challenging to achieve compatibility with unusual behavior of Fastly's RFC-8941 header dictionary implementation.

This PRs implementation takes the approach of extracting the field being operated on at the time of access using the observed behavior of Fastly's implementation.

With this approach edge cases in how fastly handles things can be correctly supported for example dealing with fields that contain the field separator.

```vcl
set req.http.foo:a = "1,b=2";
log req.http.foo:a; // -> 1,b=2
log req.http.foo:b; // -> 2"
```

The regular expression used in this is admittedly quite opaque and was derived through trial and error based on observing Fastly behavior in as many cases as I could come up with. This same general approach could be achieved with an iterative parser which would be easier to follow what is happening but would be considerably more code. For a proof of concept the regex solution seemed like the best path.

Additionally the `subfield` built-in function shares the field access behavior of the `:` operator. Updated that function to share the same implementation.

This implementation was validated against Fastly's behavior using this suite of tests:
https://github.com/richardmarshall/falco-validation-tests/blob/main/header_fields/main.test.vcl