### PR TITLE
keepalive_time added to supported backend properties

### DIFF
--- a/linter/helper.go
+++ b/linter/helper.go
@@ -27,6 +27,7 @@ var BackendPropertyTypes = map[string]types.Type{
 	"between_bytes_timeout":    types.RTimeType,
 	"connect_timeout":          types.RTimeType,
 	"first_byte_timeout":       types.RTimeType,
+	"keepalive_time":           types.RTimeType,
 	"max_connections":          types.IntegerType,
 	"host_header":              types.StringType,
 	"always_use_host_header":   types.BoolType,

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -104,9 +104,29 @@ func TestLintBackendStatement(t *testing.T) {
 		input := `
 backend foo {
   .host = "example.com";
-
+  .host_header = "example.com";
+  .always_use_host_header = true;
+  .keepalive_time = 30s;
+  .connect_timeout = 1s;
+  .dynamic = true;
+  .port = "443";
+  .first_byte_timeout = 20s;
+  .max_connections = 500;
+  .between_bytes_timeout = 20s;
+  .share_key = "xei5lohleex3Joh5ie5uy7du";
+  .ssl = true;
+  .ssl_sni_hostname = "httpbin.org";
+  .ssl_cert_hostname = "httpbin.org";
+  .ssl_check_cert = always;
+  .min_tls_version = "1.2";
+  .max_tls_version = "1.2";
   .probe = {
+    .dummy = false;
+    .initial = 5;
     .request = "GET / HTTP/1.1";
+    .threshold = 1;
+    .timeout = 2s;
+    .window = 4; 
   }
 }`
 		assertNoError(t, input)


### PR DESCRIPTION
I don't see this property documented but support for it was added about a year ago:
https://www.fastly.com/documentation/reference/changes/2023/02/keepaplive-time-is-seconds/
I also added this one as well as other valid properties to backend statement 'pass' test.