### PR TITLE
special dealing for req.hash addition assignment

### DIFF
--- a/interpreter/variable/hash.go
+++ b/interpreter/variable/hash.go
@@ -69,6 +69,14 @@ func (v *HashScopeVariables) Get(s context.Scope, name string) (value.Value, err
 
 func (v *HashScopeVariables) Set(s context.Scope, name, operator string, val value.Value) error {
 	if name == "req.hash" {
+		// Special string assignment - normally "+=" operator cannot use for STRING type,
+		// But the exception case that "+=" operation can use for the "req.hash".
+		// See: https://fiddle.fastly.dev/fiddle/0f3fc0aa
+		if val.Type() == value.StringType && operator == "+=" {
+			hash := value.Unwrap[*value.String](val)
+			v.ctx.RequestHash.Value += hash.Value
+			return nil
+		}
 		if err := doAssign(v.ctx.RequestHash, operator, val); err != nil {
 			return errors.WithStack(err)
 		}

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -1048,7 +1048,15 @@ func (l *Linter) lintSetStatement(stmt *ast.SetStatement, ctx *context.Context) 
 	// We investigated type comparison and summarized.
 	// See: https://docs.google.com/spreadsheets/d/16xRPugw9ubKA1nXHIc5ysVZKokLLhysI-jAu3qbOFJ8/edit#gid=0
 	switch stmt.Operator.Operator {
-	case "+=", "-=":
+	case "+=":
+		// Special string assignment - normally "+=" operator cannot use for STRING type,
+		// But the exception case that "+=" operation can use for the "req.hash".
+		// See: https://fiddle.fastly.dev/fiddle/0f3fc0aa
+		if stmt.Ident.Value == "req.hash" && right == types.StringType {
+			break
+		}
+		l.lintAddSubOperator(stmt.Operator, left, right, isLiteralExpression(stmt.Value))
+	case "-=":
 		l.lintAddSubOperator(stmt.Operator, left, right, isLiteralExpression(stmt.Value))
 	case "*=", "/=", "%=":
 		l.lintArithmeticOperator(stmt.Operator, left, right, isLiteralExpression(stmt.Value))


### PR DESCRIPTION
This PR fixes the edge case bug - normally `+=` operator cannot be used for STRING but can be used for `req.hash` predefined variable for adding request hash.

## Normal case (fail)

```vcl
sub vcl_recv {
  set req.http.Foo += "foo"; // error
}
```

## Edge case (should pass)

```vcl
sub vcl_hash {
  set req.hash += "foo"; // pass
}
```

## Reproduce

```vcl
// test.vcl
sub vcl_hash {
  set req.hash += req.url;
}
```

```
🔥 [ERROR] Operator "+=" cannot be used for STRING (operator/conditional)
in /Users/sugimoto/github/falco/cmd/falco/test.vcl at line 2, position 16
 1|sub vcl_hash {
 2|  set req.hash += req.url;
                  ^^
 3|}
See reference documentation: https://developer.fastly.com/reference/vcl/operators/#conditional-operators
```

Fastly fiddle: https://fiddle.fastly.dev/fiddle/0f3fc0aa
