### PR TITLE
Setup req.http.host in ProcessInit

### DIFF
--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -122,6 +122,7 @@ func (i *Interpreter) ProcessInit(r *http.Request) error {
 	ctx.RequestStartTime = time.Now()
 	i.ctx = ctx
 	i.ctx.Request = r
+	r.Header.Set("Host", r.Host)
 
 	// OriginalHost value may be overridden. If not empty, set the request value
 	if i.ctx.OriginalHost == "" {


### PR DESCRIPTION
Currently the value for `req.http.host` is not set when running the simulator.

For the following sample vcl
```vcl
sub vcl_recv {
  log "Host: " + req.http.host;
  error 200 "OK";
}
```

Make a request to the simulator with `Host` header set.
```shell
curl -H'Host: www.example.com' http://localhost:3124
```

Simulator log output shows that `req.http.host` is empty.
```shell                            
Simulator server starts on 0.0.0.0:3124
Request Incoming =========>
Host: 
Move state: RECV -> ERROR
Move state: ERROR -> DELIVER
Move state: DELIVER -> LOG
<========= Request finished
```