### PR TITLE
Fix setup of query string when setting bereq.url

### DIFF
--- a/interpreter/variable/fetch.go
+++ b/interpreter/variable/fetch.go
@@ -280,7 +280,8 @@ func (v *FetchScopeVariables) Set(s context.Scope, name, operator string, val va
 		}
 		// Update request URLs
 		bereq.URL.Path = parsed.Path
-		bereq.URL.RawQuery = parsed.RawPath
+		bereq.URL.RawPath = parsed.RawPath
+		bereq.URL.RawQuery = parsed.RawQuery
 		bereq.URL.RawFragment = parsed.RawFragment
 		return nil
 	case BERESP_BROTLI:

--- a/interpreter/variable/miss.go
+++ b/interpreter/variable/miss.go
@@ -158,7 +158,8 @@ func (v *MissScopeVariables) Set(s context.Scope, name, operator string, val val
 		}
 		// Update request URLs
 		bereq.URL.Path = parsed.Path
-		bereq.URL.RawQuery = parsed.RawPath
+		bereq.URL.RawPath = parsed.RawPath
+		bereq.URL.RawQuery = parsed.RawQuery
 		bereq.URL.RawFragment = parsed.RawFragment
 		return nil
 	}

--- a/interpreter/variable/pass.go
+++ b/interpreter/variable/pass.go
@@ -147,7 +147,8 @@ func (v *PassScopeVariables) Set(s context.Scope, name, operator string, val val
 		}
 		// Update request URLs
 		bereq.URL.Path = parsed.Path
-		bereq.URL.RawQuery = parsed.RawPath
+		bereq.URL.RawPath = parsed.RawPath
+		bereq.URL.RawQuery = parsed.RawQuery
 		bereq.URL.RawFragment = parsed.RawFragment
 		return nil
 	}


### PR DESCRIPTION
When setting `bereq.url` the query string portion of the updated url is lost.

For example the result of the following set statement:
```vcl
set bereq.url = "/foo?bar=baz";
```

Will be:
```
/foo
```

This PR updates the set logic to match `req.url`.