### PR TITLE
improve trailing/infix comment parsing

### DIFF
--- a/ast/comment.go
+++ b/ast/comment.go
@@ -10,6 +10,20 @@ import (
 type Comment struct {
 	Token token.Token
 	Value string
+	// PrefixedLineFeed represents the previous token of this comment is token.LF.
+	// For example:
+	//
+	// ...some statements...
+	// } // comment with PrefixedLineFeed: false
+	// ----
+	// ...some statements ...
+	// }
+	// // comment with PrefixedLineFeed: true
+	// This flag is used for parsing trailing comment,
+	// If this flag is false, it should be treated as trailing comment
+	// because the comment presents on the same line.
+	// Otherwise, this flag is true, it should be the leading comment for a next token.
+	PrefixedLineFeed bool
 }
 
 func (c *Comment) String() string {

--- a/parser/declaration_parser.go
+++ b/parser/declaration_parser.go
@@ -440,7 +440,6 @@ func (p *Parser) parseSubroutineDeclaration() (*ast.SubroutineDeclaration, error
 	if !p.expectPeek(token.LEFT_BRACE) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "LEFT_BRACE"))
 	}
-	swapLeadingTrailing(p.curToken, s.Name.Meta)
 
 	var err error
 	if s.Block, err = p.parseBlockStatement(); err != nil {
@@ -464,7 +463,6 @@ func (p *Parser) parsePenaltyboxDeclaration() (*ast.PenaltyboxDeclaration, error
 	if !p.expectPeek(token.LEFT_BRACE) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "LEFT_BRACE"))
 	}
-	swapLeadingTrailing(p.curToken, pb.Name.Meta)
 
 	var err error
 	if pb.Block, err = p.parseBlockStatement(); err != nil {
@@ -487,7 +485,6 @@ func (p *Parser) parseRatecounterDeclaration() (*ast.RatecounterDeclaration, err
 	if !p.expectPeek(token.LEFT_BRACE) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "LEFT_BRACE"))
 	}
-	swapLeadingTrailing(p.curToken, r.Name.Meta)
 
 	var err error
 	if r.Block, err = p.parseBlockStatement(); err != nil {

--- a/parser/declaration_parser.go
+++ b/parser/declaration_parser.go
@@ -30,11 +30,11 @@ func (p *Parser) parseAclDeclaration() (*ast.AclDeclaration, error) {
 			acl.CIDRs = append(acl.CIDRs, cidr)
 		}
 	}
-	acl.Meta.Trailing = p.trailing()
 	p.nextToken() // point to RIGHT BRACE
 
 	// RIGHT_BRACE leading comments are ACL infix comments
 	swapLeadingInfix(p.curToken, acl.Meta)
+	acl.Meta.Trailing = p.trailing()
 
 	return acl, nil
 }
@@ -76,8 +76,8 @@ func (p *Parser) parseAclCidr() (*ast.AclCidr, error) {
 	if !p.peekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	cidr.Meta.Trailing = p.trailing()
 	p.nextToken() // point to semicolon
+	cidr.Meta.Trailing = p.trailing()
 
 	return cidr, nil
 }
@@ -110,8 +110,8 @@ func (p *Parser) parseBackendDeclaration() (*ast.BackendDeclaration, error) {
 	}
 
 	swapLeadingInfix(p.peekToken, b.Meta)
-	b.Meta.Trailing = p.trailing()
 	p.nextToken()
+	b.Meta.Trailing = p.trailing()
 
 	return b, nil
 }
@@ -134,7 +134,6 @@ func (p *Parser) parseBackendProperty() (*ast.BackendProperty, error) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "ASSIGN"))
 	}
 	swapLeadingTrailing(p.curToken, prop.Key.Meta)
-
 	p.nextToken() // point to right token
 
 	// When current token is "{", property key should be ".probe"
@@ -151,9 +150,9 @@ func (p *Parser) parseBackendProperty() (*ast.BackendProperty, error) {
 			probe.Values = append(probe.Values, pp)
 		}
 
-		probe.Meta.Trailing = p.trailing()
 		p.nextToken() // point to RIGHT_BRACE
 		swapLeadingInfix(p.curToken, probe.Meta)
+		probe.Meta.Trailing = p.trailing()
 		prop.Value = probe
 		return prop, nil
 	}
@@ -168,8 +167,8 @@ func (p *Parser) parseBackendProperty() (*ast.BackendProperty, error) {
 	if !p.peekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	prop.Meta.Trailing = p.trailing()
 	p.nextToken() // point to SEMICOLON
+	prop.Meta.Trailing = p.trailing()
 
 	return prop, nil
 }
