### PR TITLE
Errors with concurrent simulator requests due to global interpreter state

### DIFF
--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -24,6 +25,7 @@ import (
 type Interpreter struct {
 	vars      variable.Variable
 	localVars variable.LocalVariables
+	lock      sync.Mutex
 
 	options []context.Option
 

--- a/interpreter/variable/all.go
+++ b/interpreter/variable/all.go
@@ -2,21 +2,20 @@ package variable
 
 import (
 	"bytes"
+	"crypto/md5"
+	"crypto/sha256"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"math"
 	"net"
+	"net/http"
+	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
-
-	"crypto/md5"
-	"crypto/sha256"
-	"encoding/base64"
-	"net/http"
-	"net/url"
-	"path/filepath"
 
 	"github.com/avct/uasurfer"
 	"github.com/pkg/errors"
@@ -557,11 +556,11 @@ func (v *AllScopeVariables) Get(s context.Scope, name string) (value.Value, erro
 
 	// Fixed values
 	case SERVER_DATACENTER:
-		return &value.String{Value: "FALCO"}, nil
+		return &value.String{Value: FALCO_DATACENTER}, nil
 	case SERVER_HOSTNAME:
-		return &value.String{Value: "cache-localsimulator"}, nil
+		return &value.String{Value: FALCO_SERVER_HOSTNAME}, nil
 	case SERVER_IDENTITY:
-		return &value.String{Value: "cache-localsimulator"}, nil
+		return &value.String{Value: FALCO_SERVER_HOSTNAME}, nil
 	case SERVER_REGION:
 		return &value.String{Value: "US"}, nil
 	case STALE_EXISTS:

--- a/interpreter/variable/constant.go
+++ b/interpreter/variable/constant.go
@@ -9,6 +9,8 @@ const (
 	PORT                     = "port"
 	PURGE                    = "purge"
 	FALCO_VIRTUAL_SERVICE_ID = "falco-virtual-service-id"
+	FALCO_SERVER_HOSTNAME    = "cache-localsimulator"
+	FALCO_DATACENTER         = "FALCO"
 )
 
 // Mapping from tls package ciphersuite name (IANA) to OpenSSL name


### PR DESCRIPTION
Currently if the interpreter is not threadsafe as much of the state for an individual request being processed is stored in the interpreter struct itself. This causes problems for the simulator if it receives multiple concurrent requests.

While it might be nice for the interpreter to be threadsafe reworking things for that would be rather involved. A simpler solution to solve this specific issue is to add an interpreter lock which the simulator HTTP handler can acquire before processing a request.

This PR adds lock/unlock behavior for the interpreter http handler as well as setting up the Fastly-FF header to let the handler detect loops. Without that a deadlock could occur if the simulator was configured to be a backend for itself.