### PR TITLE
Additional details in simulator output

### DIFF
--- a/cmd/falco/help.go
+++ b/cmd/falco/help.go
@@ -98,6 +98,7 @@ Flags:
     -h, --help         : Show this help
     -r, --remote       : Connect with Fastly API
     -request           : Simulate request config
+    -body              : Output response body
     -debug             : Enable debug mode
     --max_backends     : Override max backends limitation
     --max_acls         : Override max acls limitation

--- a/cmd/falco/runner.go
+++ b/cmd/falco/runner.go
@@ -428,6 +428,7 @@ func (r *Runner) Simulate(rslv resolver.Resolver) error {
 		icontext.WithResolver(rslv),
 		icontext.WithMaxBackends(r.config.OverrideMaxBackends),
 		icontext.WithMaxAcls(r.config.OverrideMaxAcls),
+		icontext.WithOutputResponseBody(r.config.Simulator.OutputResponseBody),
 	}
 	if r.snippets != nil {
 		options = append(options, icontext.WithSnippets(r.snippets))

--- a/config/config.go
+++ b/config/config.go
@@ -33,7 +33,8 @@ type SimulatorConfig struct {
 	IncludePaths []string // Copy from root field
 
 	// Override Request configuration
-	OverrideRequest *RequestConfig
+	OverrideRequest    *RequestConfig
+	OutputResponseBody bool `cli:"body" yaml:"output_response_body"`
 }
 
 // Testing configuration
@@ -52,7 +53,7 @@ type Config struct {
 	IncludePaths []string `cli:"I,include_path" yaml:"include_paths"`
 	Transforms   []string `cli:"t,transformer" yaml:"transformers"`
 	Help         bool     `cli:"h,help"`
-	Version      bool     `cli:"V"`
+	Version      bool     `cli:"V,version"`
 	Remote       bool     `cli:"r,remote" yaml:"remote"`
 	Json         bool     `cli:"json"`
 	Request      string   `cli:"request"`

--- a/interpreter/context/context.go
+++ b/interpreter/context/context.go
@@ -55,6 +55,7 @@ type Context struct {
 	Gotos               map[string]*ast.GotoStatement
 	SubroutineFunctions map[string]*ast.SubroutineDeclaration
 	OriginalHost        string
+	OutputResponseBody  bool
 
 	OverrideMaxBackends int
 	OverrideMaxAcls     int

--- a/interpreter/context/option.go
+++ b/interpreter/context/option.go
@@ -49,3 +49,9 @@ func WithOverrideHost(host string) Option {
 		c.OriginalHost = host
 	}
 }
+
+func WithOutputResponseBody(o bool) Option {
+	return func(c *Context) {
+		c.OutputResponseBody = o
+	}
+}

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -131,7 +131,7 @@ func (i *Interpreter) ProcessInit(r *http.Request) error {
 		i.ctx.OriginalHost = r.Host
 	}
 
-	i.process = process.New()
+	i.process = process.New(i.ctx.OutputResponseBody)
 	i.ctx.Scope = context.InitScope
 	i.vars = variable.NewAllScopeVariables(i.ctx)
 

--- a/interpreter/process/flow.go
+++ b/interpreter/process/flow.go
@@ -12,6 +12,7 @@ type Flow struct {
 	Line            int       `json:"line"`
 	Position        int       `json:"position"`
 	Subroutine      string    `json:"subroutine"`
+	Backend         string    `json:"backend,omitempty"`
 	Request         *HttpFlow `json:"req,omitempty"`
 	BackendRequest  *HttpFlow `json:"bereq,omitempty"`
 	BackendResponse *HttpFlow `json:"beresp,omitempty"`
@@ -28,6 +29,9 @@ func NewFlow(ctx *icontext.Context, sub *ast.SubroutineDeclaration) *Flow {
 		Line:       token.Line,
 		Position:   token.Position,
 		Subroutine: sub.Name.Value,
+	}
+	if ctx.Backend != nil {
+		f.Backend = ctx.Backend.String()
 	}
 	if ctx.Request != nil {
 		f.Request = newFlowRequest(ctx.Request.Clone(c))


### PR DESCRIPTION
## Report selected backend in flows

Currently the simulator does not provide a way to see the selected backend at each recorded flow. This information is helpful when validating the behavior of backend selection in vcl_recv vs vcl_miss/vcl_pass.

## Optional output of response body

Add a new cli flag to the simulator which toggles the output of the response body in `.client_response`.

## fix missing `--version` flag

Help output includes the `--version` flag for displaying the Falco version but the flag was missing from the Config struct tags.