@@ -220,8 +219,8 @@ func (p *Parser) parseDirectorDeclaration() (*ast.DirectorDeclaration, error) {
 	}
 
 	swapLeadingInfix(p.peekToken, d.Meta)
-	d.Meta.Trailing = p.trailing()
 	p.nextToken() // point to RIGHT_BRACE
+	d.Meta.Trailing = p.trailing()
 
 	return d, nil
 }
@@ -253,8 +252,8 @@ func (p *Parser) parseDirectorProperty() (ast.Expression, error) {
 	if !p.peekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	prop.Meta.Trailing = p.trailing()
 	p.nextToken() // point to SEMICOLON
+	prop.Meta.Trailing = p.trailing()
 
 	return prop, nil
 }
@@ -302,8 +301,8 @@ func (p *Parser) parseDirectorBackend() (ast.Expression, error) {
 	}
 
 	swapLeadingInfix(p.peekToken, backend.Meta)
-	backend.Meta.Trailing = p.trailing()
 	p.nextToken() // point to RIGHT_BRACE
+	backend.Meta.Trailing = p.trailing()
 
 	return backend, nil
 }
@@ -344,8 +343,8 @@ func (p *Parser) parseTableDeclaration() (*ast.TableDeclaration, error) {
 	}
 
 	swapLeadingInfix(p.peekToken, t.Meta)
-	t.Meta.Trailing = p.trailing()
 	p.nextToken() // point to RIGHT_BRACE
+	t.Meta.Trailing = p.trailing()
 
 	return t, nil
 }
