### PR TITLE
Prioritize cache object

### DIFF
--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -579,26 +579,16 @@ func (i *Interpreter) ProcessError() error {
 	// @see: https://developer.fastly.com/reference/vcl/variables/client-response/resp-is-locally-generated/
 	i.ctx.IsLocallyGenerated = &value.Boolean{Value: true}
 
-	if i.ctx.Object == nil {
-		if i.ctx.BackendResponse != nil {
-			i.ctx.Object = i.cloneResponse(i.ctx.BackendResponse)
-			i.ctx.Object.StatusCode = int(i.ctx.ObjectStatus.Value)
-			i.ctx.Object.Body = io.NopCloser(strings.NewReader(i.ctx.ObjectResponse.Value))
-		} else {
-			i.ctx.Object = &http.Response{
-				StatusCode: int(i.ctx.ObjectStatus.Value),
-				Status:     http.StatusText(int(i.ctx.ObjectStatus.Value)),
-				Proto:      "HTTP/1.0",
-				ProtoMajor: 1,
-				ProtoMinor: 1,
-				Header: http.Header{
-					"Content-Type": {"text/plain"},
-				},
-				Body:          io.NopCloser(strings.NewReader(i.ctx.ObjectResponse.Value)),
-				ContentLength: int64(len(i.ctx.ObjectResponse.Value)),
-				Request:       i.ctx.Request,
-			}
-		}
+	i.ctx.Object = &http.Response{
+		StatusCode:    int(i.ctx.ObjectStatus.Value),
+		Status:        http.StatusText(int(i.ctx.ObjectStatus.Value)),
+		Proto:         "HTTP/1.0",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Header:        http.Header{},
+		Body:          io.NopCloser(strings.NewReader(i.ctx.ObjectResponse.Value)),
+		ContentLength: int64(len(i.ctx.ObjectResponse.Value)),
+		Request:       i.ctx.Request,
 	}
 
 	// Simulate Fastly statement lifecycle


### PR DESCRIPTION
Currently the setup of `i.ctx.Response` in `ProcessDeliver` is prioritizing `i.ctx.BackendResponse` if it is set. This causes a problem for requests that transition with this flow: `FETCH -> ERROR -> DELIVER`. The response setup in `vcl_error` is lost and the simulator incorrectly uses the backend response.

Additionally the deferred closure in `ProcessFetch` is setting `i.ctx.Response` to be the backend response. This does not impact VCL code in `vcl_deliver` like the previous issue but it does impact the simulator output as the correct response data is overwritten when ProcessFetch returns which occurs after the request handling is complete but before the `i.process.Finalize` is called.

While fixing those issues also discovered that when the simulator moves to the error state the obj value is not always setup to be an empty response. Values from the backend response or cache object will be included in the response which is incorrect as described here: https://www.fastly.com/documentation/reference/vcl/subroutines/error/.

Fixes #276 