### PR TITLE
Add enforcing and ignoring subroutine scope in linter config

### DIFF
--- a/cmd/falco/runner.go
+++ b/cmd/falco/runner.go
@@ -220,7 +220,7 @@ func (r *Runner) run(ctx *context.Context, main *resolver.VCL, mode RunMode) (*p
 		}
 	}
 
-	lt := linter.New()
+	lt := linter.New(r.config.Linter)
 	lt.Lint(vcl, ctx)
 
 	for k, v := range lt.Lexers() {

--- a/config/config.go
+++ b/config/config.go
@@ -20,10 +20,12 @@ type OverrideBackend struct {
 
 // Linter configuration
 type LinterConfig struct {
-	VerboseLevel   string            `yaml:"verbose"`
-	VerboseWarning bool              `cli:"v"`
-	VerboseInfo    bool              `cli:"vv"`
-	Rules          map[string]string `yaml:"rules"`
+	VerboseLevel            string              `yaml:"verbose"`
+	VerboseWarning          bool                `cli:"v"`
+	VerboseInfo             bool                `cli:"vv"`
+	Rules                   map[string]string   `yaml:"rules"`
+	EnforceSubroutineScopes map[string][]string `yaml:"enforce_subroutine_scopes"`
+	IgnoreSubroutines       []string            `yaml:"ignore_subroutines"`
 }
 
 // Simulator configuration

--- a/linter/helper.go
+++ b/linter/helper.go
@@ -343,7 +343,7 @@ func getSubroutineCallScope(s *ast.SubroutineDeclaration) int {
 	}
 
 	// If could not via subroutine name, find by annotations
-	// typically defined is module file
+	// typically defined in module file
 	scopes := 0
 	for _, a := range annotations(s.Leading) {
 		switch strings.ToUpper(a) {
@@ -368,9 +368,50 @@ func getSubroutineCallScope(s *ast.SubroutineDeclaration) int {
 		}
 	}
 	if scopes == 0 {
-		return context.RECV
+		// Unknown scope
+		return -1
 	}
 	return scopes
+}
+
+func enforceSubroutineCallScopeFromConfig(scopeNames []string) int {
+	var scopes int
+	for i := range scopeNames {
+		switch strings.ToUpper(scopeNames[i]) {
+		case "RECV":
+			scopes |= context.RECV
+		case "HASH":
+			scopes |= context.HASH
+		case "HIT":
+			scopes |= context.HIT
+		case "MISS":
+			scopes |= context.MISS
+		case "PASS":
+			scopes |= context.PASS
+		case "FETCH":
+			scopes |= context.FETCH
+		case "ERROR":
+			scopes |= context.ERROR
+		case "DELIVER":
+			scopes |= context.DELIVER
+		case "LOG":
+			scopes |= context.LOG
+		}
+	}
+	if scopes == 0 {
+		// Unknown scope
+		return -1
+	}
+	return scopes
+}
+
+func isIgnoredSubroutineInConfig(ignores []string, subroutineName string) bool {
+	for i := range ignores {
+		if ignores[i] == subroutineName {
+			return true
+		}
+	}
+	return false
 }
 
 func getFastlySubroutineScope(name string) string {

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/config"
 	"github.com/ysugimoto/falco/context"
 	"github.com/ysugimoto/falco/lexer"
 	"github.com/ysugimoto/falco/parser"
@@ -14,6 +15,25 @@ import (
 	"github.com/ysugimoto/falco/types"
 )
 
+var testConfig = &config.LinterConfig{
+	EnforceSubroutineScopes: map[string][]string{
+		"enforced_subroutine": {"pass", "miss"},
+		"foo":                 {"recv"},
+		"bar":                 {"recv"},
+		"baz":                 {"recv"},
+		"example":             {"recv"},
+		"returns_one":         {"recv"},
+		"custom_sub":          {"recv"},
+		"test_sub":            {"recv"},
+		"hoisted_subroutine":  {"recv"},
+		"returns_true":        {"recv"},
+		"get_bool":            {"recv"},
+	},
+	IgnoreSubroutines: []string{
+		"ignored_subroutine",
+	},
+}
+
 func assertNoError(t *testing.T, input string, opts ...context.Option) {
 	vcl, err := parser.New(lexer.NewFromString(input)).ParseVCL()
 	if err != nil {
@@ -21,7 +41,7 @@ func assertNoError(t *testing.T, input string, opts ...context.Option) {
 		t.FailNow()
 	}
 
-	l := New()
+	l := New(testConfig)
 	l.lint(vcl, context.New(opts...))
 	if len(l.Errors) > 0 {
 		t.Errorf("Lint error: %s", l.Errors)
@@ -38,7 +58,7 @@ func assertError(t *testing.T, input string, opts ...context.Option) {
 		t.FailNow()
 	}
 
-	l := New()
+	l := New(testConfig)
 	l.lint(vcl, context.New(opts...))
 	if len(l.Errors) == 0 {
 		t.Errorf("Expect one lint error but empty returned")
@@ -54,7 +74,7 @@ func assertErrorWithSeverity(t *testing.T, input string, severity Severity, opts
 		t.FailNow()
 	}
 
-	l := New()
+	l := New(testConfig)
 	l.lint(vcl, context.New(opts...))
 	if len(l.Errors) == 0 {
 		t.Errorf("Expect one lint error but empty returned")
@@ -1692,7 +1712,7 @@ sub bar {
 			t.FailNow()
 		}
 
-		l := New()
+		l := New(testConfig)
 		l.Lint(vcl, context.New())
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
@@ -1708,7 +1728,7 @@ acl foo {}
 			t.FailNow()
 		}
 
-		l := New()
+		l := New(testConfig)
 		l.Lint(vcl, context.New())
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
@@ -1725,7 +1745,7 @@ acl foo {}
 		}
 		ctx := context.New()
 		ctx.AddAcl("foo", &types.Acl{})
-		l := New()
+		l := New(testConfig)
 		l.Lint(vcl, ctx)
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
@@ -1747,7 +1767,7 @@ sub bar {
 			t.FailNow()
 		}
 
-		l := New()
+		l := New(testConfig)
 		l.Lint(vcl, context.New())
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
@@ -1763,7 +1783,7 @@ table foo {}
 			t.FailNow()
 		}
 
-		l := New()
+		l := New(testConfig)
 		l.Lint(vcl, context.New())
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
@@ -1780,7 +1800,7 @@ table foo {}
 		}
 		ctx := context.New()
 		ctx.AddTable("foo", &types.Table{})
-		l := New()
+		l := New(testConfig)
 		l.Lint(vcl, ctx)
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
@@ -1802,7 +1822,7 @@ sub vcl_recl {
 			t.FailNow()
 		}
 
-		l := New()
+		l := New(testConfig)
 		l.Lint(vcl, context.New())
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
@@ -1818,7 +1838,7 @@ backend foo {}
 			t.FailNow()
 		}
 
-		l := New()
+		l := New(testConfig)
 		l.Lint(vcl, context.New())
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
@@ -1835,7 +1855,7 @@ backend foo {}
 		}
 		ctx := context.New()
 		ctx.AddBackend("foo", &types.Backend{})
-		l := New()
+		l := New(testConfig)
 		l.Lint(vcl, ctx)
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
@@ -1857,7 +1877,7 @@ sub vcl_recl {
 			t.FailNow()
 		}
 
-		l := New()
+		l := New(testConfig)
 		l.Lint(vcl, context.New())
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
@@ -1873,7 +1893,7 @@ sub foo {}
 			t.FailNow()
 		}
 
-		l := New()
+		l := New(testConfig)
 		l.Lint(vcl, context.New())
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
@@ -1894,7 +1914,7 @@ sub vcl_recv {
 			t.FailNow()
 		}
 
-		l := New()
+		l := New(testConfig)
 		l.Lint(vcl, context.New())
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
@@ -1913,7 +1933,7 @@ sub vcl_recv {
 			t.FailNow()
 		}
 
-		l := New()
+		l := New(testConfig)
 		l.Lint(vcl, context.New())
 		if len(l.Errors) == 0 {
 			t.Errorf("Expect one lint error but empty returned")
@@ -2714,6 +2734,28 @@ sub vcl_recv {
 	#FASTLY RECV
 	call foo;
 }`
+		assertNoError(t, input)
+	})
+}
+
+func TestEnforcedSubroutineScopes(t *testing.T) {
+	t.Run("Pass on enforce scope subroutine", func(t *testing.T) {
+		input := `
+sub enforced_subroutine {
+	set bereq.method = "POST";
+}
+`
+		assertNoError(t, input)
+	})
+}
+
+func TestIgnoredSubroutnes(t *testing.T) {
+	t.Run("ignore subroutine linting from config", func(t *testing.T) {
+		input := `
+sub ignored_subroutine {
+	set bereq.method = 1;
+}
+`
 		assertNoError(t, input)
 	})
 }

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -18,16 +18,18 @@ import (
 var testConfig = &config.LinterConfig{
 	EnforceSubroutineScopes: map[string][]string{
 		"enforced_subroutine": {"pass", "miss"},
-		"foo":                 {"recv"},
-		"bar":                 {"recv"},
-		"baz":                 {"recv"},
-		"example":             {"recv"},
-		"returns_one":         {"recv"},
-		"custom_sub":          {"recv"},
-		"test_sub":            {"recv"},
-		"hoisted_subroutine":  {"recv"},
-		"returns_true":        {"recv"},
-		"get_bool":            {"recv"},
+
+		// Keep backward compatibility for the changes https://github.com/ysugimoto/falco/issues/273
+		"foo":                {"recv"},
+		"bar":                {"recv"},
+		"baz":                {"recv"},
+		"example":            {"recv"},
+		"returns_one":        {"recv"},
+		"custom_sub":         {"recv"},
+		"test_sub":           {"recv"},
+		"hoisted_subroutine": {"recv"},
+		"returns_true":       {"recv"},
+		"get_bool":           {"recv"},
 	},
 	IgnoreSubroutines: []string{
 		"ignored_subroutine",

--- a/linter/rules.go
+++ b/linter/rules.go
@@ -32,6 +32,7 @@ const (
 	SUBROUTINE_BOILERPLATE_MACRO         = "subroutine/boilerplate-macro"
 	SUBROUTINE_DUPLICATED                = "subroutine/duplicated"
 	SUBROUTINE_INVALID_RETURN_TYPE       = "subroutine/invalid-return-type"
+	UNRECOGNIZE_CALL_SCOPE               = "sburoutine/unrecognize-call-scope"
 	PENALTYBOX_SYNTAX                    = "penaltybox/syntax"
 	PENALTYBOX_DUPLICATED                = "penaltybox/duplicated"
 	PENALTYBOX_NONEMPTY_BLOCK            = "penaltybox/nonempty-block"
@@ -102,4 +103,5 @@ var references = map[Rule]string{
 	SYNTHETIC_STATEMENT_SCOPE:        "https://developer.fastly.com/reference/vcl/statements/synthetic/",
 	SYNTHETIC_BASE64_STATEMENT_SCOPE: "https://developer.fastly.com/reference/vcl/statements/synthetic-base64/",
 	DISALLOW_EMPTY_RETURN:            "https://developer.fastly.com/reference/vcl/subroutines#returning-a-state",
+	UNRECOGNIZE_CALL_SCOPE:           "https://github.com/ysugimoto/falco/blob/main/docs/linter.md#user-defined-subroutine",
 }


### PR DESCRIPTION
Fixes #273 

This PR adds more linter configuration for:

- enforce_subroutine_scopes
- ignore_subroutines

The background of this change is that Fastly says an NGWAF configuration will be provided via dynamic snippet in deliver service and the dynamic snippet is managed by Fastly, so it cannot be added annotation comments to recognize call scope (discussed at #272 ).

To avoid linting errors with this snippet, we can use the above configurations to suppress linting errors.

Additionally, if we can't recognize the subroutine call scope, raise an error about `Unrecognized Call Scope` as `WARNING`.