### PR TITLE
Regex patterns must be literals

### DIFF
--- a/interpreter/function/builtin/regsub.go
+++ b/interpreter/function/builtin/regsub.go
@@ -10,9 +10,28 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Regsub_Name = "regsub"
+const (
+	Regsub_Name = "regsub"
 
-var Regsub_ArgumentTypes = []value.Type{value.StringType, value.StringType, value.StringType}
+	regSubExpandReplace = "${$1}"
+)
+
+var (
+	Regsub_ArgumentTypes = []value.Type{value.StringType, value.StringType, value.StringType}
+
+	regsubExpandRE = regexp.MustCompile(`\\([0-9]+)`)
+)
+
+func replaceOneString(re *regexp.Regexp, input, replacement string) string {
+	replace := true
+	return re.ReplaceAllStringFunc(input, func(m string) string {
+		if !replace {
+			return m
+		}
+		replace = false
+		return re.ReplaceAllString(m, replacement)
+	})
+}
 
 func Regsub_Validate(args []value.Value) error {
 	if len(args) != 3 {
@@ -23,41 +42,10 @@ func Regsub_Validate(args []value.Value) error {
 			return errors.TypeMismatch(Regsub_Name, i+1, Regsub_ArgumentTypes[i], args[i].Type())
 		}
 	}
-	return nil
-}
-
-func convertGoExpandString(replacement string) (string, bool) {
-	var converted []rune
-	var found bool
-	repl := []rune(replacement)
-
-	for i := 0; i < len(repl); i++ {
-		r := repl[i]
-		if r != 0x5C { // escape sequence, "\"
-			converted = append(converted, r)
-			continue
-		}
-		// If rune is escape sequence, find next numeric character which indicates matched index like "\1"
-		var matchIndex []rune
-		for {
-			if i+1 > len(repl)-1 {
-				break
-			}
-			r = repl[i+1]
-			if r >= 0x31 && r <= 0x39 {
-				matchIndex = append(matchIndex, r)
-				i++
-				continue
-			}
-			break
-		}
-		if len(matchIndex) > 0 {
-			converted = append(converted, []rune("${"+string(matchIndex)+"}")...)
-			found = true
-		}
+	if !args[1].IsLiteral() {
+		return errors.TypeMismatch(Regsub_Name, 2, "STRING LITERAL", args[1].Type())
 	}
-
-	return string(converted), found
+	return nil
 }
 
 // Fastly built-in function implementation of regsub
@@ -82,23 +70,8 @@ func Regsub(ctx *context.Context, args ...value.Value) (value.Value, error) {
 		)
 	}
 
-	// Note: VCL's regsub uses PCRE regexp but golang is not PCRE
-	matches := re.FindStringSubmatchIndex(input.Value)
-	if matches == nil {
-		return &value.String{Value: input.Value}, nil
-	}
-
-	if expand, found := convertGoExpandString(replacement.Value); found {
-		replaced := re.ExpandString([]byte{}, expand, input.Value, matches)
-		return &value.String{Value: string(replaced)}, nil
-	}
-	var replaced string
-	if matches[0] > 0 {
-		replaced += input.Value[:matches[0]]
-	}
-	replaced += replacement.Value
-	if matches[1] < len(input.Value)-1 {
-		replaced += input.Value[matches[1]:]
-	}
-	return &value.String{Value: replaced}, nil
+	expand := regsubExpandRE.ReplaceAllString(replacement.Value, regSubExpandReplace)
+	return &value.String{
+		Value: replaceOneString(re, input.Value, expand),
+	}, nil
 }

--- a/interpreter/function/builtin/regsuball.go
+++ b/interpreter/function/builtin/regsuball.go
@@ -23,6 +23,9 @@ func Regsuball_Validate(args []value.Value) error {
 			return errors.TypeMismatch(Regsuball_Name, i+1, Regsuball_ArgumentTypes[i], args[i].Type())
 		}
 	}
