### PR TITLE
Record test runtime errors

### DIFF
--- a/tester/tester.go
+++ b/tester/tester.go
@@ -150,6 +150,9 @@ func (t *Tester) run(testFile string) (*TestResult, error) {
 					Scope: s.String(),
 					Time:  time.Since(start).Milliseconds(),
 				})
+				if err != nil {
+					t.counter.Fail()
+				}
 			}
 		}
 		finishChan <- cases


### PR DESCRIPTION
If a test results in a runtime error the exit status of `falco test` is still `0`. This is due to the fact that when testing functions return error values the Fails counter for the tests isn't incremented.

For example:

`main.vcl`:
```vcl
sub vcl_recv {
  log table.lookup(foo, "asdf", ""); // undefined table
}
```

`main.test.vcl`:
```vcl
sub test {
  testing.call_subroutine("vcl_recv");
}
```

Test is marked as failed but command does not include an error exit status:
```shell
$ falco test main.vcl
Running tests... Done.
 FAIL  ~/falco-validation-tests/test-runtime-errors/main.test.vcl
  ●  [RECV] test

    Undefined variable foo

    1| sub test {
    2|   testing.call_subroutine("vcl_recv");
    3| }

0 passed, 1 failed, 1 total, 0 assertions
$ echo $?
0
```

This causes problems for using `falco test` in CI situations and ensuring a failure of a test fails the build.