@@ -403,9 +402,9 @@ func (p *Parser) parseTableProperty() (*ast.TableProperty, error) {
 	switch p.peekToken.Token.Type {
 	case token.COMMA:
 		// usual case, user should add trailing comma for east properties :)
-		prop.Meta.Trailing = p.trailing()
 		prop.HasComma = true
 		p.nextToken() // point to COMMA
+		prop.Meta.Trailing = p.trailing()
 	case token.RIGHT_BRACE:
 		// if peed token is RIGHT_BRACE, it means table declaration end. if also be valid
 		// Note that in this case, we could not parse trailing comment. it is parsed as declaration infix comment.

--- a/parser/declaration_parser_test.go
+++ b/parser/declaration_parser_test.go
@@ -17,7 +17,7 @@ acl internal {
 	!"192.168.0.3";
 	!"192.168.0.4"/32;
 	// Leading comment
-	"192.168.0.5"; // Trailing comment
+	"192.168.0.5"; // CIDR Trailing comment
 	// Infix comment
 } // Trailing comment
 `
@@ -75,7 +75,7 @@ acl internal {
 						},
 					},
 					{
-						Meta: ast.New(T, 1, comments("// Leading comment"), comments("// Trailing comment")),
+						Meta: ast.New(T, 1, comments("// Leading comment"), comments("// CIDR Trailing comment")),
 						IP: &ast.IP{
 							Meta:  ast.New(token.Token{}, 1),
 							Value: "192.168.0.5",
@@ -93,26 +93,28 @@ acl internal {
 }
 
 func TestParseBackend(t *testing.T) {
-	input := `// Leading comment
+	input := `// Backend Leading comment
 backend example {
-	// Leading comment
-	.host = "example.com"; // Trailing comment
+	// Host Leading comment
+	.host = "example.com"; // Host Trailing comment
 	.probe = {
-		// Leading comment
-		.request = "GET / HTTP/1.1"; // Trailing comment
-	}
-}`
+		// Request Leading comment
+		.request = "GET / HTTP/1.1"; // Request Trailing comment
+		// Probe Infix comment
+	} // Probe Trailing comment
+	// Backend Infix comment
+} // Backend Trailing comment`
 	expect := &ast.VCL{
 		Statements: []ast.Statement{
 			&ast.BackendDeclaration{
-				Meta: ast.New(T, 0, comments("// Leading comment")),
+				Meta: ast.New(T, 0, comments("// Backend Leading comment"), comments("// Backend Trailing comment"), comments("// Backend Infix comment")),
 				Name: &ast.Ident{
 					Meta:  ast.New(T, 0),
 					Value: "example",
 				},
 				Properties: []*ast.BackendProperty{
 					{
-						Meta: ast.New(T, 1, comments("// Leading comment"), comments("// Trailing comment")),
+						Meta: ast.New(T, 1, comments("// Host Leading comment"), comments("// Host Trailing comment")),
 						Key: &ast.Ident{
 							Meta:  ast.New(T, 1),
 							Value: "host",
@@ -129,10 +131,10 @@ backend example {
 							Value: "probe",
 						},
 						Value: &ast.BackendProbeObject{
-							Meta: ast.New(T, 2),
+							Meta: ast.New(T, 2, ast.Comments{}, comments("// Probe Trailing comment"), comments("// Probe Infix comment")),
 							Values: []*ast.BackendProperty{
 								{
-									Meta: ast.New(T, 2, comments("// Leading comment"), comments("// Trailing comment")),
+									Meta: ast.New(T, 2, comments("// Request Leading comment"), comments("// Request Trailing comment")),
 									Key: &ast.Ident{
 										Meta:  ast.New(T, 2),
 										Value: "request",
@@ -158,19 +160,20 @@ backend example {
 
 func TestParseTable(t *testing.T) {
 	t.Run("with comma strictly", func(t *testing.T) {
-		input := `// Table definition
+		input := `// Table Leading comment
 table tbl {
 	"foo": "bar",
-	// Leading comment
-	"lorem": "ipsum", // Trailing comment
-	// Leading comment
-	"dolor": "sit", // Trailing comment
-}`
+	// Prop Leading comment
+	"lorem": "ipsum", // Prop Trailing comment
+	// Prop2 Leading comment
+	"dolor": "sit", // Prop2 Trailing comment
+	// Table Infix comment
+} // Table Trailing comment`
 
 		expect := &ast.VCL{
 			Statements: []ast.Statement{
 				&ast.TableDeclaration{
-					Meta: ast.New(T, 0, comments("// Table definition")),
+					Meta: ast.New(T, 0, comments("// Table Leading comment"), comments("// Table Trailing comment"), comments("// Table Infix comment")),
 					Name: &ast.Ident{
 						Meta:  ast.New(T, 0),
 						Value: "tbl",
@@ -189,7 +192,7 @@ table tbl {
 							HasComma: true,
 						},
 						{
-							Meta: ast.New(T, 1, comments("// Leading comment"), comments("// Trailing comment")),
+							Meta: ast.New(T, 1, comments("// Prop Leading comment"), comments("// Prop Trailing comment")),
 							Key: &ast.String{
 								Meta:  ast.New(T, 1),
 								Value: "lorem",
@@ -201,7 +204,7 @@ table tbl {
 							HasComma: true,
 						},
 						{
-							Meta: ast.New(T, 1, comments("// Leading comment"), comments("// Trailing comment")),
+							Meta: ast.New(T, 1, comments("// Prop2 Leading comment"), comments("// Prop2 Trailing comment")),
 							Key: &ast.String{
 								Meta:  ast.New(T, 1),
 								Value: "dolor",
@@ -224,19 +227,20 @@ table tbl {
 	})
 
 	t.Run("without comma", func(t *testing.T) {
-		input := `// Table definition
+		input := `// Table Leading comment
 table tbl {
  	"foo": "bar",
- 	// Leading comment
- 	"lorem": "ipsum", // Trailing comment
- 	// Leading comment
- 	"dolor": "sit" // Trailing comment
-}`
+ 	// Prop Leading comment
+ 	"lorem": "ipsum", // Prop Trailing comment
+ 	// Prop2 Leading comment
+ 	"dolor": "sit" // Prop2 Trailing comment
+	// Table Infix comment
+} // Table Trailing comment`
 
 		expect := &ast.VCL{
 			Statements: []ast.Statement{
 				&ast.TableDeclaration{
-					Meta: ast.New(T, 0, comments("// Table definition"), comments(), comments("// Trailing comment")),
+					Meta: ast.New(T, 0, comments("// Table Leading comment"), comments("// Table Trailing comment"), comments("// Table Infix comment")),
 					Name: &ast.Ident{
 						Meta:  ast.New(T, 0),
 						Value: "tbl",
@@ -255,7 +259,7 @@ table tbl {
 							HasComma: true,
 						},
 						{
-							Meta: ast.New(T, 1, comments("// Leading comment"), comments("// Trailing comment")),
+							Meta: ast.New(T, 1, comments("// Prop Leading comment"), comments("// Prop Trailing comment")),
 							Key: &ast.String{
 								Meta:  ast.New(T, 1),
 								Value: "lorem",
@@ -267,7 +271,7 @@ table tbl {
 							HasComma: true,
 						},
 						{
-							Meta: ast.New(T, 1, comments("// Leading comment"), comments("// Trailing comment")),
+							Meta: ast.New(T, 1, comments("// Prop2 Leading comment"), comments("// Prop2 Trailing comment")),
 							Key: &ast.String{
 								Meta:  ast.New(T, 1),
 								Value: "dolor",
@@ -289,14 +293,15 @@ table tbl {
 	})
 
 	t.Run("empty table", func(t *testing.T) {
-		input := `// Table definition
+		input := `// Table Leading comment
 table tbl {
-}`
+	// Table Infix comment
+} // Table Trailing comment`
 
 		expect := &ast.VCL{
 			Statements: []ast.Statement{
 				&ast.TableDeclaration{
-					Meta: ast.New(T, 0, comments("// Table definition")),
+					Meta: ast.New(T, 0, comments("// Table Leading comment"), comments("// Table Trailing comment"), comments("// Table Infix comment")),
 					Name: &ast.Ident{
 						Meta:  ast.New(T, 0),
 						Value: "tbl",
@@ -314,17 +319,18 @@ table tbl {
 }
 
 func TestParseDirector(t *testing.T) {
-	input := `// Director definition
+	input := `// Director Leading comment
 director example client {
-	// Leading comment
-	.quorum = 20%; // Trailing comment
-	// Leading comment
-	{ .backend = example; .weight = 1; } // Trailing comment
-}`
+	// Quorum Leading comment
+	.quorum = 20%; // Quorum Trailing comment
+	// Backend Leading comment
+	{ .backend = example; .weight = 1; } // Backend Trailing comment
+	// Director Infix comment
+} // Director Trailing comment`
 	expect := &ast.VCL{
 		Statements: []ast.Statement{
 			&ast.DirectorDeclaration{
-				Meta: ast.New(T, 0, comments("// Director definition")),
+				Meta: ast.New(T, 0, comments("// Director Leading comment"), comments("// Director Trailing comment"), comments("// Director Infix comment")),
 				Name: &ast.Ident{
 					Meta:  ast.New(T, 0),
 					Value: "example",
@@ -335,7 +341,7 @@ director example client {
 				},
 				Properties: []ast.Expression{
 					&ast.DirectorProperty{
-						Meta: ast.New(T, 1, comments("// Leading comment"), comments("// Trailing comment")),
+						Meta: ast.New(T, 1, comments("// Quorum Leading comment"), comments("// Quorum Trailing comment")),
 						Key: &ast.Ident{
 							Meta:  ast.New(T, 1),
 							Value: "quorum",
@@ -346,7 +352,7 @@ director example client {
 						},
 					},
 					&ast.DirectorBackendObject{
-						Meta: ast.New(T, 2, comments("// Leading comment"), comments("// Trailing comment")),
+						Meta: ast.New(T, 2, comments("// Backend Leading comment"), comments("// Backend Trailing comment")),
 						Values: []*ast.DirectorProperty{
 							{
 								Meta: ast.New(T, 2),
@@ -384,19 +390,20 @@ director example client {
 }
 
 func TestParsePenaltybox(t *testing.T) {
-	input := `// Penaltybox definition
-	penaltybox ip_pbox {
-} // Trailing comment`
+	input := `// Penaltybox Leading comment
+penaltybox ip_pbox {
+  // Penaltybox Infix comment
+} // Penaltybox Trailing comment`
 	expect := &ast.VCL{
 		Statements: []ast.Statement{
 			&ast.PenaltyboxDeclaration{
-				Meta: ast.New(T, 0, comments("// Penaltybox definition")),
+				Meta: ast.New(T, 0, comments("// Penaltybox Leading comment")),
 				Name: &ast.Ident{
 					Meta:  ast.New(T, 0),
 					Value: "ip_pbox",
 				},
 				Block: &ast.BlockStatement{
-					Meta:       ast.New(T, 1, ast.Comments{}, comments("// Trailing comment")),
+					Meta:       ast.New(T, 1, ast.Comments{}, comments("// Penaltybox Trailing comment"), comments("// Penaltybox Infix comment")),
 					Statements: []ast.Statement{},
 				},
 			},
@@ -410,19 +417,20 @@ func TestParsePenaltybox(t *testing.T) {
 }
 
 func TestParseRatecounter(t *testing.T) {
-	input := `// Ratecounter definition
-	ratecounter ip_ratecounter {
-} // Trailing comment`
+	input := `// Ratecounter Leading comment
+ratecounter ip_ratecounter {
+	// Ratecounter Infix comment
+} // Ratecounter Trailing comment`
 	expect := &ast.VCL{
 		Statements: []ast.Statement{
 			&ast.RatecounterDeclaration{
-				Meta: ast.New(T, 0, comments("// Ratecounter definition")),
+				Meta: ast.New(T, 0, comments("// Ratecounter Leading comment")),
 				Name: &ast.Ident{
 					Meta:  ast.New(T, 0),
 					Value: "ip_ratecounter",
 				},
 				Block: &ast.BlockStatement{
-					Meta:       ast.New(T, 1, ast.Comments{}, comments("// Trailing comment")),
+					Meta:       ast.New(T, 1, ast.Comments{}, comments("// Ratecounter Trailing comment"), comments("// Ratecounter Infix comment")),
 					Statements: []ast.Statement{},
 				},
 			},

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,8 +1,6 @@
 package parser
 
 import (
-	"strings"
-
 	"github.com/pkg/errors"
 	"github.com/ysugimoto/falco/ast"
 	"github.com/ysugimoto/falco/lexer"
@@ -79,15 +77,19 @@ func (p *Parser) nextToken() {
 
 func (p *Parser) readPeek() {
 	leading := ast.Comments{}
+	var prefixedLineFeed bool
+
 	for {
 		t := p.l.NextToken()
 		switch t.Type {
 		case token.LF:
+			prefixedLineFeed = true
 			continue
 		case token.COMMENT:
 			leading = append(leading, &ast.Comment{
-				Token: t,
-				Value: t.Literal,
+				Token:            t,
+				Value:            t.Literal,
+				PrefixedLineFeed: prefixedLineFeed,
 			})
 			continue
 		case token.LEFT_BRACE:
@@ -102,33 +104,18 @@ func (p *Parser) readPeek() {
 
 func (p *Parser) trailing() ast.Comments {
 	cs := ast.Comments{}
-	for {
-		// Analyze peek token
-		tok := p.l.PeekToken()
-		if tok.Type == token.LF {
-			break
-		}
-		if tok.Type == token.EOF {
-			if len(p.peekToken.LeadingComment()) > 0 {
-				cs = append(cs, &ast.Comment{
-					Token: tok,
-					Value: strings.TrimSpace(p.peekToken.LeadingComment()),
-				})
+	// Divide trailing comment for current node and leading comment for next node
+	if len(p.peekToken.Leading) > 0 {
+		updated := []*ast.Comment{}
+		for i, l := range p.peekToken.Leading {
+			if l.PrefixedLineFeed {
+				updated = p.peekToken.Leading[i:]
+				break
 			}
-			return cs
+			cs = append(cs, p.peekToken.Leading[i])
 		}
-		if tok.Type == token.COMMENT {
-			cs = append(cs, &ast.Comment{
-				Token: tok,
-				Value: tok.Literal,
-			})
-			// advance token
-			p.l.NextToken()
-			continue
-		}
-		break
+		p.peekToken.Leading = updated
 	}
-
 	return cs
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -196,7 +196,7 @@ sub vcl_recv {
 func TestAllCommentPositions(t *testing.T) {
 	input := `
 // subroutine leading
-sub /* subroutine ident leading */ vcl_recv {
+sub /* subroutine ident leading */ vcl_recv /* subroutine block leading */ {
 	// if leading
 	if (
 		req.http.Host &&
@@ -219,7 +219,7 @@ sub /* subroutine ident leading */ vcl_recv {
 					Value: "vcl_recv",
 				},
 				Block: &ast.BlockStatement{
-					Meta: ast.New(T, 1, ast.Comments{}, comments("// subroutine trailing"), comments("// subroutine block infix")),
+					Meta: ast.New(T, 1, comments("/* subroutine block leading */"), comments("// subroutine trailing"), comments("// subroutine block infix")),
 					Statements: []ast.Statement{
 						&ast.IfStatement{
 							Meta: ast.New(T, 1, comments("// if leading")),

--- a/parser/statement_parser.go
+++ b/parser/statement_parser.go
@@ -91,8 +91,8 @@ func (p *Parser) parseImportStatement() (*ast.ImportStatement, error) {
 	if !p.peekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	i.Meta.Trailing = p.trailing()
 	p.nextToken() // point to SEMICOLON
+	i.Meta.Trailing = p.trailing()
 
 	return i, nil
 }
@@ -106,13 +106,13 @@ func (p *Parser) parseIncludeStatement() (ast.Statement, error) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "STRING"))
 	}
 	i.Module = p.parseString()
-	i.Meta.Trailing = p.trailing()
 
 	// Semicolons are actually not required at the end of include lines
 	// either works on fastly.
 	if p.peekTokenIs(token.SEMICOLON) {
 		p.nextToken() // point to SEMICOLON
 	}
+	i.Meta.Trailing = p.trailing()
 
 	return i, nil
 }
@@ -138,8 +138,8 @@ func (p *Parser) parseBlockStatement() (*ast.BlockStatement, error) {
 		b.Statements = append(b.Statements, stmt)
 	}
 
-	b.Meta.Trailing = p.trailing()
 	p.nextToken() // point to RIGHT_BRACE
+	b.Meta.Trailing = p.trailing()
 
 	// RIGHT_BRACE leading comments are block infix comments
 	swapLeadingInfix(p.curToken, b.Meta)
@@ -178,8 +178,8 @@ func (p *Parser) parseSetStatement() (*ast.SetStatement, error) {
 	if !p.peekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	stmt.Meta.Trailing = p.trailing()
 	p.nextToken() // point to SEMICOLON
+	stmt.Meta.Trailing = p.trailing()
 
 	return stmt, nil
 }
@@ -197,8 +197,8 @@ func (p *Parser) parseUnsetStatement() (*ast.UnsetStatement, error) {
 	if !p.peekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	stmt.Meta.Trailing = p.trailing()
 	p.nextToken() // point to SEMICOLON
+	stmt.Meta.Trailing = p.trailing()
 
 	return stmt, nil
 }
@@ -216,8 +216,8 @@ func (p *Parser) parseRemoveStatement() (*ast.RemoveStatement, error) {
 	if !p.peekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	stmt.Meta.Trailing = p.trailing()
 	p.nextToken() // point to SEMICOLON
+	stmt.Meta.Trailing = p.trailing()
 
 	return stmt, nil
 }
@@ -253,8 +253,8 @@ func (p *Parser) parseAddStatement() (*ast.AddStatement, error) {
 	if !p.peekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	stmt.Meta.Trailing = p.trailing()
 	p.nextToken() // point to SEMICOLON
+	stmt.Meta.Trailing = p.trailing()
 
 	return stmt, nil
 }
@@ -282,8 +282,8 @@ func (p *Parser) parseCallStatement() (*ast.CallStatement, error) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
 
-	stmt.Meta.Trailing = p.trailing()
 	p.nextToken() // point to SEMICOLON
+	stmt.Meta.Trailing = p.trailing()
 
 	return stmt, nil
 }
@@ -314,8 +314,8 @@ func (p *Parser) parseDeclareStatement() (*ast.DeclareStatement, error) {
 	if !p.peekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	stmt.Meta.Trailing = p.trailing()
 	p.nextToken() // point to SEMICOLON
+	stmt.Meta.Trailing = p.trailing()
 
 	return stmt, nil
 }
@@ -361,8 +361,8 @@ func (p *Parser) parseErrorStatement() (*ast.ErrorStatement, error) {
 	if !p.peekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	stmt.Meta.Trailing = p.trailing()
 	p.nextToken() // point to SEMICOLON
+	stmt.Meta.Trailing = p.trailing()
 
 	return stmt, nil
 }
@@ -375,8 +375,8 @@ func (p *Parser) parseEsiStatement() (*ast.EsiStatement, error) {
 	if !p.peekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	stmt.Meta.Trailing = p.trailing()
 	p.nextToken() // point to SEMICOLON
+	stmt.Meta.Trailing = p.trailing()
 
 	return stmt, nil
 }
@@ -396,8 +396,8 @@ func (p *Parser) parseLogStatement() (*ast.LogStatement, error) {
 	if !p.peekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	stmt.Meta.Trailing = p.trailing()
 	p.nextToken() // point to SEMICOLON
+	stmt.Meta.Trailing = p.trailing()
 
 	return stmt, nil
 }
@@ -410,8 +410,8 @@ func (p *Parser) parseRestartStatement() (*ast.RestartStatement, error) {
 	if !p.peekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	stmt.Meta.Trailing = p.trailing()
 	p.nextToken() // point to SEMICOLON
+	stmt.Meta.Trailing = p.trailing()
 
 	return stmt, nil
 }
@@ -459,8 +459,8 @@ func (p *Parser) parseReturnStatement() (*ast.ReturnStatement, error) {
 	if !p.peekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	stmt.Meta.Trailing = p.trailing()
 	p.nextToken() // point to SEMICOLON
+	stmt.Meta.Trailing = p.trailing()
 
 	return stmt, nil
 }
@@ -480,8 +480,8 @@ func (p *Parser) parseSyntheticStatement() (*ast.SyntheticStatement, error) {
 	if !p.peekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	stmt.Meta.Trailing = p.trailing()
 	p.nextToken() // point to SEMICOLON
+	stmt.Meta.Trailing = p.trailing()
 
 	return stmt, nil
 }
@@ -501,8 +501,8 @@ func (p *Parser) parseSyntheticBase64Statement() (*ast.SyntheticBase64Statement,
 	if !p.peekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	stmt.Meta.Trailing = p.trailing()
 	p.nextToken() // point to SEMICOLON
+	stmt.Meta.Trailing = p.trailing()
 
 	return stmt, nil
 }
@@ -579,6 +579,7 @@ func (p *Parser) parseIfStatement() (*ast.IfStatement, error) {
 		goto FINISH
 	}
 FINISH:
+	stmt.Meta.Trailing = p.trailing()
 	return stmt, nil
 }
 
@@ -708,7 +709,7 @@ func (p *Parser) parseSwitchStatement() (*ast.SwitchStatement, error) {
 	}
 
 	p.nextToken()
-	swapLeadingTrailing(p.peekToken, stmt.Meta)
+	stmt.Meta.Trailing = p.trailing()
 	return stmt, nil
 }
 
@@ -720,8 +721,8 @@ func (p *Parser) parseBreakStatement() (*ast.BreakStatement, error) {
 	if !p.peekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	stmt.Meta.Trailing = p.trailing()
 	p.nextToken() // point to SEMICOLON
+	stmt.Meta.Trailing = p.trailing()
 
 	return stmt, nil
 }
@@ -734,8 +735,8 @@ func (p *Parser) parseFallthroughStatement() (*ast.FallthroughStatement, error) 
 	if !p.peekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	stmt.Meta.Trailing = p.trailing()
 	p.nextToken() // point to SEMICOLON
+	stmt.Meta.Trailing = p.trailing()
 
 	return stmt, nil
 }
@@ -816,8 +817,8 @@ func (p *Parser) parseGotoStatement() (*ast.GotoStatement, error) {
 	if !p.peekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	stmt.Meta.Trailing = p.trailing()
 	p.nextToken() // point to SEMICOLON
+	stmt.Meta.Trailing = p.trailing()
 
 	return stmt, nil
 }
@@ -853,8 +854,8 @@ func (p *Parser) parseFunctionCall() (*ast.FunctionCallStatement, error) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
 
-	stmt.Meta.Trailing = p.trailing()
 	p.nextToken() // point to SEMICOLON
+	stmt.Meta.Trailing = p.trailing()
 
 	return stmt, nil
 }

--- a/parser/statement_parser.go
+++ b/parser/statement_parser.go
@@ -546,11 +546,18 @@ func (p *Parser) parseIfStatement() (*ast.IfStatement, error) {
 
 			// If more peek token is IF, it should be "else if"
 			if p.peekTokenIs(token.IF) { // else if
+				// The leading comment of else if node is exists in "ELSE" token
+				// so store the comment before forward token
+				leading := p.curToken.Leading
+
 				p.nextToken() // point to IF
 				another, err := p.parseAnotherIfStatement()
 				if err != nil {
 					return nil, errors.WithStack(err)
 				}
+				// And restore the leading comments
+				another.Leading = leading
+
 				stmt.Another = append(stmt.Another, another)
 				continue
 			}

--- a/parser/statement_parser_test.go
+++ b/parser/statement_parser_test.go
@@ -789,6 +789,104 @@ sub vcl_recv {
 		}
 		assert(t, vcl, expect)
 	})
+
+	t.Run("Full comments", func(t *testing.T) {
+		input := `
+sub vcl_recv {
+	// If Leading comment
+	if (req.http.Host ~ "example.com") {
+		restart;
+		// If Infix comment
+	} // If Trailing comment
+	// Elsif Leading comment
+	elsif (req.http.X-Forwarded-For ~ "192.168.0.1") {
+		restart;
+		// Elsif Infix comment
+	}
+	// Else Leading comment
+	else {
+		restart;
+		// Else Infix comment
+	} // Else Trailing comment
+}`
+		expect := &ast.VCL{
+			Statements: []ast.Statement{
+				&ast.SubroutineDeclaration{
+					Meta: ast.New(T, 0),
+					Name: &ast.Ident{
+						Meta:  ast.New(T, 0),
+						Value: "vcl_recv",
+					},
+					Block: &ast.BlockStatement{
+						Meta: ast.New(T, 1),
+						Statements: []ast.Statement{
+							&ast.IfStatement{
+								Meta: ast.New(T, 1, comments("// If Leading comment")),
+								Condition: &ast.InfixExpression{
+									Meta: ast.New(T, 1),
+									Left: &ast.Ident{
+										Meta:  ast.New(T, 1),
+										Value: "req.http.Host",
+									},
+									Operator: "~",
+									Right: &ast.String{
+										Meta:  ast.New(T, 1),
+										Value: "example.com",
+									},
+								},
+								Consequence: &ast.BlockStatement{
+									Meta: ast.New(T, 2, ast.Comments{}, comments("// If Trailing comment"), comments("// If Infix comment")),
+									Statements: []ast.Statement{
+										&ast.RestartStatement{
+											Meta: ast.New(T, 2),
+										},
+									},
+								},
+								Another: []*ast.IfStatement{
+									{
+										Meta: ast.New(T, 1, comments("// Elsif Leading comment")),
+										Condition: &ast.InfixExpression{
+											Meta: ast.New(T, 1),
+											Left: &ast.Ident{
+												Meta:  ast.New(T, 1),
+												Value: "req.http.X-Forwarded-For",
+											},
+											Operator: "~",
+											Right: &ast.String{
+												Meta:  ast.New(T, 1),
+												Value: "192.168.0.1",
+											},
+										},
+										Consequence: &ast.BlockStatement{
+											Meta: ast.New(T, 2, ast.Comments{}, ast.Comments{}, comments("// Elsif Infix comment")),
+											Statements: []ast.Statement{
+												&ast.RestartStatement{
+													Meta: ast.New(T, 2),
+												},
+											},
+										},
+									},
+								},
+								Alternative: &ast.BlockStatement{
+									Meta: ast.New(T, 2, ast.Comments{}, comments("// Else Trailing comment"), comments("// Else Infix comment")),
+									Statements: []ast.Statement{
+										&ast.RestartStatement{
+											Meta: ast.New(T, 2),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		vcl, err := New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Errorf("%+v", err)
+		}
+		assert(t, vcl, expect)
+	})
 }
 
 func TestParseSwitchStatement(t *testing.T) {
@@ -1612,7 +1710,7 @@ sub vcl_recv {
 									Meta:     ast.New(T, 1),
 									Operator: "+",
 									Right: &ast.String{
-										Meta:  ast.New(T, 1),
+										Meta: ast.New(T, 1),
 										Value: "	timestamp:",
 									},
 									Left: &ast.InfixExpression{
@@ -1864,6 +1962,51 @@ sub vcl_recv {
 		}
 		assert(t, vcl, expect)
 	})
+
+	t.Run("nested blocks with comments", func(t *testing.T) {
+		input := `
+sub vcl_recv {
+	// Block Leading comment
+	{
+		log "vcl_recv";
+		// Block Infix comment
+	} // Block Trailing comment
+}`
+
+		expect := &ast.VCL{
+			Statements: []ast.Statement{
+				&ast.SubroutineDeclaration{
+					Meta: ast.New(T, 0),
+					Name: &ast.Ident{
+						Meta:  ast.New(T, 0),
+						Value: "vcl_recv",
+					},
+					Block: &ast.BlockStatement{
+						Meta: ast.New(T, 1),
+						Statements: []ast.Statement{
+							&ast.BlockStatement{
+								Meta: ast.New(T, 2, comments("// Block Leading comment"), comments("// Block Trailing comment"), comments("// Block Infix comment")),
+								Statements: []ast.Statement{
+									&ast.LogStatement{
+										Meta: ast.New(T, 2),
+										Value: &ast.String{
+											Meta:  ast.New(T, 2),
+											Value: "vcl_recv",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		vcl, err := New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Errorf("%+v", err)
+		}
+		assert(t, vcl, expect)
+	})
 }
 
 func TestGotoStatement(t *testing.T) {
@@ -1952,7 +2095,8 @@ func TestFunctionCallStatement(t *testing.T) {
 	t.Run("normal function call without arguments", func(t *testing.T) {
 		input := `
 sub vcl_recv {
-	testFun();
+	// Function Leading comment
+	testFun(); // Function Trailing comment
 }`
 
 		expect := &ast.VCL{
@@ -1967,9 +2111,9 @@ sub vcl_recv {
 						Meta: ast.New(T, 1),
 						Statements: []ast.Statement{
 							&ast.FunctionCallStatement{
-								Meta: ast.New(T, 1),
+								Meta: ast.New(T, 1, comments("// Function Leading comment"), comments("// Function Trailing comment")),
 								Function: &ast.Ident{
-									Meta:  ast.New(T, 1),
+									Meta:  ast.New(T, 1, comments("// Function Leading comment"), comments("// Function Trailing comment")),
 									Value: "testFun",
 								},
 								Arguments: []ast.Expression{},


### PR DESCRIPTION
This PR fixes a tiny bug about parsing comment tokens, particularly `InfixComment` and `TrailingComment`.
Please look at the following spec.

### Comment Parsing

From the VCL parsing spec, we always have the next token as `peekToken`, including the leading comment but the leading comment will have the InfixComment or Trailing Comment for the `currentToken`. This causes problems that:

```vcl
sub vcl_recv {
    set req.http.Foo = "bar";
    // this comment should be a InfixComment in BlockStatement of subroutine  - (1)
} // this comment should be a TrailingComment in BlockStatement of subroutine -(2)
// this comment should be a LeadingComment in the next token - (3)
```

The previous implementation had a problem in that (2) and (3) comments could not parse correctly because both comments have a leading comment in `peekToken`.

### Solving

I changed the comment parsing implementation by defining the `PrefixedLineFeed` property in `ast.Comment`, this property indicates that the previous token of comment had an `LF` or not, and by checking whether this property is true, we can complete distinguishing `TrailingCommang` and `LeadingComment`.


This implementation won't affect to main features like lint, and interpreter, just for comment treating but needed to implement formatted (now I'm working on it).