### PR TITLE
fix {NAME} signature dealing and add one lacked variable

### DIFF
--- a/__generator__/predefined.yml
+++ b/__generator__/predefined.yml
@@ -2283,3 +2283,8 @@ ratecounter.%any%.rate.60s:
   reference: "https://developer.fastly.com/reference/vcl/variables/rate-limiting/ratecounter-rate-60s/"
   on: [RECV, HASH, HIT, MISS, PASS, FETCH, ERROR, DELIVER, LOG]
   get: FLOAT
+
+director.%any%.healthy:
+  reference: "https://developer.fastly.com/documentation/reference/vcl/variables/miscellaneous/director-healthy/"
+  on: [RECV, HASH, HIT, MISS, PASS, FETCH, ERROR, DELIVER, LOG]
+  get: BOOL

--- a/cmd/documentation-checker/html.go
+++ b/cmd/documentation-checker/html.go
@@ -53,11 +53,17 @@ func fetchFastlyDocument(ctx context.Context, url string, m *sync.Map) error {
 			}
 			name := a.FirstChild.Data
 			if name == ignoreFunctionIf ||
-				strings.Contains(name, ignoreHTTPHeaderRelatedSignaure) ||
 				strings.Contains(name, ignoreRegexCapturedNumber) {
 
 				continue
 			}
+
+			name = strings.ReplaceAll(
+				name,
+				ignoreHTTPHeaderRelatedSignaure,
+				"%any%",
+			)
+
 			var link string
 			for _, v := range a.Attr {
 				if v.Key == "href" {


### PR DESCRIPTION
fixes #287 

`{NAME}` is an arbitrary identifier in fastly documentation and falco treats as `%any%`.
This difference causes skipping in documentation-checker utility command.

This PR fixes it by replacing character from `{NAME}` to `%any%`

And we can find one predefined variable after fixed, added it.