+	if !args[1].IsLiteral() {
+		return errors.TypeMismatch(Regsuball_Name, 2, "STRING LITERAL", args[1].Type())
+	}
 	return nil
 }
 
@@ -48,7 +51,7 @@ func Regsuball(ctx *context.Context, args ...value.Value) (value.Value, error) {
 		)
 	}
 
-	expand, _ := convertGoExpandString(replacement.Value)
+	expand := regsubExpandRE.ReplaceAllString(replacement.Value, regSubExpandReplace)
 	return &value.String{
 		Value: re.ReplaceAllString(input.Value, expand),
 	}, nil

--- a/interpreter/operator/operator.go
+++ b/interpreter/operator/operator.go
@@ -635,6 +635,11 @@ func Regex(ctx *context.Context, left, right value.Value) (value.Value, error) {
 		switch right.Type() {
 		case value.StringType:
 			rv := value.Unwrap[*value.String](right)
+			if !rv.IsLiteral() {
+				return value.Null, errors.WithStack(
+					fmt.Errorf("Right String type must be a literal"),
+				)
+			}
 			re, err := regexp.Compile(rv.Value)
 			if err != nil {
 				return value.Null, errors.WithStack(

--- a/interpreter/operator/operator_regex_test.go
+++ b/interpreter/operator/operator_regex_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/ysugimoto/falco/ast"
 	"github.com/ysugimoto/falco/interpreter/context"
 	"github.com/ysugimoto/falco/interpreter/value"
@@ -135,8 +136,8 @@ func TestRegexOperator(t *testing.T) {
 			{left: &value.String{Value: "example"}, right: &value.Integer{Value: 10, Literal: true}, isError: true},
 			{left: &value.String{Value: "example"}, right: &value.Float{Value: 10.0}, isError: true},
 			{left: &value.String{Value: "example"}, right: &value.Float{Value: 10.0, Literal: true}, isError: true},
-			{left: &value.String{Value: "example"}, right: &value.String{Value: "amp"}, expect: true},
-			{left: &value.String{Value: "example"}, right: &value.String{Value: "^++a"}, isError: true}, // invalid regex syntax
+			{left: &value.String{Value: "example"}, right: &value.String{Value: "amp"}, isError: true}, // pattern must be literal
+			{left: &value.String{Value: "example"}, right: &value.String{Value: "^++a"}, isError: true},
 			{left: &value.String{Value: "example"}, right: &value.String{Value: "amp", Literal: true}, expect: true},
 			{left: &value.String{Value: "example"}, right: &value.String{Value: "^++a", Literal: true}, isError: true}, // invalid regex syntax
 			{left: &value.String{Value: "example"}, right: &value.RTime{Value: 100 * time.Second}, isError: true},
@@ -439,6 +440,46 @@ func TestRegexOperator(t *testing.T) {
 			b := value.Unwrap[*value.Boolean](v)
 			if b.Value != tt.expect {
 				t.Errorf("Index %d: expect value %t, got %t", i, tt.expect, b.Value)
+			}
+		}
+	})
+
+	t.Run("re.match.{N}", func(t *testing.T) {
+		tests := []struct {
+			left   value.Value
+			right  value.Value
+			expect map[string]*value.String
+		}{
+			{
+				left:  &value.String{Value: "example"},
+				right: &value.String{Value: "amp", Literal: true},
+				expect: map[string]*value.String{
+					"0": {Value: "amp"},
+				},
+			},
+			{
+				left:  &value.String{Value: "www.example.com"},
+				right: &value.String{Value: `^([^.]+)\.([^.]+)\.([^.]+)$`, Literal: true},
+				expect: map[string]*value.String{
+					"0": {Value: "www.example.com"},
+					"1": {Value: "www"},
+					"2": {Value: "example"},
+					"3": {Value: "com"},
+				},
+			},
+		}
+
+		for i, tt := range tests {
+			ctx := &context.Context{
+				RegexMatchedValues: make(map[string]*value.String),
+			}
+			_, err := Regex(ctx, tt.left, tt.right)
+			if err != nil {
+				t.Errorf("Index %d: Unexpected error %s", i, err)
+				continue
+			}
+			if diff := cmp.Diff(ctx.RegexMatchedValues, tt.expect); diff != "" {
+				t.Errorf("Index %d: unexpected re.group.{N} values, diff=%s", i, diff)
 			}
 		}
 	})

--- a/linter/function.go
+++ b/linter/function.go
@@ -101,5 +101,16 @@ func (l *Linter) lintFunctionArguments(fn *context.BuiltinFunction, calledFn fun
 		}
 	}
 
+	// Special cases
+	if calledFn.name == "regsub" || calledFn.name == "regsuball" {
+		if !isTypeLiteral(calledFn.arguments[1]) {
+			l.Error(&LintError{
+				Severity: ERROR,
+				Token:    calledFn.arguments[1].GetMeta().Token,
+				Message:  "Regex patterns must be string literals.",
+			})
+		}
+	}
+
 	return fn.Return
 }

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -1659,10 +1659,17 @@ func (l *Linter) lintInfixExpression(exp *ast.InfixExpression, ctx *context.Cont
 		return types.BoolType
 	case "~", "!~":
 		// Regex operator could compare only STRING,  IP or ACL type
-		if !expectType(left, types.StringType, types.IPType, types.AclType) {
+		if !expectType(left, types.StringType, types.IPType) {
 			l.Error(InvalidTypeExpression(exp.GetMeta(), left, types.StringType, types.IPType, types.AclType).Match(OPERATOR_CONDITIONAL))
-		} else if !expectType(right, types.StringType, types.IPType, types.AclType) {
-			l.Error(InvalidTypeExpression(exp.GetMeta(), right, types.StringType, types.IPType, types.AclType).Match(OPERATOR_CONDITIONAL))
+		} else if !expectType(right, types.StringType, types.AclType) {
+			l.Error(InvalidTypeExpression(exp.GetMeta(), right, types.StringType).Match(OPERATOR_CONDITIONAL))
+		}
+		if expectType(right, types.StringType) && !isLiteralExpression(exp.Right) {
+			l.Error(&LintError{
+				Severity: ERROR,
+				Token:    exp.Right.GetMeta().Token,
+				Message:  "Regex patterns must be string literals.",
+			})
 		}
 		// And, if right expression is STRING, regex must be valid
 		if v, ok := exp.Right.(*ast.String); ok {


### PR DESCRIPTION
This PR fixes two issues, first that regex patterns must be string literals as they are handled at compile time.

https://www.fastly.com/documentation/reference/vcl/regex/
> Where an operator or function expects a regex, you must provide a literal pattern in your code.

To fix this in Falco the `Regex` operator function as well as the regex related builtin vcl functions needed to be updated to check that the pattern argument is a string literal. Also updated the linter to detect non-literal patterns for the regex match operators and `regsub*` function arguments.

Second there is a bug in `regsub` where non-matching portions of the input string can get lost.

For example the case:
```vcl
regsub("foo;bar", "^([^;]+)", "\1");
```

The result of this should be the same as the input string `foo:bar` because the regex pattern is matching the first segment of the input `foo` and replacing it with the match group 1 which is the same value. However the current `regsub` logic results in the non-matching portion of the input to be lost.

```vcl
sub test {
  assert.equal(regsub("foo;bar", "^([^;]+)", "\1"), "foo;bar");
}
```

```shell
    Assertion Error: Assertion error: expect=foo;bar, actual=foo
    Actual Value: foo

    1| sub test {
    2|   assert.equal(regsub("foo;bar", "^([^;]+)", "\1"), "foo;bar");
    3| }
```

Fiddle showing the correct behavior on fastly: https://fiddle.fastly.dev/fiddle/3c908f13

Resolved this by replacing the current logic with an implementation that uses `ReplaceAllStringFunc` in a way that behaves like a `ReplaceOneStringFunc` function. Additionally changed the logic for converting the VCL replacement group format to the go format to one that uses a regex replacement.