### PR TITLE
Fix offset/length handling in substr & utf8.substr

### DIFF
--- a/interpreter/function/builtin/substr.go
+++ b/interpreter/function/builtin/substr.go
@@ -35,7 +35,7 @@ func Substr(ctx *context.Context, args ...value.Value) (value.Value, error) {
 		return value.Null, err
 	}
 
-	input := []byte(value.Unwrap[*value.String](args[0]).Value)
+	input := value.Unwrap[*value.String](args[0]).Value
 	offset := int(value.Unwrap[*value.Integer](args[1]).Value)
 	var length *int
 	if len(args) > 2 {
@@ -46,22 +46,21 @@ func Substr(ctx *context.Context, args ...value.Value) (value.Value, error) {
 	var start, end int
 	if offset < 0 {
 		start = len(input) + offset
+		if start < 0 {
+			return &value.String{}, nil
+		}
 	} else {
 		start = offset
 	}
 	if length == nil {
 		end = len(input)
 	} else if *length < 0 {
-		if offset < 0 {
-			end = len(input) + *length + 1
-		} else {
-			end = len(input) + *length
-		}
+		end = len(input) + *length
 	} else {
-		if offset < 0 {
-			end = start + *length
-		} else {
-			end = start + *length + 1
+		end = start + *length
+		// Handle integer overflow
+		if end < 0 {
+			return &value.String{}, nil
 		}
 	}
 	if end > len(input) {
@@ -69,12 +68,10 @@ func Substr(ctx *context.Context, args ...value.Value) (value.Value, error) {
 	}
 
 	if start > len(input) {
-		return &value.String{IsNotSet: true}, errors.New(Substr_Name,
-			"Invalid start offset %d against input string %s", offset, input,
-		)
+		return &value.String{}, nil
 	}
 	if end <= start {
-		return &value.String{Value: ""}, nil
+		return &value.String{}, nil
 	}
-	return &value.String{Value: string(input[start:end])}, nil
+	return &value.String{Value: input[start:end]}, nil
 }


### PR DESCRIPTION
The offset and length handling logic in `substr` and `utf8.substr` currently result in incorrect results for some inputs.

For example:

```vcl
sub test {
  assert.equal(substr("abcdefg", 0, 2), "ab");
}
```

```shell
  ●  [RECV] test

    Assertion Error: Assertion error: expect=ab, actual=abc
    Actual Value: abc

    1| sub test {
    2|   assert.equal(substr("abcdefg", 0, 2), "ab");
    3| }

0 passed, 1 failed, 1 total, 1 assertions
```

The correct result is `ab` for a substring of length 2. Fiddle showing fastly handles this correctly https://fiddle.fastly.dev/fiddle/9de9a70b

This PR fixes this case as well as improving compatibility with Fastly behavior for some edge cases.
* If the calculated starting point of substr is negative return empty string
* Detect integer overflow and return empty string
* Offset beyond length of string returns empty string