### PR TITLE
fix exprression comment parsing

### DIFF
--- a/parser/expression_parser.go
+++ b/parser/expression_parser.go
@@ -73,12 +73,17 @@ func (p *Parser) parseExpression(precedence int) (ast.Expression, error) {
 		if !ok {
 			return left, nil
 		}
+		swapLeadingTrailing(p.peekToken, left.GetMeta())
 		p.nextToken()
 		left, err = infix(left)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
 		continue
+	}
+
+	if p.peekTokenIs(token.SEMICOLON) {
+		swapLeadingTrailing(p.peekToken, left.GetMeta())
 	}
 
 	return left, nil

--- a/parser/helper.go
+++ b/parser/helper.go
@@ -52,12 +52,12 @@ func isAssignmentOperator(t token.Token) bool {
 
 // Comment control helper
 func swapLeadingTrailing(from, to *ast.Meta) {
-	to.Trailing = from.Leading
+	to.Trailing = append(to.Trailing, from.Leading...)
 	from.Leading = ast.Comments{}
 }
 
 func swapLeadingInfix(from, to *ast.Meta) {
-	to.Infix = from.Leading
+	to.Infix = append(to.Infix, from.Leading...)
 	from.Leading = ast.Comments{}
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -204,7 +204,8 @@ sub /* subroutine ident leading */ vcl_recv /* subroutine block leading */ {
 		req.http.Foo == "bar"
 	) {
 		// set leading
-		set req.http.Host = "bar";
+		set req.http.Host = /* expression leading */ "bar" /* expression trailing */;
+		set req.http.Host = /* expression leading */ "bar" /* infix expression leading */ "baz" /* expression trailing */;
 	  // if infix
 	} // if trailing
 	// subroutine block infix
@@ -257,8 +258,31 @@ sub /* subroutine ident leading */ vcl_recv /* subroutine block leading */ {
 											Operator: "=",
 										},
 										Value: &ast.String{
-											Meta:  ast.New(T, 2),
+											Meta:  ast.New(T, 2, comments("/* expression leading */"), comments("/* expression trailing */")),
 											Value: "bar",
+										},
+									},
+									&ast.SetStatement{
+										Meta: ast.New(T, 2),
+										Ident: &ast.Ident{
+											Meta:  ast.New(T, 2),
+											Value: "req.http.Host",
+										},
+										Operator: &ast.Operator{
+											Meta:     ast.New(T, 2),
+											Operator: "=",
+										},
+										Value: &ast.InfixExpression{
+											Meta: ast.New(T, 2, ast.Comments{}, comments("/* expression trailing */")),
+											Left: &ast.String{
+												Meta:  ast.New(T, 2, comments("/* expression leading */"), comments("/* infix expression leading */")),
+												Value: "bar",
+											},
+											Operator: "+",
+											Right: &ast.String{
+												Meta:  ast.New(T, 2, ast.Comments{}, comments("/* expression trailing */")),
+												Value: "baz",
+											},
 										},
 									},
 								},


### PR DESCRIPTION
This PR fixes more comment parsing logic in `parser`.

## Problem 

We have a problem parsing inline comments on the last of a token (before the semicolon) in `InfixExpression`:

```vcl
set vcl_recv {
  set req.http.Foo = /* comment 1 */ "bar" /* comment 2 */ "baz" /* comment 3 */;
}
```

The current parser lacks `/* comment 3 */` in `InfixExpression`, so this PR fixes this.

## Plan to solve

I'm focusing on what the `/* comment 2 */` comment  should own where `Left` or `Right` expression, I thought that both expressions should have it in trailing comment in `Left`:

```vcl
set vcl_recv {
  set req.http.Foo = /* comment 1 */ "bar" /* comment 2 */ "baz" /* comment 3 */;
  // Left:           ^ leading comment     ^ trailing comment
  // Right:                                                      ^ trailing comment
}
```

The `InfixExpression` node may have some comments but they should be ignored for formatting because Left and Right expressions can represent all comments to be formatted.