### PR TITLE
Improve parser/ast for complex comments

### DIFF
--- a/ast/acl_declaration.go
+++ b/ast/acl_declaration.go
@@ -16,16 +16,17 @@ func (a *AclDeclaration) GetMeta() *Meta { return a.Meta }
 func (a *AclDeclaration) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(a.LeadingComment())
+	buf.WriteString(a.LeadingComment(lineFeed))
 	buf.WriteString("acl ")
 	buf.WriteString(a.Name.String())
 	buf.WriteString(" {\n")
 	for _, cidr := range a.CIDRs {
-		buf.WriteString(cidr.String() + "\n")
+		buf.WriteString(cidr.String())
+		buf.WriteString("\n")
 	}
-	buf.WriteString(a.InfixComment())
+	buf.WriteString(a.InfixComment(lineFeed))
 	buf.WriteString("}")
-	buf.WriteString(a.TrailingComment())
+	buf.WriteString(a.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()
@@ -42,17 +43,19 @@ func (c *AclCidr) GetMeta() *Meta { return c.Meta }
 func (c *AclCidr) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(c.LeadingComment())
+	buf.WriteString(c.LeadingComment(lineFeed))
 	buf.WriteString(indent(c.Nest))
 	if c.Inverse != nil && c.Inverse.Value {
 		buf.WriteString("!")
 	}
-	buf.WriteString(`"` + c.IP.String() + `"`)
+	buf.WriteString(c.IP.LeadingComment(inline))
+	buf.WriteString(`"` + c.IP.Value + `"`)
 	if c.Mask != nil {
 		buf.WriteString("/" + c.Mask.String())
 	}
+	buf.WriteString(c.IP.TrailingComment(inline))
 	buf.WriteString(";")
-	buf.WriteString(c.TrailingComment())
+	buf.WriteString(c.TrailingComment(inline))
 
 	return buf.String()
 }

--- a/ast/acl_declaration_test.go
+++ b/ast/acl_declaration_test.go
@@ -8,7 +8,7 @@ func TestAclDeclaration(t *testing.T) {
 	acl := &AclDeclaration{
 		Meta: New(T, 0, comments("// This is comment"), comments("// This is comment")),
 		Name: &Ident{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments("/* before_name */"), comments("/* after_name */")),
 			Value: "internal",
 		},
 		CIDRs: []*AclCidr{
@@ -38,21 +38,35 @@ func TestAclDeclaration(t *testing.T) {
 					Value: "192.168.0.2",
 				},
 			},
+			{
+				Meta: New(T, 1),
+				Inverse: &Boolean{
+					Meta:  New(T, 0),
+					Value: true,
+				},
+				IP: &IP{
+					Meta:  New(T, 0, comments("/* foo */")),
+					Value: "192.168.0.3",
+				},
+				Mask: &Integer{
+					Meta:  New(T, 0, comments(), comments("/* bar */")),
+					Value: 32,
+				},
+			},
 		},
 	}
 
 	expect := `// This is comment
-acl internal {
+acl /* before_name */ internal /* after_name */ {
   // This is comment
   # This is another comment
   !"192.168.0.1"/32; // This is comment
   // This is comment
   # This is another comment
   "192.168.0.2"; // This is comment
+  !/* foo */ "192.168.0.3"/32 /* bar */;
 } // This is comment
 `
 
-	if acl.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, acl.String())
-	}
+	assert(t, acl.String(), expect)
 }

--- a/ast/add_statement.go
+++ b/ast/add_statement.go
@@ -16,13 +16,13 @@ func (a *AddStatement) GetMeta() *Meta { return a.Meta }
 func (a *AddStatement) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(a.LeadingComment())
-	buf.WriteString(indent(a.Nest) + "add ")
-	buf.WriteString(a.Ident.String())
-	buf.WriteString(" " + a.Operator.String() + " ")
-	buf.WriteString(a.Value.String())
+	buf.WriteString(a.LeadingComment(lineFeed))
+	buf.WriteString(indent(a.Nest) + "add")
+	buf.WriteString(padding(a.Ident.String()))
+	buf.WriteString(a.Operator.String())
+	buf.WriteString(paddingLeft(a.Value.String()))
 	buf.WriteString(";")
-	buf.WriteString(a.TrailingComment())
+	buf.WriteString(a.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()

--- a/ast/add_statement_test.go
+++ b/ast/add_statement_test.go
@@ -8,23 +8,21 @@ func TestAddStatement(t *testing.T) {
 	add := &AddStatement{
 		Meta: New(T, 0, comments("// This is comment"), comments("// This is comment")),
 		Ident: &Ident{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments("/* a */"), comments("/* b */")),
 			Value: "req.http.Host",
 		},
 		Operator: &Operator{
 			Operator: "=",
 		},
 		Value: &String{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments("/* c */"), comments("/* d */")),
 			Value: "example.com",
 		},
 	}
 
 	expect := `// This is comment
-add req.http.Host = "example.com"; // This is comment
+add /* a */ req.http.Host /* b */ = /* c */ "example.com" /* d */; // This is comment
 `
 
-	if add.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, add.String())
-	}
+	assert(t, add.String(), expect)
 }

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -2,6 +2,7 @@ package ast
 
 import (
 	"bytes"
+	"strings"
 
 	"github.com/ysugimoto/falco/token"
 )
@@ -14,15 +15,17 @@ type Node interface {
 type Statement interface {
 	Node
 	statement()
-	LeadingComment() string
-	TrailingComment() string
+	LeadingComment(combinationMode) string
+	TrailingComment(combinationMode) string
+	InfixComment(combinationMode) string
 }
 
 type Expression interface {
 	Node
 	expression()
-	LeadingComment() string
-	TrailingComment() string
+	LeadingComment(combinationMode) string
+	TrailingComment(combinationMode) string
+	InfixComment(combinationMode) string
 }
 
 // Meta struct of all nodes
@@ -34,56 +37,37 @@ type Meta struct {
 	Nest     int
 }
 
-func (m *Meta) LeadingComment() string {
-	if len(m.Leading) == 0 {
+// combinationMode represents comment combination mode
+type combinationMode string
+
+const (
+	lineFeed combinationMode = "\n"
+	inline   combinationMode = " "
+)
+
+func (m *Meta) comment(cs Comments, sep combinationMode) string {
+	if len(cs) == 0 {
 		return ""
 	}
 	var buf bytes.Buffer
 
-	for i := range m.Leading {
-		buf.WriteString(indent(m.Nest) + m.Leading[i].String() + "\n")
+	for i := range cs {
+		buf.WriteString(indent(m.Nest) + cs[i].String() + string(sep))
 	}
 
 	return buf.String()
 }
 
-func (m *Meta) LeadingInlineComment() string {
-	if len(m.Leading) == 0 {
-		return ""
-	}
-	var buf bytes.Buffer
-
-	for i := range m.Leading {
-		buf.WriteString(indent(m.Nest) + m.Leading[i].String() + " ")
-	}
-
-	return buf.String()
+func (m *Meta) LeadingComment(cm combinationMode) string {
+	return m.comment(m.Leading, cm)
 }
 
-func (m *Meta) TrailingComment() string {
-	if len(m.Trailing) == 0 {
-		return ""
-	}
-	var buf bytes.Buffer
-
-	for i := range m.Trailing {
-		buf.WriteString(m.Trailing[i].String())
-	}
-
-	return " " + buf.String()
+func (m *Meta) TrailingComment(cm combinationMode) string {
+	return paddingLeft(m.comment(m.Trailing, cm))
 }
 
-func (m *Meta) InfixComment() string {
-	if len(m.Infix) == 0 {
-		return ""
-	}
-	var buf bytes.Buffer
-
-	for i := range m.Infix {
-		buf.WriteString(indent(m.Nest) + m.Infix[i].String() + "\n")
-	}
-
-	return buf.String()
+func (m *Meta) InfixComment(cm combinationMode) string {
+	return m.comment(m.Infix, cm)
 }
 
 func New(t token.Token, nest int, comments ...Comments) *Meta {
@@ -118,3 +102,28 @@ type Operator struct {
 }
 
 func (o *Operator) String() string { return o.Operator }
+
+// Format redundant white space
+func padding(s string) string {
+	trimmed := strings.Trim(s, " ")
+	if trimmed == "" {
+		return ""
+	}
+	return " " + trimmed + " "
+}
+
+func paddingLeft(s string) string {
+	trimmed := strings.Trim(s, " ")
+	if trimmed == "" {
+		return ""
+	}
+	return " " + trimmed
+}
+
+func paddingRight(s string) string {
+	trimmed := strings.Trim(s, " ")
+	if trimmed == "" {
+		return ""
+	}
+	return trimmed + " "
+}

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -1,6 +1,9 @@
 package ast
 
 import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
 	"github.com/ysugimoto/falco/token"
 )
 
@@ -14,4 +17,10 @@ func comments(c ...string) Comments {
 		})
 	}
 	return cs
+}
+
+func assert(t *testing.T, actual, expect string) {
+	if diff := cmp.Diff(actual, expect); diff != "" {
+		t.Errorf("Stringer error, diff=%s", diff)
+	}
 }

--- a/ast/backend_declaration.go
+++ b/ast/backend_declaration.go
@@ -16,16 +16,16 @@ func (b *BackendDeclaration) GetMeta() *Meta { return b.Meta }
 func (b *BackendDeclaration) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(b.LeadingComment())
+	buf.WriteString(b.LeadingComment(lineFeed))
 	buf.WriteString("backend ")
 	buf.WriteString(b.Name.String())
 	buf.WriteString(" {\n")
 	for _, prop := range b.Properties {
 		buf.WriteString(prop.String() + "\n")
 	}
-	buf.WriteString(b.InfixComment())
+	buf.WriteString(b.InfixComment(lineFeed))
 	buf.WriteString("}")
-	buf.WriteString(b.TrailingComment())
+	buf.WriteString(b.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()
@@ -42,14 +42,14 @@ func (p *BackendProperty) GetMeta() *Meta { return p.Meta }
 func (p *BackendProperty) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(p.LeadingComment())
+	buf.WriteString(p.LeadingComment(lineFeed))
 	buf.WriteString(indent(p.Nest) + "." + p.Key.String())
 	buf.WriteString(" = ")
 	buf.WriteString(p.Value.String())
 	if _, ok := p.Value.(*BackendProbeObject); !ok {
 		buf.WriteString(";")
 	}
-	buf.WriteString(p.TrailingComment())
+	buf.WriteString(p.TrailingComment(inline))
 
 	return buf.String()
 }
@@ -66,15 +66,15 @@ func (o *BackendProbeObject) String() string {
 
 	buf.WriteString("{\n")
 	for _, p := range o.Values {
-		buf.WriteString(p.LeadingComment())
+		buf.WriteString(p.LeadingComment(lineFeed))
 		buf.WriteString(indent(p.Nest) + "." + p.Key.String())
 		buf.WriteString(" = ")
 		buf.WriteString(p.Value.String())
 		buf.WriteString(";")
-		buf.WriteString(p.TrailingComment())
+		buf.WriteString(p.TrailingComment(inline))
 		buf.WriteString("\n")
 	}
-	buf.WriteString(o.InfixComment())
+	buf.WriteString(o.InfixComment(lineFeed))
 	buf.WriteString(indent(o.Nest) + "}")
 
 	return buf.String()

--- a/ast/backend_declaration_test.go
+++ b/ast/backend_declaration_test.go
@@ -8,7 +8,7 @@ func TestBackendDeclaration(t *testing.T) {
 	backend := &BackendDeclaration{
 		Meta: New(T, 0, comments("// This is comment"), comments("// This is comment")),
 		Name: &Ident{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments("/* before_name */"), comments("/* after_name */")),
 			Value: "example",
 		},
 		Properties: []*BackendProperty{
@@ -21,6 +21,17 @@ func TestBackendDeclaration(t *testing.T) {
 				Value: &String{
 					Meta:  New(T, 0),
 					Value: "example.com",
+				},
+			},
+			{
+				Meta: New(T, 1),
+				Key: &Ident{
+					Meta:  New(T, 0, comments(), comments("/* after_name */")),
+					Value: "port",
+				},
+				Value: &String{
+					Meta:  New(T, 0, comments("/* before_value */"), comments("/* after_value */")),
+					Value: "443",
 				},
 			},
 			{
@@ -50,10 +61,11 @@ func TestBackendDeclaration(t *testing.T) {
 	}
 
 	expect := `// This is comment
-backend example {
+backend /* before_name */ example /* after_name */ {
   // This is comment
   # This is another comment
   .host = "example.com"; // This is comment
+  .port /* after_name */ = /* before_value */ "443" /* after_value */;
   // This is comment
   # This is another comment
   .probe = {
@@ -64,7 +76,5 @@ backend example {
 } // This is comment
 `
 
-	if backend.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, backend.String())
-	}
+	assert(t, backend.String(), expect)
 }

--- a/ast/block_statement.go
+++ b/ast/block_statement.go
@@ -14,11 +14,12 @@ func (b *BlockStatement) GetMeta() *Meta { return b.Meta }
 func (b *BlockStatement) String() string {
 	var buf bytes.Buffer
 
+	buf.WriteString(b.LeadingComment(lineFeed))
 	buf.WriteString("{\n")
 	for _, stmt := range b.Statements {
 		buf.WriteString(stmt.String())
 	}
-	buf.WriteString(b.InfixComment())
+	buf.WriteString(indent(b.Nest-1) + b.InfixComment(lineFeed))
 	if b.Nest == 0 {
 		buf.WriteString("}")
 	} else {

--- a/ast/block_statement_test.go
+++ b/ast/block_statement_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestBlockStatement(t *testing.T) {
 	block := &BlockStatement{
-		Meta: New(T, 1, comments(), comments(), comments("// This is comment")),
+		Meta: New(T, 1, comments(), comments(), comments("// This is infix comment")),
 		Statements: []Statement{
 			&SetStatement{
 				Meta: New(T, 1, comments("// This is comment"), comments("// This is comment")),
@@ -28,10 +28,8 @@ func TestBlockStatement(t *testing.T) {
 	expect := `{
   // This is comment
   set req.http.Host = "example.com"; // This is comment
-  // This is comment
+  // This is infix comment
 }`
 
-	if block.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, block.String())
-	}
+	assert(t, block.String(), expect)
 }

--- a/ast/break_statement.go
+++ b/ast/break_statement.go
@@ -13,9 +13,11 @@ func (r *BreakStatement) GetMeta() *Meta { return r.Meta }
 func (r *BreakStatement) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(r.LeadingComment())
-	buf.WriteString(indent(r.Nest) + "break;")
-	buf.WriteString(r.TrailingComment())
+	buf.WriteString(r.LeadingComment(lineFeed))
+	buf.WriteString(indent(r.Nest) + "break")
+	buf.WriteString(paddingLeft(r.InfixComment(inline)))
+	buf.WriteString(";")
+	buf.WriteString(r.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()

--- a/ast/break_statement_test.go
+++ b/ast/break_statement_test.go
@@ -6,14 +6,12 @@ import (
 
 func TestBreakStatement(t *testing.T) {
 	brk := &BreakStatement{
-		Meta: New(T, 0, comments("// This is comment"), comments("// This is comment")),
+		Meta: New(T, 0, comments("// leading comment"), comments("// trailing comment"), comments("/* infix comment */")),
 	}
 
-	expect := `// This is comment
-break; // This is comment
+	expect := `// leading comment
+break /* infix comment */; // trailing comment
 `
 
-	if brk.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, brk.String())
-	}
+	assert(t, brk.String(), expect)
 }

--- a/ast/call_statement.go
+++ b/ast/call_statement.go
@@ -14,9 +14,9 @@ func (c *CallStatement) GetMeta() *Meta { return c.Meta }
 func (c *CallStatement) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(c.LeadingComment())
+	buf.WriteString(c.LeadingComment(lineFeed))
 	buf.WriteString(indent(c.Nest) + "call " + c.Subroutine.String() + ";")
-	buf.WriteString(c.TrailingComment())
+	buf.WriteString(c.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()

--- a/ast/call_statement_test.go
+++ b/ast/call_statement_test.go
@@ -6,18 +6,16 @@ import (
 
 func TestCallStatement(t *testing.T) {
 	call := &CallStatement{
-		Meta: New(T, 0, comments("// This is comment"), comments("// This is comment")),
+		Meta: New(T, 0, comments("// leading comment"), comments("// trailing comment")),
 		Subroutine: &Ident{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments("/* before_subroutine */"), comments("/* after_subroutine */")),
 			Value: "mod_recv",
 		},
 	}
 
-	expect := `// This is comment
-call mod_recv; // This is comment
+	expect := `// leading comment
+call /* before_subroutine */ mod_recv /* after_subroutine */; // trailing comment
 `
 
-	if call.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, call.String())
-	}
+	assert(t, call.String(), expect)
 }

--- a/ast/case_statement.go
+++ b/ast/case_statement.go
@@ -16,9 +16,11 @@ func (s *CaseStatement) GetMeta() *Meta { return s.Meta }
 func (s *CaseStatement) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(s.LeadingComment())
+	buf.WriteString(s.LeadingComment(lineFeed))
 	if s.Test != nil {
-		buf.WriteString("case ")
+		buf.WriteString("case")
+		buf.WriteString(paddingLeft(s.InfixComment(inline)))
+		buf.WriteString(" ")
 		if s.Test.Operator == "~" {
 			buf.WriteString("~")
 		}
@@ -27,7 +29,7 @@ func (s *CaseStatement) String() string {
 	} else {
 		buf.WriteString("default:")
 	}
-	buf.WriteString(s.TrailingComment())
+	buf.WriteString(s.TrailingComment(inline))
 	buf.WriteString("\n")
 	for _, stmt := range s.Statements {
 		buf.WriteString(indent(s.Nest) + stmt.String())

--- a/ast/declare_statement.go
+++ b/ast/declare_statement.go
@@ -15,12 +15,14 @@ func (d *DeclareStatement) GetMeta() *Meta { return d.Meta }
 func (d *DeclareStatement) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(d.LeadingComment())
-	buf.WriteString(indent(d.Nest) + "declare local ")
-	buf.WriteString(d.Name.String())
-	buf.WriteString(" ")
+	buf.WriteString(d.LeadingComment(lineFeed))
+	buf.WriteString(indent(d.Nest))
+	buf.WriteString("declare")
+	buf.WriteString(paddingLeft(d.InfixComment(inline)))
+	buf.WriteString(" local")
+	buf.WriteString(padding(d.Name.String()))
 	buf.WriteString(d.ValueType.String() + ";")
-	buf.WriteString(d.TrailingComment())
+	buf.WriteString(d.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()

--- a/ast/declare_statement_test.go
+++ b/ast/declare_statement_test.go
@@ -6,22 +6,20 @@ import (
 
 func TestDeclareStatement(t *testing.T) {
 	declare := &DeclareStatement{
-		Meta: New(T, 0, comments("// This is comment"), comments("// This is comment")),
+		Meta: New(T, 0, comments("// leading comment"), comments("// trailing comment"), comments("/* before_local */")),
 		Name: &Ident{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments("/* before_name */"), comments("/* after_name */")),
 			Value: "var.Foo",
 		},
 		ValueType: &Ident{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments(), comments("/* after_type */")),
 			Value: "STRING",
 		},
 	}
 
-	expect := `// This is comment
-declare local var.Foo STRING; // This is comment
+	expect := `// leading comment
+declare /* before_local */ local /* before_name */ var.Foo /* after_name */ STRING /* after_type */; // trailing comment
 `
 
-	if declare.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, declare.String())
-	}
+	assert(t, declare.String(), expect)
 }

--- a/ast/director_declaration.go
+++ b/ast/director_declaration.go
@@ -16,7 +16,7 @@ func (d *DirectorDeclaration) GetMeta() *Meta { return d.Meta }
 func (d *DirectorDeclaration) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(d.LeadingComment())
+	buf.WriteString(d.LeadingComment(lineFeed))
 	buf.WriteString("director ")
 	buf.WriteString(d.Name.String())
 	if d.DirectorType != nil {
@@ -26,8 +26,11 @@ func (d *DirectorDeclaration) String() string {
 	for _, prop := range d.Properties {
 		buf.WriteString(prop.String())
 	}
+	if v := d.InfixComment(lineFeed); v != "" {
+		buf.WriteString("  " + v)
+	}
 	buf.WriteString("}")
-	buf.WriteString(d.TrailingComment())
+	buf.WriteString(d.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()
@@ -44,12 +47,12 @@ func (d *DirectorProperty) GetMeta() *Meta { return d.Meta }
 func (d *DirectorProperty) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(d.LeadingComment())
+	buf.WriteString(d.LeadingComment(lineFeed))
 	buf.WriteString(indent(d.Nest) + "." + d.Key.String())
 	buf.WriteString(" = ")
 	buf.WriteString(d.Value.String())
 	buf.WriteString(";")
-	buf.WriteString(d.TrailingComment())
+	buf.WriteString(d.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()
@@ -65,16 +68,23 @@ func (d *DirectorBackendObject) GetMeta() *Meta { return d.Meta }
 func (d *DirectorBackendObject) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(d.LeadingComment())
+	buf.WriteString(d.LeadingComment(lineFeed))
 	buf.WriteString(indent(d.Nest) + "{")
 	for _, v := range d.Values {
-		buf.WriteString(" ." + v.Key.String())
-		buf.WriteString(" = ")
-		buf.WriteString(v.Value.String())
+		buf.WriteString(paddingLeft(v.Key.LeadingComment(inline)))
+		buf.WriteString(" .")
+		buf.WriteString(paddingRight(v.Key.Value))
+		buf.WriteString(paddingRight(v.Key.TrailingComment(inline)))
+		buf.WriteString("=")
+		buf.WriteString(paddingLeft(v.Value.String()))
 		buf.WriteString(";")
+		buf.WriteString(v.TrailingComment(inline))
+	}
+	if v := d.InfixComment(inline); v != "" {
+		buf.WriteString(paddingLeft(v))
 	}
 	buf.WriteString(" }")
-	buf.WriteString(d.TrailingComment())
+	buf.WriteString(d.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()

--- a/ast/director_declaration_test.go
+++ b/ast/director_declaration_test.go
@@ -6,38 +6,38 @@ import (
 
 func TestDirectorDeclaration(t *testing.T) {
 	director := &DirectorDeclaration{
-		Meta: New(T, 0, comments("// This is comment"), comments("// This is comment")),
+		Meta: New(T, 0, comments("// leading comment"), comments("// trailing comment"), comments("// infix comment")),
 		Name: &Ident{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments("/* before_name */"), comments("/* after_name */")),
 			Value: "example",
 		},
 		DirectorType: &Ident{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments(), comments("/* after_type */")),
 			Value: "client",
 		},
 		Properties: []Expression{
 			&DirectorProperty{
 				Meta: New(T, 1, comments("// This is comment", "# This is another comment"), comments("// This is comment")),
 				Key: &Ident{
-					Meta:  New(T, 0),
+					Meta:  New(T, 0, comments(), comments("/* after_name */")),
 					Value: "quorum",
 				},
 				Value: &PostfixExpression{
-					Meta: New(T, 0),
+					Meta: New(T, 0, comments(), comments("/* after_value */")),
 					Left: &Integer{
-						Meta:  New(T, 0),
+						Meta:  New(T, 0, comments("/* before_value */")),
 						Value: 20,
 					},
 					Operator: "%",
 				},
 			},
 			&DirectorBackendObject{
-				Meta: New(T, 1, comments("// This is comment", "# This is another comment"), comments("// This is comment")),
+				Meta: New(T, 1, comments("// This is comment", "# This is another comment"), comments("// This is comment"), comments("/* trail_brace */")),
 				Values: []*DirectorProperty{
 					{
-						Meta: New(T, 1, comments("// This is comment", "# This is another comment"), comments("// This is comment")),
+						Meta: New(T, 1),
 						Key: &Ident{
-							Meta:  New(T, 0),
+							Meta:  New(T, 0, comments("/* inside_brace */")),
 							Value: "request",
 						},
 						Value: &String{
@@ -46,13 +46,13 @@ func TestDirectorDeclaration(t *testing.T) {
 						},
 					},
 					{
-						Meta: New(T, 1, comments("// This is comment", "# This is another comment"), comments("// This is comment")),
+						Meta: New(T, 1),
 						Key: &Ident{
-							Meta:  New(T, 0),
+							Meta:  New(T, 0, comments("/* leading */"), comments("/* after_name */")),
 							Value: "weight",
 						},
 						Value: &Integer{
-							Meta:  New(T, 0),
+							Meta:  New(T, 0, comments("/* before_value */"), comments("/* after_value */")),
 							Value: 1,
 						},
 					},
@@ -61,18 +61,17 @@ func TestDirectorDeclaration(t *testing.T) {
 		},
 	}
 
-	expect := `// This is comment
-director example client {
+	expect := `// leading comment
+director /* before_name */ example /* after_name */ client /* after_type */ {
   // This is comment
   # This is another comment
-  .quorum = 20%; // This is comment
+  .quorum /* after_name */ = /* before_value */ 20% /* after_value */; // This is comment
   // This is comment
   # This is another comment
-  { .request = "GET / HTTP/1.1"; .weight = 1; } // This is comment
-} // This is comment
+  { /* inside_brace */ .request = "GET / HTTP/1.1"; /* leading */ .weight /* after_name */ = /* before_value */ 1 /* after_value */; /* trail_brace */ } // This is comment
+  // infix comment
+} // trailing comment
 `
 
-	if director.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, director.String())
-	}
+	assert(t, director.String(), expect)
 }

--- a/ast/error_statement.go
+++ b/ast/error_statement.go
@@ -15,13 +15,13 @@ func (e *ErrorStatement) GetMeta() *Meta { return e.Meta }
 func (e *ErrorStatement) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(e.LeadingComment())
+	buf.WriteString(e.LeadingComment(lineFeed))
 	buf.WriteString(indent(e.Nest) + "error " + e.Code.String())
 	if e.Argument != nil {
 		buf.WriteString(" " + e.Argument.String())
 	}
 	buf.WriteString(";")
-	buf.WriteString(e.TrailingComment())
+	buf.WriteString(e.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()

--- a/ast/error_statement_test.go
+++ b/ast/error_statement_test.go
@@ -8,20 +8,17 @@ func TestErrorStatement(t *testing.T) {
 	e := &ErrorStatement{
 		Meta: New(T, 0, comments("// This is comment"), comments("// This is comment")),
 		Code: &Ident{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments("/* before_code */")),
 			Value: "200",
 		},
 		Argument: &String{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments("/* before_argument */"), comments("/* after_argument */")),
 			Value: "/foobar",
 		},
 	}
 
 	expect := `// This is comment
-error 200 "/foobar"; // This is comment
+error /* before_code */ 200 /* before_argument */ "/foobar" /* after_argument */; // This is comment
 `
-
-	if e.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, e.String())
-	}
+	assert(t, e.String(), expect)
 }

--- a/ast/esi_statement.go
+++ b/ast/esi_statement.go
@@ -13,9 +13,11 @@ func (e *EsiStatement) GetMeta() *Meta { return e.Meta }
 func (e *EsiStatement) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(e.LeadingComment())
-	buf.WriteString(indent(e.Nest) + "esi;")
-	buf.WriteString(e.TrailingComment())
+	buf.WriteString(e.LeadingComment(lineFeed))
+	buf.WriteString(indent(e.Nest) + "esi")
+	buf.WriteString(paddingLeft(e.InfixComment(inline)))
+	buf.WriteString(";")
+	buf.WriteString(e.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()

--- a/ast/esi_statement_test.go
+++ b/ast/esi_statement_test.go
@@ -6,14 +6,11 @@ import (
 
 func TestEsiStatement(t *testing.T) {
 	esi := &EsiStatement{
-		Meta: New(T, 0, comments("// This is comment"), comments("// This is comment")),
+		Meta: New(T, 0, comments("// leading comment"), comments("// trailing comment"), comments("/* infix comment */")),
 	}
 
-	expect := `// This is comment
-esi; // This is comment
+	expect := `// leading comment
+esi /* infix comment */; // trailing comment
 `
-
-	if esi.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, esi.String())
-	}
+	assert(t, esi.String(), expect)
 }

--- a/ast/fallthrough_statement.go
+++ b/ast/fallthrough_statement.go
@@ -13,9 +13,11 @@ func (r *FallthroughStatement) GetMeta() *Meta { return r.Meta }
 func (r *FallthroughStatement) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(r.LeadingComment())
-	buf.WriteString(indent(r.Nest) + "fallthrough;")
-	buf.WriteString(r.TrailingComment())
+	buf.WriteString(r.LeadingComment(lineFeed))
+	buf.WriteString(indent(r.Nest) + "fallthrough")
+	buf.WriteString(paddingLeft(r.InfixComment(inline)))
+	buf.WriteString(";")
+	buf.WriteString(r.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()

--- a/ast/fallthrough_statement_test.go
+++ b/ast/fallthrough_statement_test.go
@@ -6,14 +6,11 @@ import (
 
 func TestFallthroughStatement(t *testing.T) {
 	ft := &FallthroughStatement{
-		Meta: New(T, 0, comments("// This is comment"), comments("// This is comment")),
+		Meta: New(T, 0, comments("// leading comment"), comments("// trailing comment"), comments("/* infix comment */")),
 	}
 
-	expect := `// This is comment
-fallthrough; // This is comment
+	expect := `// leading comment
+fallthrough /* infix comment */; // trailing comment
 `
-
-	if ft.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, ft.String())
-	}
+	assert(t, ft.String(), expect)
 }

--- a/ast/functioncall_expression.go
+++ b/ast/functioncall_expression.go
@@ -15,7 +15,7 @@ func (f *FunctionCallExpression) GetMeta() *Meta { return f.Meta }
 func (f *FunctionCallExpression) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(f.LeadingInlineComment())
+	buf.WriteString(f.LeadingComment(inline))
 	buf.WriteString(f.Function.String() + "(")
 	for i, a := range f.Arguments {
 		buf.WriteString(a.String())
@@ -24,7 +24,7 @@ func (f *FunctionCallExpression) String() string {
 		}
 	}
 	buf.WriteString(")")
-	buf.WriteString(f.TrailingComment())
+	buf.WriteString(f.TrailingComment(inline))
 
 	return buf.String()
 }

--- a/ast/functioncall_expression_test.go
+++ b/ast/functioncall_expression_test.go
@@ -6,22 +6,19 @@ import (
 
 func TestFunctionCallExpression(t *testing.T) {
 	fn := &FunctionCallExpression{
-		Meta: New(T, 0, comments("/* This is comment */"), comments("/* This is comment */")),
+		Meta: New(T, 0, comments("/* leading */"), comments("/* trailing */")),
 		Function: &Ident{
 			Meta:  New(T, 0),
 			Value: "url.pathname",
 		},
 		Arguments: []Expression{
 			&String{
-				Meta:  New(T, 0),
+				Meta:  New(T, 0, comments("/* before_arg */"), comments("/* after_arg */")),
 				Value: "/foo",
 			},
 		},
 	}
 
-	expect := `/* This is comment */ url.pathname("/foo") /* This is comment */`
-
-	if fn.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, fn.String())
-	}
+	expect := `/* leading */ url.pathname(/* before_arg */ "/foo" /* after_arg */) /* trailing */`
+	assert(t, fn.String(), expect)
 }

--- a/ast/functioncall_statement.go
+++ b/ast/functioncall_statement.go
@@ -6,9 +6,8 @@ import (
 
 type FunctionCallStatement struct {
 	*Meta
-	Function                   *Ident
-	Arguments                  []Expression
-	ParenthesisTrailingComment Comments
+	Function  *Ident
+	Arguments []Expression
 }
 
 func (fc *FunctionCallStatement) statement()     {}
@@ -16,7 +15,7 @@ func (fc *FunctionCallStatement) GetMeta() *Meta { return fc.Meta }
 func (fc *FunctionCallStatement) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(fc.LeadingInlineComment())
+	buf.WriteString(fc.LeadingComment(lineFeed))
 	buf.WriteString(fc.Function.String() + "(")
 	for i, a := range fc.Arguments {
 		buf.WriteString(a.String())
@@ -25,11 +24,11 @@ func (fc *FunctionCallStatement) String() string {
 		}
 	}
 	buf.WriteString(")")
-	if v := fc.ParenthesisTrailingComment.String(); v != "" {
-		buf.WriteString(" " + v)
+	if v := fc.InfixComment(inline); v != "" {
+		buf.WriteString(paddingLeft(v))
 	}
 	buf.WriteString(";")
-	buf.WriteString(fc.TrailingComment())
+	buf.WriteString(fc.TrailingComment(inline))
 
 	return buf.String()
 }

--- a/ast/functioncall_statement.go
+++ b/ast/functioncall_statement.go
@@ -6,8 +6,9 @@ import (
 
 type FunctionCallStatement struct {
 	*Meta
-	Function  *Ident
-	Arguments []Expression
+	Function                   *Ident
+	Arguments                  []Expression
+	ParenthesisTrailingComment Comments
 }
 
 func (fc *FunctionCallStatement) statement()     {}
@@ -24,6 +25,10 @@ func (fc *FunctionCallStatement) String() string {
 		}
 	}
 	buf.WriteString(")")
+	if v := fc.ParenthesisTrailingComment.String(); v != "" {
+		buf.WriteString(" " + v)
+	}
+	buf.WriteString(";")
 	buf.WriteString(fc.TrailingComment())
 
 	return buf.String()

--- a/ast/functioncall_statement_test.go
+++ b/ast/functioncall_statement_test.go
@@ -6,26 +6,25 @@ import (
 
 func TestFunctionCallStatement(t *testing.T) {
 	fn := &FunctionCallStatement{
-		Meta: New(T, 0, comments("/* This is comment */"), comments("/* This is comment */")),
+		Meta: New(T, 0, comments("/* leading comment */"), comments("/* trailing comment */"), comments("/* infix comment */")),
 		Function: &Ident{
 			Meta:  New(T, 0),
 			Value: "std.collect",
 		},
 		Arguments: []Expression{
 			&String{
-				Meta:  New(T, 0),
+				Meta:  New(T, 0, comments("/* before_arg1 */"), comments("/* after_arg1 */")),
 				Value: "req.http.Cookie",
 			},
 			&String{
-				Meta:  New(T, 0),
+				Meta:  New(T, 0, comments("/* before_arg2 */"), comments("/* after_arg2 */")),
 				Value: ";",
 			},
 		},
 	}
 
-	expect := `/* This is comment */ std.collect("req.http.Cookie", ";"); /* This is comment */`
+	expect := `/* leading comment */
+std.collect(/* before_arg1 */ "req.http.Cookie" /* after_arg1 */, /* before_arg2 */ ";" /* after_arg2 */) /* infix comment */; /* trailing comment */`
 
-	if fn.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, fn.String())
-	}
+	assert(t, fn.String(), expect)
 }

--- a/ast/functioncall_statement_test.go
+++ b/ast/functioncall_statement_test.go
@@ -23,7 +23,7 @@ func TestFunctionCallStatement(t *testing.T) {
 		},
 	}
 
-	expect := `/* This is comment */ std.collect("req.http.Cookie", ";") /* This is comment */`
+	expect := `/* This is comment */ std.collect("req.http.Cookie", ";"); /* This is comment */`
 
 	if fn.String() != expect {
 		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, fn.String())

--- a/ast/goto_destination_statement.go
+++ b/ast/goto_destination_statement.go
@@ -14,9 +14,9 @@ func (gd *GotoDestinationStatement) GetMeta() *Meta { return gd.Meta }
 func (gd *GotoDestinationStatement) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(gd.LeadingComment())
+	buf.WriteString(gd.LeadingComment(lineFeed))
 	buf.WriteString(indent(gd.Nest) + gd.Name.Value)
-	buf.WriteString(gd.TrailingComment())
+	buf.WriteString(gd.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()

--- a/ast/goto_destination_statement_test.go
+++ b/ast/goto_destination_statement_test.go
@@ -6,18 +6,15 @@ import (
 
 func TestGotoDestinationStatement(t *testing.T) {
 	g := &GotoDestinationStatement{
-		Meta: New(T, 0, comments("// This is comment"), comments("// This is comment")),
+		Meta: New(T, 0, comments("// leading comment"), comments("// trailing comment")),
 		Name: &Ident{
 			Meta:  New(T, 0),
 			Value: "update_and_set:",
 		},
 	}
 
-	expect := `// This is comment
-update_and_set: // This is comment
+	expect := `// leading comment
+update_and_set: // trailing comment
 `
-
-	if g.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, g.String())
-	}
+	assert(t, g.String(), expect)
 }

--- a/ast/goto_statement.go
+++ b/ast/goto_statement.go
@@ -14,9 +14,11 @@ func (g *GotoStatement) GetMeta() *Meta { return g.Meta }
 func (g *GotoStatement) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(g.LeadingComment())
-	buf.WriteString(indent(g.Nest) + "goto " + g.Destination.String() + ";")
-	buf.WriteString(g.TrailingComment())
+	buf.WriteString(g.LeadingComment(lineFeed))
+	buf.WriteString(indent(g.Nest) + "goto")
+	buf.WriteString(paddingLeft(g.Destination.String()))
+	buf.WriteString(";")
+	buf.WriteString(g.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()

--- a/ast/goto_statement_test.go
+++ b/ast/goto_statement_test.go
@@ -6,18 +6,15 @@ import (
 
 func TestGotoStatement(t *testing.T) {
 	g := &GotoStatement{
-		Meta: New(T, 0, comments("// This is comment"), comments("// This is comment")),
+		Meta: New(T, 0, comments("// leading comment"), comments("// trailing comment")),
 		Destination: &Ident{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments("/* before_name */"), comments("/* after_name */")),
 			Value: "update_and_set",
 		},
 	}
 
-	expect := `// This is comment
-goto update_and_set; // This is comment
+	expect := `// leading comment
+goto /* before_name */ update_and_set /* after_name */; // trailing comment
 `
-
-	if g.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, g.String())
-	}
+	assert(t, g.String(), expect)
 }

--- a/ast/if_expression.go
+++ b/ast/if_expression.go
@@ -16,15 +16,17 @@ func (i *IfExpression) GetMeta() *Meta { return i.Meta }
 func (i *IfExpression) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(i.LeadingInlineComment())
-	buf.WriteString("if(")
+	buf.WriteString(i.LeadingComment(inline))
+	buf.WriteString("if")
+	buf.WriteString(i.InfixComment(inline))
+	buf.WriteString("(")
 	buf.WriteString(i.Condition.String())
 	buf.WriteString(", ")
 	buf.WriteString(i.Consequence.String())
 	buf.WriteString(", ")
 	buf.WriteString(i.Alternative.String())
 	buf.WriteString(")")
-	buf.WriteString(i.TrailingComment())
+	buf.WriteString(i.TrailingComment(inline))
 
 	return buf.String()
 }

--- a/ast/if_expression_test.go
+++ b/ast/if_expression_test.go
@@ -6,24 +6,21 @@ import (
 
 func TestIfExpression(t *testing.T) {
 	ife := &IfExpression{
-		Meta: New(T, 0, comments("/* This is comment */"), comments("/* This is comment */")),
+		Meta: New(T, 0, comments("/* leading */"), comments("/* trailing */")),
 		Condition: &Ident{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments("/* before_condition */"), comments("/* after_condition */")),
 			Value: "req.http.Host",
 		},
 		Consequence: &String{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments("/* before_consequence */"), comments("/* after_consequence */")),
 			Value: "/foo",
 		},
 		Alternative: &String{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments("/* before_alternative */"), comments("/* after_alternative */")),
 			Value: "/bar",
 		},
 	}
 
-	expect := `/* This is comment */ if(req.http.Host, "/foo", "/bar") /* This is comment */`
-
-	if ife.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, ife.String())
-	}
+	expect := `/* leading */ if(/* before_condition */ req.http.Host /* after_condition */, /* before_consequence */ "/foo" /* after_consequence */, /* before_alternative */ "/bar" /* after_alternative */) /* trailing */`
+	assert(t, ife.String(), expect)
 }

--- a/ast/if_statement.go
+++ b/ast/if_statement.go
@@ -17,27 +17,41 @@ func (i *IfStatement) statement()     {}
 func (i *IfStatement) GetMeta() *Meta { return i.Meta }
 func (i *IfStatement) String() string {
 	var buf bytes.Buffer
+	var tmp Comments
 
-	buf.WriteString(i.LeadingComment())
-	buf.WriteString(indent(i.Nest) + i.Keyword + " (")
+	buf.WriteString(i.LeadingComment(lineFeed))
+	buf.WriteString(indent(i.Nest) + i.Keyword)
+	buf.WriteString(paddingLeft(i.InfixComment(inline)))
+	buf.WriteString(" (")
 	buf.WriteString(i.Condition.String())
-	buf.WriteString(") ")
+	buf.WriteString(")")
+	buf.WriteString(paddingLeft(i.Consequence.LeadingComment(inline)))
+	buf.WriteString(" ")
+	tmp = i.Consequence.Leading
+	i.Consequence.Leading = Comments{}
 	buf.WriteString(i.Consequence.String())
+	i.Consequence.Leading = tmp
 
 	for _, a := range i.Another {
 		buf.WriteString("\n")
-		buf.WriteString(a.LeadingComment())
-		buf.WriteString(indent(i.Nest) + "else if (")
+		buf.WriteString(a.LeadingComment(lineFeed))
+		buf.WriteString(indent(i.Nest) + "else if")
+		buf.WriteString(paddingLeft(a.InfixComment(inline)))
+		buf.WriteString(" (")
 		buf.WriteString(a.Condition.String())
-		buf.WriteString(") ")
+		buf.WriteString(")")
+		buf.WriteString(paddingLeft(a.Consequence.LeadingComment(inline)))
+		buf.WriteString(" ")
+		a.Consequence.Leading = Comments{}
 		buf.WriteString(a.Consequence.String())
-		buf.WriteString(a.TrailingComment())
+		a.Consequence.Leading = tmp
+		buf.WriteString(a.TrailingComment(inline))
 	}
 	if i.Alternative != nil {
 		buf.WriteString("\n")
 		buf.WriteString(i.Alternative.String())
 	}
-	buf.WriteString(i.TrailingComment())
+	buf.WriteString(i.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()
@@ -53,8 +67,10 @@ func (e *ElseStatement) GetMeta() *Meta { return e.Meta }
 func (e *ElseStatement) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(e.LeadingComment())
-	buf.WriteString(indent(e.Nest) + "else ")
+	buf.WriteString(e.LeadingComment(lineFeed))
+	buf.WriteString(indent(e.Nest) + "else")
+	buf.WriteString(paddingLeft(e.InfixComment(inline)))
+	buf.WriteString(" ")
 	buf.WriteString(e.Consequence.String())
 
 	return buf.String()

--- a/ast/if_statement.go
+++ b/ast/if_statement.go
@@ -6,11 +6,11 @@ import (
 
 type IfStatement struct {
 	*Meta
-	Condition           Expression
-	Consequence         *BlockStatement
-	Another             []*IfStatement
-	Alternative         *BlockStatement
-	AlternativeComments Comments
+	Keyword     string
+	Condition   Expression
+	Consequence *BlockStatement
+	Another     []*IfStatement
+	Alternative *ElseStatement
 }
 
 func (i *IfStatement) statement()     {}
@@ -19,7 +19,7 @@ func (i *IfStatement) String() string {
 	var buf bytes.Buffer
 
 	buf.WriteString(i.LeadingComment())
-	buf.WriteString(indent(i.Nest) + "if (")
+	buf.WriteString(indent(i.Nest) + i.Keyword + " (")
 	buf.WriteString(i.Condition.String())
 	buf.WriteString(") ")
 	buf.WriteString(i.Consequence.String())
@@ -35,8 +35,6 @@ func (i *IfStatement) String() string {
 	}
 	if i.Alternative != nil {
 		buf.WriteString("\n")
-		buf.WriteString(i.alternativeComments())
-		buf.WriteString(indent(i.Nest) + "else ")
 		buf.WriteString(i.Alternative.String())
 	}
 	buf.WriteString(i.TrailingComment())
@@ -45,15 +43,19 @@ func (i *IfStatement) String() string {
 	return buf.String()
 }
 
-func (i *IfStatement) alternativeComments() string {
-	if len(i.AlternativeComments) == 0 {
-		return ""
-	}
+type ElseStatement struct {
+	*Meta
+	Consequence *BlockStatement
+}
+
+func (e *ElseStatement) statement()     {}
+func (e *ElseStatement) GetMeta() *Meta { return e.Meta }
+func (e *ElseStatement) String() string {
 	var buf bytes.Buffer
 
-	for _, v := range i.AlternativeComments {
-		buf.WriteString(indent(i.Nest) + v.String() + "\n")
-	}
+	buf.WriteString(e.LeadingComment())
+	buf.WriteString(indent(e.Nest) + "else ")
+	buf.WriteString(e.Consequence.String())
 
 	return buf.String()
 }

--- a/ast/if_statement_test.go
+++ b/ast/if_statement_test.go
@@ -36,16 +36,14 @@ func TestIfStatement(t *testing.T) {
 				},
 			},
 		},
-		AlternativeComments: Comments{
-			{
-				Value: "// This is comment",
-			},
-		},
-		Alternative: &BlockStatement{
+		Alternative: &ElseStatement{
 			Meta: New(T, 0, comments("// This is comment"), comments("/* This is comment */")),
-			Statements: []Statement{
-				&EsiStatement{
-					Meta: New(T, 1, comments("// This is comment"), comments("/* This is comment */")),
+			Consequence: &BlockStatement{
+				Meta: New(T, 0),
+				Statements: []Statement{
+					&EsiStatement{
+						Meta: New(T, 1, comments("// This is comment"), comments("/* This is comment */")),
+					},
 				},
 			},
 		},

--- a/ast/if_statement_test.go
+++ b/ast/if_statement_test.go
@@ -6,20 +6,22 @@ import (
 
 func TestIfStatement(t *testing.T) {
 	ifs := &IfStatement{
-		Meta: New(T, 0, comments("// This is comment"), comments("/* This is comment */")),
+		Meta:    New(T, 0, comments("// This is comment"), comments("/* This is comment */"), comments("/* infix */")),
+		Keyword: "if",
 		Condition: &Ident{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments("/* before_condition */"), comments("/* after_condition */")),
 			Value: "req.http.Host",
 		},
 		Another: []*IfStatement{
 			{
-				Meta: New(T, 0, comments("// This is comment"), comments("/* This is comment */")),
+				Meta:    New(T, 0, comments("// This is comment"), comments("/* This is comment */"), comments("/* infix */")),
+				Keyword: "else if",
 				Condition: &Ident{
-					Meta:  New(T, 0),
+					Meta:  New(T, 0, comments("/* before_condition */"), comments("/* after_condition */")),
 					Value: "req.http.Host",
 				},
 				Consequence: &BlockStatement{
-					Meta: New(T, 0, comments("// This is comment"), comments("/* This is comment */")),
+					Meta: New(T, 0, comments("/* before_block */"), comments("/* This is comment */")),
 					Statements: []Statement{
 						&EsiStatement{
 							Meta: New(T, 1, comments("// This is comment"), comments("/* This is comment */")),
@@ -29,7 +31,7 @@ func TestIfStatement(t *testing.T) {
 			},
 		},
 		Consequence: &BlockStatement{
-			Meta: New(T, 0, comments("// This is comment"), comments("/* This is comment */")),
+			Meta: New(T, 0, comments("/* before_block */")),
 			Statements: []Statement{
 				&EsiStatement{
 					Meta: New(T, 1, comments("// This is comment"), comments("/* This is comment */")),
@@ -37,7 +39,7 @@ func TestIfStatement(t *testing.T) {
 			},
 		},
 		Alternative: &ElseStatement{
-			Meta: New(T, 0, comments("// This is comment"), comments("/* This is comment */")),
+			Meta: New(T, 0, comments("// This is comment"), comments("/* This is comment */"), comments("/* infix */")),
 			Consequence: &BlockStatement{
 				Meta: New(T, 0),
 				Statements: []Statement{
@@ -50,23 +52,21 @@ func TestIfStatement(t *testing.T) {
 	}
 
 	expect := `// This is comment
-if (req.http.Host) {
+if /* infix */ (/* before_condition */ req.http.Host /* after_condition */) /* before_block */ {
   // This is comment
   esi; /* This is comment */
 }
 // This is comment
-else if (req.http.Host) {
+else if /* infix */ (/* before_condition */ req.http.Host /* after_condition */) /* before_block */ {
   // This is comment
   esi; /* This is comment */
 } /* This is comment */
 // This is comment
-else {
+else /* infix */ {
   // This is comment
   esi; /* This is comment */
 } /* This is comment */
 `
 
-	if ifs.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, ifs.String())
-	}
+	assert(t, ifs.String(), expect)
 }

--- a/ast/import_statement.go
+++ b/ast/import_statement.go
@@ -14,9 +14,9 @@ func (i *ImportStatement) GetMeta() *Meta { return i.Meta }
 func (i *ImportStatement) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(i.LeadingComment())
-	buf.WriteString(indent(i.Nest) + "import " + i.Name.String() + ";")
-	buf.WriteString(i.TrailingComment())
+	buf.WriteString(i.LeadingComment(lineFeed))
+	buf.WriteString(indent(i.Nest) + "import" + paddingLeft(i.Name.String()) + ";")
+	buf.WriteString(i.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()

--- a/ast/import_statement_test.go
+++ b/ast/import_statement_test.go
@@ -6,18 +6,16 @@ import (
 
 func TestImportStatement(t *testing.T) {
 	is := &ImportStatement{
-		Meta: New(T, 0, comments("// This is comment"), comments("// This is comment")),
+		Meta: New(T, 0, comments("// leading comment"), comments("// leading comment")),
 		Name: &Ident{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments("/* before_name */"), comments("/* after_name */")),
 			Value: "boltsort",
 		},
 	}
 
-	expect := `// This is comment
-import boltsort; // This is comment
+	expect := `// leading comment
+import /* before_name */ boltsort /* after_name */; // leading comment
 `
 
-	if is.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, is.String())
-	}
+	assert(t, is.String(), expect)
 }

--- a/ast/include_statement.go
+++ b/ast/include_statement.go
@@ -14,9 +14,9 @@ func (i *IncludeStatement) GetMeta() *Meta { return i.Meta }
 func (i *IncludeStatement) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(i.LeadingComment())
-	buf.WriteString(indent(i.Nest) + "include " + i.Module.String() + ";")
-	buf.WriteString(i.TrailingComment())
+	buf.WriteString(i.LeadingComment(lineFeed))
+	buf.WriteString(indent(i.Nest) + "include" + paddingLeft(i.Module.String()) + ";")
+	buf.WriteString(i.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()

--- a/ast/include_statement_test.go
+++ b/ast/include_statement_test.go
@@ -6,18 +6,15 @@ import (
 
 func TestIncludeStatement(t *testing.T) {
 	is := &IncludeStatement{
-		Meta: New(T, 0, comments("// This is comment"), comments("// This is comment")),
+		Meta: New(T, 0, comments("// leading comment"), comments("// trailing comment")),
 		Module: &String{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments("/* before_name */"), comments("/* after_name */")),
 			Value: "mod_recv",
 		},
 	}
 
-	expect := `// This is comment
-include "mod_recv"; // This is comment
+	expect := `// leading comment
+include /* before_name */ "mod_recv" /* after_name */; // trailing comment
 `
-
-	if is.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, is.String())
-	}
+	assert(t, is.String(), expect)
 }

--- a/ast/log_statement.go
+++ b/ast/log_statement.go
@@ -14,9 +14,9 @@ func (l *LogStatement) GetMeta() *Meta { return l.Meta }
 func (l *LogStatement) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(l.LeadingComment())
-	buf.WriteString(indent(l.Nest) + "log " + l.Value.String() + ";")
-	buf.WriteString(l.TrailingComment())
+	buf.WriteString(l.LeadingComment(lineFeed))
+	buf.WriteString(indent(l.Nest) + "log" + paddingLeft(l.Value.String()) + ";")
+	buf.WriteString(l.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()

--- a/ast/log_statement_test.go
+++ b/ast/log_statement_test.go
@@ -6,18 +6,15 @@ import (
 
 func TestLogStatement(t *testing.T) {
 	log := &LogStatement{
-		Meta: New(T, 0, comments("// This is comment"), comments("// This is comment")),
+		Meta: New(T, 0, comments("// leading comment"), comments("// trailing comment")),
 		Value: &String{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments("/* before_name */"), comments("/* after_name */")),
 			Value: "foobar",
 		},
 	}
 
-	expect := `// This is comment
-log "foobar"; // This is comment
+	expect := `// leading comment
+log /* before_name */ "foobar" /* after_name */; // trailing comment
 `
-
-	if log.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, log.String())
-	}
+	assert(t, log.String(), expect)
 }

--- a/ast/penaltybox_declaration.go
+++ b/ast/penaltybox_declaration.go
@@ -13,11 +13,11 @@ func (p *PenaltyboxDeclaration) GetMeta() *Meta { return p.Meta }
 func (p *PenaltyboxDeclaration) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(p.LeadingComment())
-	buf.WriteString("penaltybox ")
-	buf.WriteString(p.Name.String())
-	buf.WriteString(" " + p.Block.String())
-	buf.WriteString(p.TrailingComment())
+	buf.WriteString(p.LeadingComment(lineFeed))
+	buf.WriteString("penaltybox")
+	buf.WriteString(padding(p.Name.String()))
+	buf.WriteString(p.Block.String())
+	buf.WriteString(p.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()

--- a/ast/penaltybox_declaration_test.go
+++ b/ast/penaltybox_declaration_test.go
@@ -8,20 +8,17 @@ func TestPenaltyboxStatement(t *testing.T) {
 	p := &PenaltyboxDeclaration{
 		Meta: New(T, 0, comments("// This is comment"), comments("/* This is comment */")),
 		Name: &Ident{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments("/* before_name */"), comments("/* after_name */")),
 			Value: "ip_pbox",
 		},
 		Block: &BlockStatement{
-			Meta: New(T, 0, comments("/* This is comment */")),
+			Meta: New(T, 0, comments(), comments("/* This is comment */")),
 		},
 	}
 
 	expect := `// This is comment
-penaltybox ip_pbox {
+penaltybox /* before_name */ ip_pbox /* after_name */ {
 } /* This is comment */
 `
-
-	if p.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, p.String())
-	}
+	assert(t, p.String(), expect)
 }

--- a/ast/postfix_expression.go
+++ b/ast/postfix_expression.go
@@ -17,6 +17,7 @@ func (i *PostfixExpression) String() string {
 
 	buf.WriteString(i.Left.String())
 	buf.WriteString(i.Operator)
+	buf.WriteString(paddingLeft(i.TrailingComment(inline)))
 
 	return buf.String()
 }

--- a/ast/prefix_expression.go
+++ b/ast/prefix_expression.go
@@ -16,7 +16,7 @@ func (p *PrefixExpression) String() string {
 	var buf bytes.Buffer
 
 	buf.WriteString("(")
-	buf.WriteString(p.LeadingInlineComment())
+	buf.WriteString(p.LeadingComment(inline))
 	buf.WriteString(p.Operator)
 	buf.WriteString(p.Right.String())
 	buf.WriteString(")")

--- a/ast/ratecounter_declaration.go
+++ b/ast/ratecounter_declaration.go
@@ -13,11 +13,11 @@ func (r *RatecounterDeclaration) GetMeta() *Meta { return r.Meta }
 func (r *RatecounterDeclaration) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(r.LeadingComment())
-	buf.WriteString("ratecounter ")
-	buf.WriteString(r.Name.String())
-	buf.WriteString(" " + r.Block.String())
-	buf.WriteString(r.TrailingComment())
+	buf.WriteString(r.LeadingComment(lineFeed))
+	buf.WriteString("ratecounter")
+	buf.WriteString(padding(r.Name.String()))
+	buf.WriteString(r.Block.String())
+	buf.WriteString(r.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()

--- a/ast/ratecounter_declaration_test.go
+++ b/ast/ratecounter_declaration_test.go
@@ -8,20 +8,18 @@ func TestRatecounterStatement(t *testing.T) {
 	r := &RatecounterDeclaration{
 		Meta: New(T, 0, comments("// This is comment"), comments("/* This is comment */")),
 		Name: &Ident{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments("/* before_name */"), comments("/* after_name */")),
 			Value: "requests_rate",
 		},
 		Block: &BlockStatement{
-			Meta: New(T, 0, comments("/* This is comment */")),
+			Meta: New(T, 0, comments(), comments("/* This is comment */")),
 		},
 	}
 
 	expect := `// This is comment
-ratecounter requests_rate {
+ratecounter /* before_name */ requests_rate /* after_name */ {
 } /* This is comment */
 `
 
-	if r.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, r.String())
-	}
+	assert(t, r.String(), expect)
 }

--- a/ast/remove_statement.go
+++ b/ast/remove_statement.go
@@ -14,9 +14,9 @@ func (r *RemoveStatement) GetMeta() *Meta { return r.Meta }
 func (r *RemoveStatement) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(r.LeadingComment())
-	buf.WriteString(indent(r.Nest) + "remove " + r.Ident.String() + ";")
-	buf.WriteString(r.TrailingComment())
+	buf.WriteString(r.LeadingComment(lineFeed))
+	buf.WriteString(indent(r.Nest) + "remove" + paddingLeft(r.Ident.String()) + ";")
+	buf.WriteString(r.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()

--- a/ast/remove_statement_test.go
+++ b/ast/remove_statement_test.go
@@ -8,16 +8,13 @@ func TestRemoveStatement(t *testing.T) {
 	remove := &RemoveStatement{
 		Meta: New(T, 0, comments("// This is comment"), comments("// This is comment")),
 		Ident: &Ident{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments("/* before_name */"), comments("/* after_name */")),
 			Value: "req.http.Foo",
 		},
 	}
 
 	expect := `// This is comment
-remove req.http.Foo; // This is comment
+remove /* before_name */ req.http.Foo /* after_name */; // This is comment
 `
-
-	if remove.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, remove.String())
-	}
+	assert(t, remove.String(), expect)
 }

--- a/ast/restart_statement.go
+++ b/ast/restart_statement.go
@@ -13,9 +13,11 @@ func (r *RestartStatement) GetMeta() *Meta { return r.Meta }
 func (r *RestartStatement) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(r.LeadingComment())
-	buf.WriteString(indent(r.Nest) + "restart;")
-	buf.WriteString(r.TrailingComment())
+	buf.WriteString(r.LeadingComment(lineFeed))
+	buf.WriteString(indent(r.Nest) + "restart")
+	buf.WriteString(paddingLeft(r.InfixComment(inline)))
+	buf.WriteString(";")
+	buf.WriteString(r.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()

--- a/ast/restart_statement_test.go
+++ b/ast/restart_statement_test.go
@@ -6,14 +6,12 @@ import (
 
 func TestRestartStatement(t *testing.T) {
 	restart := &RestartStatement{
-		Meta: New(T, 0, comments("// This is comment"), comments("// This is comment")),
+		Meta: New(T, 0, comments("// This is comment"), comments("// This is comment"), comments("/* infix */")),
 	}
 
 	expect := `// This is comment
-restart; // This is comment
+restart /* infix */; // This is comment
 `
 
-	if restart.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, restart.String())
-	}
+	assert(t, restart.String(), expect)
 }

--- a/ast/return_statement.go
+++ b/ast/return_statement.go
@@ -6,8 +6,10 @@ import (
 
 type ReturnStatement struct {
 	*Meta
-	ReturnExpression *Expression
-	HasParenthesis   bool
+	ReturnExpression            Expression
+	HasParenthesis              bool
+	ParenthesisLeadingComments  Comments
+	ParenthesisTrailingComments Comments
 }
 
 func (r *ReturnStatement) statement()     {}
@@ -17,7 +19,19 @@ func (r *ReturnStatement) String() string {
 
 	buf.WriteString(r.LeadingComment())
 	if r.ReturnExpression != nil {
-		buf.WriteString(indent(r.Nest) + "return(" + (*r.ReturnExpression).String() + ");")
+		if r.HasParenthesis {
+			buf.WriteString(indent(r.Nest) + "return ")
+			if v := r.ParenthesisLeadingComments.String(); v != "" {
+				buf.WriteString(v + " ")
+			}
+			buf.WriteString("(" + r.ReturnExpression.String() + ")")
+			if v := r.ParenthesisTrailingComments.String(); v != "" {
+				buf.WriteString(" " + v)
+			}
+			buf.WriteString(";")
+		} else {
+			buf.WriteString(indent(r.Nest) + "return " + r.ReturnExpression.String() + ";")
+		}
 	} else {
 		buf.WriteString(indent(r.Nest) + "return;")
 	}

--- a/ast/return_statement.go
+++ b/ast/return_statement.go
@@ -17,7 +17,7 @@ func (r *ReturnStatement) GetMeta() *Meta { return r.Meta }
 func (r *ReturnStatement) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(r.LeadingComment())
+	buf.WriteString(r.LeadingComment(lineFeed))
 	if r.ReturnExpression != nil {
 		if r.HasParenthesis {
 			buf.WriteString(indent(r.Nest) + "return ")
@@ -35,7 +35,7 @@ func (r *ReturnStatement) String() string {
 	} else {
 		buf.WriteString(indent(r.Nest) + "return;")
 	}
-	buf.WriteString(r.TrailingComment())
+	buf.WriteString(r.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()

--- a/ast/return_statement_test.go
+++ b/ast/return_statement_test.go
@@ -9,36 +9,34 @@ func TestReturnStatement(t *testing.T) {
 		r := &ReturnStatement{
 			Meta: New(T, 0, comments("// This is comment"), comments("// This is comment")),
 			ReturnExpression: &Ident{
-				Meta:  New(T, 0),
+				Meta:  New(T, 0, comments("/* before_state */"), comments("/* after_state */")),
 				Value: "pass",
 			},
 		}
 
 		expect := `// This is comment
-return pass; // This is comment
+return /* before_state */ pass /* after_state */; // This is comment
 `
 
-		if r.String() != expect {
-			t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, r.String())
-		}
+		assert(t, r.String(), expect)
 	})
 
 	t.Run("With parenthesis", func(t *testing.T) {
 		r := &ReturnStatement{
 			Meta: New(T, 0, comments("// This is comment"), comments("// This is comment")),
 			ReturnExpression: &Ident{
-				Meta:  New(T, 0),
+				Meta:  New(T, 0, comments("/* before_state */"), comments("/* after_state */")),
 				Value: "pass",
 			},
-			HasParenthesis: true,
+			HasParenthesis:              true,
+			ParenthesisLeadingComments:  comments("/* before_paren */"),
+			ParenthesisTrailingComments: comments("/* after_paren */"),
 		}
 
 		expect := `// This is comment
-return (pass); // This is comment
+return /* before_paren */ (/* before_state */ pass /* after_state */) /* after_paren */; // This is comment
 `
 
-		if r.String() != expect {
-			t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, r.String())
-		}
+		assert(t, r.String(), expect)
 	})
 }

--- a/ast/return_statement_test.go
+++ b/ast/return_statement_test.go
@@ -5,21 +5,40 @@ import (
 )
 
 func TestReturnStatement(t *testing.T) {
-	var rt Expression
-	rt = &Ident{
-		Meta:  New(T, 0),
-		Value: "pass",
-	}
-	r := &ReturnStatement{
-		Meta:             New(T, 0, comments("// This is comment"), comments("// This is comment")),
-		ReturnExpression: &rt,
-	}
+	t.Run("Without parenthesis", func(t *testing.T) {
+		r := &ReturnStatement{
+			Meta: New(T, 0, comments("// This is comment"), comments("// This is comment")),
+			ReturnExpression: &Ident{
+				Meta:  New(T, 0),
+				Value: "pass",
+			},
+		}
 
-	expect := `// This is comment
-return(pass); // This is comment
+		expect := `// This is comment
+return pass; // This is comment
 `
 
-	if r.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, r.String())
-	}
+		if r.String() != expect {
+			t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, r.String())
+		}
+	})
+
+	t.Run("With parenthesis", func(t *testing.T) {
+		r := &ReturnStatement{
+			Meta: New(T, 0, comments("// This is comment"), comments("// This is comment")),
+			ReturnExpression: &Ident{
+				Meta:  New(T, 0),
+				Value: "pass",
+			},
+			HasParenthesis: true,
+		}
+
+		expect := `// This is comment
+return (pass); // This is comment
+`
+
+		if r.String() != expect {
+			t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, r.String())
+		}
+	})
 }

--- a/ast/set_statement.go
+++ b/ast/set_statement.go
@@ -16,12 +16,12 @@ func (s *SetStatement) GetMeta() *Meta { return s.Meta }
 func (s *SetStatement) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(s.LeadingComment())
-	buf.WriteString(indent(s.Nest) + "set ")
-	buf.WriteString(s.Ident.String())
-	buf.WriteString(" " + s.Operator.String() + " ")
-	buf.WriteString(s.Value.String() + ";")
-	buf.WriteString(s.TrailingComment())
+	buf.WriteString(s.LeadingComment(lineFeed))
+	buf.WriteString(indent(s.Nest) + "set")
+	buf.WriteString(paddingLeft(s.Ident.String()))
+	buf.WriteString(" " + s.Operator.String())
+	buf.WriteString(paddingLeft(s.Value.String()) + ";")
+	buf.WriteString(s.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()

--- a/ast/set_statement_test.go
+++ b/ast/set_statement_test.go
@@ -8,23 +8,21 @@ func TestSetStatement(t *testing.T) {
 	set := &SetStatement{
 		Meta: New(T, 0, comments("// This is comment"), comments("// This is comment")),
 		Ident: &Ident{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments("/* before_name */"), comments("/* after_name */")),
 			Value: "req.http.Host",
 		},
 		Operator: &Operator{
 			Operator: "=",
 		},
 		Value: &String{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments("/* before_value */"), comments("/* after_value */")),
 			Value: "example.com",
 		},
 	}
 
 	expect := `// This is comment
-set req.http.Host = "example.com"; // This is comment
+set /* before_name */ req.http.Host /* after_name */ = /* before_value */ "example.com" /* after_value */; // This is comment
 `
 
-	if set.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, set.String())
-	}
+	assert(t, set.String(), expect)
 }

--- a/ast/subroutine_declaration.go
+++ b/ast/subroutine_declaration.go
@@ -16,11 +16,11 @@ func (s *SubroutineDeclaration) GetMeta() *Meta { return s.Meta }
 func (s *SubroutineDeclaration) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(s.LeadingComment())
-	buf.WriteString("sub ")
-	buf.WriteString(s.Name.String())
-	buf.WriteString(" " + s.Block.String())
-	buf.WriteString(s.TrailingComment())
+	buf.WriteString(s.LeadingComment(lineFeed))
+	buf.WriteString("sub")
+	buf.WriteString(padding(s.Name.String()))
+	buf.WriteString(s.Block.String())
+	buf.WriteString(s.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()

--- a/ast/subroutine_declaration_test.go
+++ b/ast/subroutine_declaration_test.go
@@ -6,13 +6,13 @@ import (
 
 func TestSubroutineStatement(t *testing.T) {
 	sub := &SubroutineDeclaration{
-		Meta: New(T, 0, comments("// This is comment"), comments("/* This is comment */")),
+		Meta: New(T, 0, comments("// leading comment"), comments("/* trailing comment */")),
 		Name: &Ident{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments("/* before_name */"), comments("/* after_name */")),
 			Value: "vcl_recv",
 		},
 		Block: &BlockStatement{
-			Meta: New(T, 0, comments("// This is comment"), comments("/* This is comment */")),
+			Meta: New(T, 1, comments(), comments(), comments("// infix comment")),
 			Statements: []Statement{
 				&EsiStatement{
 					Meta: New(T, 1, comments("// This is comment"), comments("/* This is comment */")),
@@ -21,14 +21,13 @@ func TestSubroutineStatement(t *testing.T) {
 		},
 	}
 
-	expect := `// This is comment
-sub vcl_recv {
+	expect := `// leading comment
+sub /* before_name */ vcl_recv /* after_name */ {
   // This is comment
   esi; /* This is comment */
-} /* This is comment */
+  // infix comment
+} /* trailing comment */
 `
 
-	if sub.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, sub.String())
-	}
+	assert(t, sub.String(), expect)
 }

--- a/ast/switch_statement.go
+++ b/ast/switch_statement.go
@@ -4,7 +4,7 @@ import "bytes"
 
 type SwitchStatement struct {
 	*Meta
-	Control Expression
+	Control *SwitchControl
 	Cases   []*CaseStatement
 	Default int
 }
@@ -15,9 +15,9 @@ func (s *SwitchStatement) String() string {
 	var buf bytes.Buffer
 
 	buf.WriteString(s.LeadingComment())
-	buf.WriteString("switch (")
+	buf.WriteString("switch ")
 	buf.WriteString(s.Control.String())
-	buf.WriteString(") {\n")
+	buf.WriteString(" {\n")
 	for _, stmt := range s.Cases {
 		buf.WriteString(stmt.String())
 	}
@@ -25,6 +25,24 @@ func (s *SwitchStatement) String() string {
 	buf.WriteString("}")
 	buf.WriteString(s.TrailingComment())
 	buf.WriteString("\n")
+
+	return buf.String()
+}
+
+type SwitchControl struct {
+	*Meta
+	Expression Expression
+}
+
+func (s *SwitchControl) statement()     {}
+func (s *SwitchControl) GetMeta() *Meta { return s.Meta }
+func (s *SwitchControl) String() string {
+	var buf bytes.Buffer
+
+	buf.WriteString(s.LeadingComment())
+	buf.WriteString("(")
+	buf.WriteString(s.Expression.String())
+	buf.WriteString(")")
 
 	return buf.String()
 }

--- a/ast/switch_statement.go
+++ b/ast/switch_statement.go
@@ -14,16 +14,16 @@ func (s *SwitchStatement) GetMeta() *Meta { return s.Meta }
 func (s *SwitchStatement) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(s.LeadingComment())
-	buf.WriteString("switch ")
-	buf.WriteString(s.Control.String())
-	buf.WriteString(" {\n")
+	buf.WriteString(s.LeadingComment(lineFeed))
+	buf.WriteString("switch")
+	buf.WriteString(padding(s.Control.String()))
+	buf.WriteString("{\n")
 	for _, stmt := range s.Cases {
 		buf.WriteString(stmt.String())
 	}
 
 	buf.WriteString("}")
-	buf.WriteString(s.TrailingComment())
+	buf.WriteString(s.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()
@@ -39,10 +39,11 @@ func (s *SwitchControl) GetMeta() *Meta { return s.Meta }
 func (s *SwitchControl) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(s.LeadingComment())
+	buf.WriteString(s.LeadingComment(inline))
 	buf.WriteString("(")
 	buf.WriteString(s.Expression.String())
 	buf.WriteString(")")
+	buf.WriteString(s.TrailingComment(inline))
 
 	return buf.String()
 }

--- a/ast/switch_statement_test.go
+++ b/ast/switch_statement_test.go
@@ -8,15 +8,15 @@ func TestSwitchStatement(t *testing.T) {
 	switchs := &SwitchStatement{
 		Meta: New(T, 0, comments("// This is comment"), comments("/* This is comment */")),
 		Control: &SwitchControl{
-			Meta: New(T, 0),
+			Meta: New(T, 0, comments("/* before_paren */"), comments("/* after_paren */")),
 			Expression: &Ident{
-				Meta:  New(T, 0),
+				Meta:  New(T, 0, comments("/* before_expr */"), comments("/* after_expr */")),
 				Value: "req.http.host",
 			},
 		},
 		Cases: []*CaseStatement{
 			{
-				Meta: New(T, 0, comments("// This is comment"), comments("/* This is comment */")),
+				Meta: New(T, 0, comments("// This is comment"), comments("/* This is comment */"), comments("/* infix_case */")),
 				Test: &InfixExpression{
 					Left:     &Ident{Value: "req.http.Host"},
 					Operator: "==",
@@ -91,9 +91,9 @@ func TestSwitchStatement(t *testing.T) {
 	}
 
 	expect := `// This is comment
-switch (req.http.host) {
+switch /* before_paren */ (/* before_expr */ req.http.host /* after_expr */) /* after_paren */ {
 // This is comment
-case "1": /* This is comment */
+case /* infix_case */ "1": /* This is comment */
   // This is comment
   break; /* This is comment */
 // This is comment
@@ -115,7 +115,5 @@ default: /* This is comment */
 } /* This is comment */
 `
 
-	if switchs.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, switchs.String())
-	}
+	assert(t, switchs.String(), expect)
 }

--- a/ast/switch_statement_test.go
+++ b/ast/switch_statement_test.go
@@ -7,9 +7,12 @@ import (
 func TestSwitchStatement(t *testing.T) {
 	switchs := &SwitchStatement{
 		Meta: New(T, 0, comments("// This is comment"), comments("/* This is comment */")),
-		Control: &Ident{
-			Meta:  New(T, 0),
-			Value: "req.http.host",
+		Control: &SwitchControl{
+			Meta: New(T, 0),
+			Expression: &Ident{
+				Meta:  New(T, 0),
+				Value: "req.http.host",
+			},
 		},
 		Cases: []*CaseStatement{
 			{

--- a/ast/synthetic_base64_statement.go
+++ b/ast/synthetic_base64_statement.go
@@ -14,9 +14,11 @@ func (s *SyntheticBase64Statement) GetMeta() *Meta { return s.Meta }
 func (s *SyntheticBase64Statement) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(s.LeadingComment())
-	buf.WriteString(indent(s.Nest) + "synthetic.base64 " + s.Value.String() + ";")
-	buf.WriteString(s.TrailingComment())
+	buf.WriteString(s.LeadingComment(lineFeed))
+	buf.WriteString(indent(s.Nest) + "synthetic.base64")
+	buf.WriteString(paddingLeft(s.Value.String()))
+	buf.WriteString(";")
+	buf.WriteString(s.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()

--- a/ast/synthetic_base64_statement_test.go
+++ b/ast/synthetic_base64_statement_test.go
@@ -8,16 +8,14 @@ func TestSynthericBase64Statement(t *testing.T) {
 	s := &SyntheticBase64Statement{
 		Meta: New(T, 0, comments("// This is comment"), comments("// This is comment")),
 		Value: &String{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments("/* before_expr */"), comments("/* after_expr */")),
 			Value: "foobar",
 		},
 	}
 
 	expect := `// This is comment
-synthetic.base64 "foobar"; // This is comment
+synthetic.base64 /* before_expr */ "foobar" /* after_expr */; // This is comment
 `
 
-	if s.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, s.String())
-	}
+	assert(t, s.String(), expect)
 }

--- a/ast/synthetic_statement.go
+++ b/ast/synthetic_statement.go
@@ -14,9 +14,11 @@ func (s *SyntheticStatement) GetMeta() *Meta { return s.Meta }
 func (s *SyntheticStatement) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(s.LeadingComment())
-	buf.WriteString(indent(s.Nest) + "synthetic " + s.Value.String() + ";")
-	buf.WriteString(s.TrailingComment())
+	buf.WriteString(s.LeadingComment(lineFeed))
+	buf.WriteString(indent(s.Nest) + "synthetic")
+	buf.WriteString(paddingLeft(s.Value.String()))
+	buf.WriteString(";")
+	buf.WriteString(s.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()

--- a/ast/synthetic_statement_test.go
+++ b/ast/synthetic_statement_test.go
@@ -8,16 +8,14 @@ func TestSynthericStatement(t *testing.T) {
 	s := &SyntheticStatement{
 		Meta: New(T, 0, comments("// This is comment"), comments("// This is comment")),
 		Value: &String{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments("/* before_expr */"), comments("/* after_expr */")),
 			Value: "foobar",
 		},
 	}
 
 	expect := `// This is comment
-synthetic "foobar"; // This is comment
+synthetic /* before_expr */ "foobar" /* after_expr */; // This is comment
 `
 
-	if s.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, s.String())
-	}
+	assert(t, s.String(), expect)
 }

--- a/ast/table_declaration.go
+++ b/ast/table_declaration.go
@@ -16,18 +16,18 @@ func (t *TableDeclaration) GetMeta() *Meta { return t.Meta }
 func (t *TableDeclaration) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(t.LeadingComment())
-	buf.WriteString("table ")
-	buf.WriteString(t.Name.String())
+	buf.WriteString(t.LeadingComment(lineFeed))
+	buf.WriteString("table")
+	buf.WriteString(paddingLeft(t.Name.String()))
 	if t.ValueType != nil {
-		buf.WriteString(" " + t.ValueType.String())
+		buf.WriteString(paddingLeft(t.ValueType.String()))
 	}
 	buf.WriteString(" {\n")
 	for _, props := range t.Properties {
 		buf.WriteString(props.String())
 	}
 	buf.WriteString("}")
-	buf.WriteString(t.TrailingComment())
+	buf.WriteString(t.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()
@@ -43,12 +43,12 @@ type TableProperty struct {
 func (t *TableProperty) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(t.LeadingComment())
+	buf.WriteString(t.LeadingComment(lineFeed))
 	buf.WriteString(indent(t.Nest) + t.Key.String())
-	buf.WriteString(": ")
-	buf.WriteString(t.Value.String())
+	buf.WriteString(":")
+	buf.WriteString(paddingLeft(t.Value.String()))
 	buf.WriteString(",")
-	buf.WriteString(t.TrailingComment())
+	buf.WriteString(t.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()

--- a/ast/table_declaration_test.go
+++ b/ast/table_declaration_test.go
@@ -8,22 +8,22 @@ func TestTableDeclaration(t *testing.T) {
 	table := &TableDeclaration{
 		Meta: New(T, 0, comments("// This is comment"), comments("// This is comment")),
 		Name: &Ident{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments("/* before_name */"), comments("/* after_name */")),
 			Value: "example",
 		},
 		ValueType: &Ident{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments(), comments("/* after_type */")),
 			Value: "STRING",
 		},
 		Properties: []*TableProperty{
 			{
 				Meta: New(T, 1, comments("// This is comment", "# This is another comment"), comments("// This is comment")),
 				Key: &String{
-					Meta:  New(T, 0),
+					Meta:  New(T, 0, comments(), comments("/* after_key */")),
 					Value: "foo",
 				},
 				Value: &String{
-					Meta:  New(T, 0),
+					Meta:  New(T, 0, comments("/* before_value */"), comments("/* after_value */")),
 					Value: "bar",
 				},
 			},
@@ -31,14 +31,12 @@ func TestTableDeclaration(t *testing.T) {
 	}
 
 	expect := `// This is comment
-table example STRING {
+table /* before_name */ example /* after_name */ STRING /* after_type */ {
   // This is comment
   # This is another comment
-  "foo": "bar", // This is comment
+  "foo" /* after_key */: /* before_value */ "bar" /* after_value */, // This is comment
 } // This is comment
 `
 
-	if table.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, table.String())
-	}
+	assert(t, table.String(), expect)
 }

--- a/ast/unset_statement.go
+++ b/ast/unset_statement.go
@@ -14,9 +14,11 @@ func (u *UnsetStatement) GetMeta() *Meta { return u.Meta }
 func (u *UnsetStatement) String() string {
 	var buf bytes.Buffer
 
-	buf.WriteString(u.LeadingComment())
-	buf.WriteString(indent(u.Nest) + "unset " + u.Ident.String() + ";")
-	buf.WriteString(u.TrailingComment())
+	buf.WriteString(u.LeadingComment(lineFeed))
+	buf.WriteString(indent(u.Nest) + "unset")
+	buf.WriteString(paddingLeft(u.Ident.String()))
+	buf.WriteString(";")
+	buf.WriteString(u.TrailingComment(inline))
 	buf.WriteString("\n")
 
 	return buf.String()

--- a/ast/unset_statement_test.go
+++ b/ast/unset_statement_test.go
@@ -8,16 +8,14 @@ func TestUnsetStatement(t *testing.T) {
 	unset := &UnsetStatement{
 		Meta: New(T, 0, comments("// This is comment"), comments("// This is comment")),
 		Ident: &Ident{
-			Meta:  New(T, 0),
+			Meta:  New(T, 0, comments("/* before_name */"), comments("/* after_name */")),
 			Value: "req.http.Foo",
 		},
 	}
 
 	expect := `// This is comment
-unset req.http.Foo; // This is comment
+unset /* before_name */ req.http.Foo /* after_name */; // This is comment
 `
 
-	if unset.String() != expect {
-		t.Errorf("stringer error.\nexpect:\n%s\nactual:\n%s\n", expect, unset.String())
-	}
+	assert(t, unset.String(), expect)
 }

--- a/ast/vcl_types.go
+++ b/ast/vcl_types.go
@@ -2,6 +2,7 @@ package ast
 
 import (
 	"fmt"
+	"strings"
 )
 
 type Ident struct {
@@ -12,7 +13,7 @@ type Ident struct {
 func (i *Ident) expression()    {}
 func (i *Ident) GetMeta() *Meta { return i.Meta }
 func (i *Ident) String() string {
-	return i.LeadingInlineComment() + i.Value + i.TrailingComment()
+	return strings.TrimSpace(i.LeadingComment(inline) + i.Value + i.TrailingComment(inline))
 }
 
 type IP struct {
@@ -23,7 +24,7 @@ type IP struct {
 func (i *IP) expression()    {}
 func (i *IP) GetMeta() *Meta { return i.Meta }
 func (i *IP) String() string {
-	return i.LeadingInlineComment() + i.Value + i.TrailingComment()
+	return strings.TrimSpace(i.LeadingComment(inline) + i.Value + i.TrailingComment(inline))
 }
 
 type Boolean struct {
@@ -34,7 +35,9 @@ type Boolean struct {
 func (b *Boolean) expression()    {}
 func (b *Boolean) GetMeta() *Meta { return b.Meta }
 func (b *Boolean) String() string {
-	return b.LeadingInlineComment() + fmt.Sprintf("%t", b.Value) + b.TrailingComment()
+	return strings.TrimSpace(
+		fmt.Sprintf("%s%t%s", b.LeadingComment(inline), b.Value, b.TrailingComment(inline)),
+	)
 }
 
 type Integer struct {
@@ -45,7 +48,9 @@ type Integer struct {
 func (i *Integer) expression()    {}
 func (i *Integer) GetMeta() *Meta { return i.Meta }
 func (i *Integer) String() string {
-	return i.LeadingInlineComment() + fmt.Sprintf("%d", i.Value) + i.TrailingComment()
+	return strings.TrimSpace(
+		fmt.Sprintf("%s%d%s", i.LeadingComment(inline), i.Value, i.TrailingComment(inline)),
+	)
 }
 
 type String struct {
@@ -57,9 +62,13 @@ func (s *String) expression()    {}
 func (s *String) GetMeta() *Meta { return s.Meta }
 func (s *String) String() string {
 	if s.Token.Offset == 4 { // offset=4 means bracket string
-		return s.LeadingComment() + fmt.Sprintf(`{"%s"}`, s.Value) + s.TrailingComment()
+		return strings.TrimSpace(
+			fmt.Sprintf(`%s{"%s"}%s`, s.LeadingComment(inline), s.Value, s.TrailingComment(inline)),
+		)
 	}
-	return s.LeadingInlineComment() + fmt.Sprintf(`"%s"`, s.Value) + s.TrailingComment()
+	return strings.TrimSpace(
+		fmt.Sprintf(`%s"%s"%s`, s.LeadingComment(inline), s.Value, s.TrailingComment(inline)),
+	)
 }
 
 type Float struct {
@@ -70,7 +79,9 @@ type Float struct {
 func (f *Float) expression()    {}
 func (f *Float) GetMeta() *Meta { return f.Meta }
 func (f *Float) String() string {
-	return f.LeadingInlineComment() + fmt.Sprintf("%f", f.Value) + f.TrailingComment()
+	return strings.TrimSpace(
+		fmt.Sprintf(`%s%f%s`, f.LeadingComment(inline), f.Value, f.TrailingComment(inline)),
+	)
 }
 
 type RTime struct {
@@ -81,5 +92,5 @@ type RTime struct {
 func (r *RTime) expression()    {}
 func (r *RTime) GetMeta() *Meta { return r.Meta }
 func (r *RTime) String() string {
-	return r.LeadingInlineComment() + r.Value + r.TrailingComment()
+	return strings.TrimSpace(r.LeadingComment(inline) + r.Value + r.TrailingComment(inline))
 }

--- a/debugger/debugger.go
+++ b/debugger/debugger.go
@@ -37,7 +37,7 @@ func (d *Debugger) Run(node ast.Node) interpreter.DebugState {
 		return d.breakPoint(node.GetMeta().Token)
 	default:
 		meta := node.GetMeta()
-		if !strings.Contains(meta.LeadingComment(), debuggerMark) {
+		if !hasDebufferMark(meta.Leading) {
 			return interpreter.DebugPass
 		}
 		return d.breakPoint(meta.Token)
@@ -74,4 +74,8 @@ func (d *Debugger) breakPoint(t token.Token) interpreter.DebugState {
 		d.help.Highlight(helpview.F7)
 	}
 	return interpreter.DebugPass
+}
+
+func hasDebufferMark(cs ast.Comments) bool {
+	return strings.Contains(cs.String(), debuggerMark)
 }

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -1,0 +1,254 @@
+# Parser spec
+
+`falco` parses based on the following language spec of VCL.
+Especially about comment, you can write comments on the `<comment>` placeholder.
+
+If you write an VCL without following spec, parser may raise an error or lack comments so you might need to move or delete them.
+
+## ACL Declaration
+
+```
+acl <comment> <acl_name> <comment> {
+    <comment>
+    <!> <comment> "<ip_address>"</><mask> <comment>; <comment>
+    ...
+} <comment>
+```
+
+## Backend Declaration
+
+```
+backend <comment> <backend_name> <comment> {
+    <comment>
+    .<property_name> <comment> = <comment> <property_value> <comment>; <comment>
+    ...
+
+    .probe <comment> = <comment> {
+      <comment>
+      .<property_name> <comment> = <comment> <property_value> <comment>; <comment>
+      ...
+    } <comment>
+} <comment>
+```
+
+## Director Declaration
+
+```
+director <comment> <director_name> <comment> <director_type> <comment> {
+    <comment>
+    .<property_name> <comment> = <comment> <property_value> <comment>; <comment>
+    ...
+
+    {<comment> .<property_name> <comment> = <comment> <property_value> <comment>; <comment>} <comment>
+    ...
+} <comment>
+```
+
+## Table Declaration
+
+```
+table <comment> <table_name> <comment> <value_type> <comment> {
+    <comment>
+    "<property_name>" <comment>: <comment> <property_value> <comment>, <comment>
+    ...
+}
+```
+
+## Subroutine Declaration
+
+```
+sub <comment> <subroutine_name> <comment> {
+    <statement>...
+    <comment>
+} <comment>
+```
+
+## Penaltybox Declaration
+
+```
+penaltybox <comment> <penaltybox_name> <comment> {
+    <comment>
+} <comment>
+```
+
+## Ratecounter Declaration
+
+```
+ratecounter <comment> <ratecounter_name> <comment> {
+    <comment>
+} <comment>
+```
+
+## Add Statement
+
+```
+<comment>
+add <comment> <identifier> <comment> = <comment> <value> <comment>; <comment>
+```
+
+## Block Statement
+
+```
+<comment>
+{
+    <statement>...
+    <comment>
+} <comment>
+```
+
+## Call Statement
+
+```
+<comment>
+call <comment> <subroutine_name> <comment>; <comment>
+```
+
+## Declare Statement
+
+```
+<comment>
+declare <comment> local <comment> <variable_name> <comment> <variable_type> <comment>; <comment>
+```
+
+## Error Statement
+
+```
+<comment>
+error <comment> <status_code> <comment> <arguments>... <comment>; <comment>
+```
+
+## Esi Statement
+
+```
+<comment>
+esi <comment>; <comment>
+```
+
+## Function Call Statement
+
+```
+<comment>
+<function_name>(<comment> <argument> <comment>, ...) <comment>; <comment>
+```
+
+## Goto Statement
+
+```
+<comment>
+goto <comment> <goto_target> <comment>; <comment>
+```
+
+## Goto Target Statement
+
+```
+<comment>
+<goto_target>: <comment>
+```
+
+## If Statement
+
+```
+<comment>
+if <comment> (<comment> <expression> <comment>) <comment> {
+    <statement>...
+}
+<comment>
+else if <comment> (<comment> <expression> <comment>) <comment> {
+    <statement>...
+}
+<comment>
+else <comment> {
+    <statement>...
+}
+```
+
+## Import Statement
+
+```
+<comment>
+import <comment> <module_name> <comment>; <comment>
+```
+
+## Include Statement
+
+```
+<comment>
+include <comment> <module_name> <comment>; <comment>
+```
+
+## Log Statement
+
+```
+<comment>
+log <comment> <expression> <comment>...; <comment>
+```
+
+## Remove Statement
+
+```
+<comment>
+remove <comment> <identifier> <comment>; <comment>
+```
+
+## Restart Statement
+
+```
+<comment>
+restart <comment>; <comment>
+```
+
+## Return Statement
+
+```
+<comment>
+return <comment> (<comment> <state> <comment>) <comment>; <comment>
+```
+
+Parenthesis is artbitrary.
+
+## Set Statement
+
+```
+<comment>
+set <comment> <identifier> <comment> = <comment> <value> <comment>; <comment>
+```
+
+## Switch Statement
+
+```
+<comment>
+switch <comment> (<comment> <expression> <comment>) <comment> {
+    <comment>
+    case <comment> <expression> <comment>: <comment>
+        <statement>...
+        <comment>
+        fallthrough <comment>; <comment>
+        <comment>
+        break <comment>; <comment>
+    default <comment>: <comment>
+        <statement>...
+}
+```
+
+## Synthetic Statement
+
+```
+<comment>
+synthetic <comment> <expression> <comment>...; <comment>
+```
+
+## Synthetic Base64 Statement
+
+```
+<comment>
+synthetic.base64 <comment> <expression> <comment>...; <comment>
+```
+
+## Unset Statement
+
+```
+<comment>
+unset <comment> <identifier> <comment>; <comment>
+```
+
+About BNF of VCL, see https://gist.github.com/benediktkr/52d33ca982e29916a8aa

--- a/interpreter/statement.go
+++ b/interpreter/statement.go
@@ -203,7 +203,7 @@ func (i *Interpreter) ProcessReturnStatement(stmt *ast.ReturnStatement) State {
 	if stmt.ReturnExpression == nil {
 		return BARE_RETURN
 	}
-	return State((*stmt.ReturnExpression).String())
+	return State(stmt.ReturnExpression.String())
 }
 
 func (i *Interpreter) ProcessSetStatement(stmt *ast.SetStatement) error {
@@ -547,7 +547,7 @@ func (i *Interpreter) ProcessIfStatement(
 
 	// else
 	if stmt.Alternative != nil {
-		val, state, _, err := i.ProcessBlockStatement(stmt.Alternative.Statements, ds, isReturnAsValue)
+		val, state, _, err := i.ProcessBlockStatement(stmt.Alternative.Consequence.Statements, ds, isReturnAsValue)
 		if err != nil {
 			return value.Null, NONE, errors.WithStack(err)
 		}
@@ -565,7 +565,7 @@ func (i *Interpreter) ProcessSwitchStatement(
 	isReturnAsValue bool,
 ) (value.Value, State, error) {
 	// User defined functions used in a switch control statement must have a STRING return type.
-	if fnCall, ok := stmt.Control.(*ast.FunctionCallExpression); ok {
+	if fnCall, ok := stmt.Control.Expression.(*ast.FunctionCallExpression); ok {
 		fn, ok := i.ctx.SubroutineFunctions[fnCall.Function.Value]
 		if ok && fn.ReturnType.Value != string(value.StringType) {
 			return value.Null, NONE, errors.WithStack(exception.Runtime(
@@ -575,7 +575,7 @@ func (i *Interpreter) ProcessSwitchStatement(
 			))
 		}
 	}
-	expr, err := i.ProcessExpression(stmt.Control, false)
+	expr, err := i.ProcessExpression(stmt.Control.Expression, false)
 	if err != nil {
 		return value.Null, NONE, errors.WithStack(err)
 	}

--- a/interpreter/statement_test.go
+++ b/interpreter/statement_test.go
@@ -113,10 +113,6 @@ func TestDeclareStatement(t *testing.T) {
 }
 
 func TestReturnStatement(t *testing.T) {
-	var exp ast.Expression = &ast.Ident{
-		Value: "pass",
-		Meta:  &ast.Meta{},
-	}
 	tests := []struct {
 		name   string
 		stmt   *ast.ReturnStatement
@@ -125,7 +121,10 @@ func TestReturnStatement(t *testing.T) {
 		{
 			name: "should return pass state",
 			stmt: &ast.ReturnStatement{
-				ReturnExpression: &exp,
+				ReturnExpression: &ast.Ident{
+					Value: "pass",
+					Meta:  &ast.Meta{},
+				},
 			},
 			expect: PASS,
 		},
@@ -209,10 +208,6 @@ func TestSetStatement(t *testing.T) {
 }
 
 func TestBlockStatement(t *testing.T) {
-	var pass ast.Expression = &ast.Ident{
-		Value: "pass",
-		Meta:  &ast.Meta{},
-	}
 	tests := []struct {
 		name           string
 		scope          context.Scope
@@ -234,7 +229,10 @@ func TestBlockStatement(t *testing.T) {
 				&ast.BlockStatement{
 					Statements: []ast.Statement{
 						&ast.ReturnStatement{
-							ReturnExpression: &pass,
+							ReturnExpression: &ast.Ident{
+								Value: "pass",
+								Meta:  &ast.Meta{},
+							},
 						},
 					},
 				},
@@ -255,7 +253,10 @@ func TestBlockStatement(t *testing.T) {
 					},
 				},
 				&ast.ReturnStatement{
-					ReturnExpression: &pass,
+					ReturnExpression: &ast.Ident{
+						Value: "pass",
+						Meta:  &ast.Meta{},
+					},
 				},
 			},
 			expected_state: BARE_RETURN,
@@ -284,14 +285,6 @@ func TestBlockStatement(t *testing.T) {
 }
 
 func TestBlockStatementWithReturnValue(t *testing.T) {
-	var pass ast.Expression = &ast.Integer{
-		Value: 1,
-		Meta:  &ast.Meta{},
-	}
-	var invalid ast.Expression = &ast.String{
-		Value: "invalid",
-		Meta:  &ast.Meta{},
-	}
 	tests := []struct {
 		name  string
 		scope context.Scope
@@ -302,7 +295,10 @@ func TestBlockStatementWithReturnValue(t *testing.T) {
 			scope: context.RecvScope,
 			stmts: []ast.Statement{
 				&ast.ReturnStatement{
-					ReturnExpression: &pass,
+					ReturnExpression: &ast.Integer{
+						Value: 1,
+						Meta:  &ast.Meta{},
+					},
 				},
 			},
 		},
@@ -313,12 +309,18 @@ func TestBlockStatementWithReturnValue(t *testing.T) {
 				&ast.BlockStatement{
 					Statements: []ast.Statement{
 						&ast.ReturnStatement{
-							ReturnExpression: &pass,
+							ReturnExpression: &ast.Integer{
+								Value: 1,
+								Meta:  &ast.Meta{},
+							},
 						},
 					},
 				},
 				&ast.ReturnStatement{
-					ReturnExpression: &invalid,
+					ReturnExpression: &ast.String{
+						Value: "invalid",
+						Meta:  &ast.Meta{},
+					},
 				},
 			},
 		},
@@ -331,13 +333,19 @@ func TestBlockStatementWithReturnValue(t *testing.T) {
 					Consequence: &ast.BlockStatement{
 						Statements: []ast.Statement{
 							&ast.ReturnStatement{
-								ReturnExpression: &pass,
+								ReturnExpression: &ast.Integer{
+									Value: 1,
+									Meta:  &ast.Meta{},
+								},
 							},
 						},
 					},
 				},
 				&ast.ReturnStatement{
-					ReturnExpression: &invalid,
+					ReturnExpression: &ast.String{
+						Value: "invalid",
+						Meta:  &ast.Meta{},
+					},
 				},
 			},
 		},

--- a/interpreter/subroutine.go
+++ b/interpreter/subroutine.go
@@ -244,7 +244,7 @@ func (i *Interpreter) extractBoilerplateMacro(sub *ast.SubroutineDeclaration) er
 
 	var resolved []ast.Statement
 	// Find "FASTLY [macro]" comment and extract in infix comment of block statement
-	if hasFastlyBoilerplateMacro(sub.Block.InfixComment(), macroName) {
+	if hasFastlyBoilerplateMacro(sub.Block.Infix, macroName) {
 		for _, s := range snippets {
 			statements, err := loadStatementVCL(s.Name, s.Data)
 			if err != nil {
@@ -260,7 +260,7 @@ func (i *Interpreter) extractBoilerplateMacro(sub *ast.SubroutineDeclaration) er
 	// Find "FASTLY [macro]" comment and extract inside block statement
 	var found bool // guard flag, embedding macro should do only once
 	for _, stmt := range sub.Block.Statements {
-		if hasFastlyBoilerplateMacro(stmt.LeadingComment(), macroName) && !found {
+		if hasFastlyBoilerplateMacro(stmt.GetMeta().Leading, macroName) && !found {
 			for _, s := range snippets {
 				statements, err := loadStatementVCL(s.Name, s.Data)
 				if err != nil {
@@ -276,10 +276,10 @@ func (i *Interpreter) extractBoilerplateMacro(sub *ast.SubroutineDeclaration) er
 	return nil
 }
 
-func hasFastlyBoilerplateMacro(commentText, macroName string) bool {
-	for _, c := range strings.Split(commentText, "\n") {
-		c = strings.TrimLeft(c, " */#")
-		if strings.HasPrefix(strings.ToUpper(c), macroName) {
+func hasFastlyBoilerplateMacro(cs ast.Comments, macroName string) bool {
+	for _, c := range cs {
+		line := strings.TrimLeft(c.String(), " */#")
+		if strings.HasPrefix(strings.ToUpper(line), macroName) {
 			return true
 		}
 	}

--- a/interpreter/subroutine.go
+++ b/interpreter/subroutine.go
@@ -200,7 +200,7 @@ func (i *Interpreter) ProcessFunctionSubroutine(sub *ast.SubroutineDeclaration, 
 }
 
 func (i *Interpreter) ProcessExpressionReturnStatement(stmt *ast.ReturnStatement) (value.Value, State, error) {
-	val, err := i.ProcessExpression(*stmt.ReturnExpression, false)
+	val, err := i.ProcessExpression(stmt.ReturnExpression, false)
 	if err != nil {
 		return value.Null, NONE, errors.WithStack(err)
 	}

--- a/linter/helper.go
+++ b/linter/helper.go
@@ -397,11 +397,10 @@ func getFastlySubroutineScope(name string) string {
 	return ""
 }
 
-func hasFastlyBoilerPlateMacro(commentText, phrase string) bool {
-	comments := strings.Split(commentText, "\n")
-	for _, c := range comments {
-		c = strings.TrimLeft(c, " */#")
-		if strings.HasPrefix(strings.ToUpper(c), phrase) {
+func hasFastlyBoilerPlateMacro(cs ast.Comments, phrase string) bool {
+	for _, c := range cs {
+		line := strings.TrimLeft(c.String(), " */#")
+		if strings.HasPrefix(strings.ToUpper(line), phrase) {
 			return true
 		}
 	}

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -923,7 +923,7 @@ func (l *Linter) lintFastlyBoilerPlateMacro(sub *ast.SubroutineDeclaration, ctx 
 
 	var resolved []ast.Statement
 	// visit all statement comments and find "FASTLY [phase]" comment
-	if hasFastlyBoilerPlateMacro(sub.Block.InfixComment(), phrase) {
+	if hasFastlyBoilerPlateMacro(sub.Block.Infix, phrase) {
 		for _, s := range scopedSnippets {
 			resolved = append(resolved, l.loadSnippetVCL("snippet::"+s.Name, s.Data)...)
 		}
@@ -933,7 +933,7 @@ func (l *Linter) lintFastlyBoilerPlateMacro(sub *ast.SubroutineDeclaration, ctx 
 
 	var found bool
 	for _, stmt := range sub.Block.Statements {
-		if hasFastlyBoilerPlateMacro(stmt.LeadingComment(), phrase) && !found {
+		if hasFastlyBoilerPlateMacro(stmt.GetMeta().Leading, phrase) && !found {
 			// Macro found but embedding snippets should do only once
 			for _, s := range scopedSnippets {
 				resolved = append(resolved, l.loadSnippetVCL("snippet::"+s.Name, s.Data)...)

--- a/parser/expression_parser.go
+++ b/parser/expression_parser.go
@@ -261,6 +261,7 @@ func (p *Parser) parseFunctionArgumentExpressions() ([]ast.Expression, error) {
 
 	for p.peekTokenIs(token.COMMA) {
 		p.nextToken() // point to COMMA
+		swapLeadingTrailing(p.curToken, list[len(list)-1].GetMeta())
 		p.nextToken() // point to next argument expression
 		item, err := p.parseExpression(LOWEST)
 		if err != nil {
@@ -272,6 +273,7 @@ func (p *Parser) parseFunctionArgumentExpressions() ([]ast.Expression, error) {
 	if !p.expectPeek(token.RIGHT_PAREN) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "RIGHT_PAREN"))
 	}
+	swapLeadingTrailing(p.curToken, list[len(list)-1].GetMeta())
 
 	return list, nil
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -48,7 +48,7 @@ func assert(t *testing.T, actual, expect interface{}) {
 		cmpopts.IgnoreFields(ast.InfixExpression{}),
 		cmpopts.IgnoreFields(ast.PrefixExpression{}),
 		cmpopts.IgnoreFields(ast.GroupedExpression{}),
-		cmpopts.IgnoreFields(ast.IfStatement{}, "AlternativeComments"),
+		cmpopts.IgnoreFields(ast.IfStatement{}, "Keyword"),
 		cmpopts.IgnoreFields(ast.UnsetStatement{}),
 		cmpopts.IgnoreFields(ast.AddStatement{}),
 		cmpopts.IgnoreFields(ast.CallStatement{}),

--- a/parser/statement_parser_test.go
+++ b/parser/statement_parser_test.go
@@ -974,7 +974,7 @@ sub vcl_recv {
 								},
 								Another: []*ast.IfStatement{
 									{
-										Meta: ast.New(T, 1, comments("// j")),
+										Meta: ast.New(T, 1, comments("// j"), comments(), comments("/* k */")),
 										Condition: &ast.InfixExpression{
 											Meta: ast.New(T, 1, comments(), comments("/* o */")),
 											Left: &ast.Ident{
@@ -1092,12 +1092,12 @@ sub vcl_recv {
 										Fallthrough: true,
 									},
 									{
-										Meta: ast.New(T, 2),
+										Meta: ast.New(T, 2, comments(), comments(), comments("/* infix */")),
 										Test: &ast.InfixExpression{
 											Meta:     ast.New(T, 2),
 											Operator: "~",
 											Right: &ast.String{
-												Meta:  ast.New(T, 2, comments("/* infix */")),
+												Meta:  ast.New(T, 2),
 												Value: "[2-3]"},
 										},
 										Statements: []ast.Statement{
@@ -1422,12 +1422,12 @@ sub vcl_recv {
 								Default: 1,
 								Cases: []*ast.CaseStatement{
 									{
-										Meta: ast.New(T, 2, comments("// f"), comments("// i")),
+										Meta: ast.New(T, 2, comments("// f"), comments("// i"), comments("/* g */")),
 										Test: &ast.InfixExpression{
-											Meta:     ast.New(T, 2, comments("/* g */"), comments("/* h */")),
+											Meta:     ast.New(T, 2, comments(), comments("/* h */")),
 											Operator: "==",
 											Right: &ast.String{
-												Meta:  ast.New(T, 2, comments("/* g */"), comments("/* h */")),
+												Meta:  ast.New(T, 2, comments(), comments("/* h */")),
 												Value: "1",
 											},
 										},
@@ -2639,8 +2639,7 @@ sub vcl_recv {
 									Meta:  ast.New(T, 1, comments("// Function Leading comment"), comments("// Function Trailing comment")),
 									Value: "testFun",
 								},
-								Arguments:                  []ast.Expression{},
-								ParenthesisTrailingComment: comments(),
+								Arguments: []ast.Expression{},
 							},
 						},
 					},
@@ -2691,7 +2690,6 @@ sub vcl_recv {
 										Value: 3,
 									},
 								},
-								ParenthesisTrailingComment: comments(),
 							},
 						},
 					},
@@ -2742,7 +2740,6 @@ sub vcl_recv {
 										Value: 3,
 									},
 								},
-								ParenthesisTrailingComment: comments(),
 							},
 						},
 					},
@@ -2775,9 +2772,9 @@ sub vcl_recv {
 						Meta: ast.New(T, 1),
 						Statements: []ast.Statement{
 							&ast.FunctionCallStatement{
-								Meta: ast.New(T, 1, comments("// a"), comments("// i")),
+								Meta: ast.New(T, 1, comments("// a"), comments("// i"), comments("/* h */")),
 								Function: &ast.Ident{
-									Meta:  ast.New(T, 1, comments("// a"), comments("// i")),
+									Meta:  ast.New(T, 1, comments("// a"), comments("// i"), comments("/* h */")),
 									Value: "std.collect",
 								},
 								Arguments: []ast.Expression{
@@ -2794,7 +2791,6 @@ sub vcl_recv {
 										Value: 3,
 									},
 								},
-								ParenthesisTrailingComment: comments("/* h */"),
 							},
 						},
 					},

--- a/parser/statement_parser_test.go
+++ b/parser/statement_parser_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/ysugimoto/falco/ast"
 	"github.com/ysugimoto/falco/lexer"
-	"github.com/ysugimoto/falco/token"
 )
 
 func TestParseImport(t *testing.T) {
@@ -31,6 +30,28 @@ import boltsort; // Trailing comment`
 	assert(t, vcl, expect)
 }
 
+func TestParseImportWithComplexComment(t *testing.T) {
+	input := `// a
+import /* b */boltsort /* c */; // d`
+	expect := &ast.VCL{
+		Statements: []ast.Statement{
+			&ast.ImportStatement{
+				Meta: ast.New(T, 0, comments("// a"), comments("// d")),
+				Name: &ast.Ident{
+					Meta:  ast.New(T, 0, comments("/* b */"), comments("/* c */")),
+					Value: "boltsort",
+				},
+			},
+		},
+	}
+
+	vcl, err := New(lexer.NewFromString(input)).ParseVCL()
+	if err != nil {
+		t.Errorf("%+v", err)
+	}
+	assert(t, vcl, expect)
+}
+
 func TestParseInclude(t *testing.T) {
 	t.Run("with semicolon at the end", func(t *testing.T) {
 		input := `// Leading comment
@@ -40,7 +61,7 @@ include "feature_mod"; // Trailing comment`
 				&ast.IncludeStatement{
 					Meta: ast.New(T, 0, comments("// Leading comment"), comments("// Trailing comment")),
 					Module: &ast.String{
-						Meta:  ast.New(token.Token{}, 0),
+						Meta:  ast.New(T, 0),
 						Value: "feature_mod",
 					},
 				},
@@ -62,7 +83,7 @@ include "feature_mod" // Trailing comment`
 				&ast.IncludeStatement{
 					Meta: ast.New(T, 0, comments("// Leading comment"), comments("// Trailing comment")),
 					Module: &ast.String{
-						Meta:  ast.New(token.Token{}, 0),
+						Meta:  ast.New(T, 0),
 						Value: "feature_mod",
 					},
 				},
@@ -76,6 +97,52 @@ include "feature_mod" // Trailing comment`
 		assert(t, vcl, expect)
 	})
 }
+
+func TestParseIncludeWithComplexComment(t *testing.T) {
+	t.Run("with semicolon at the end", func(t *testing.T) {
+		input := `// a
+include /* b */"feature_mod"/* c */; // d`
+		expect := &ast.VCL{
+			Statements: []ast.Statement{
+				&ast.IncludeStatement{
+					Meta: ast.New(T, 0, comments("// a"), comments("// d")),
+					Module: &ast.String{
+						Meta:  ast.New(T, 0, comments("/* b */"), comments("/* c */")),
+						Value: "feature_mod",
+					},
+				},
+			},
+		}
+
+		vcl, err := New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Errorf("%+v", err)
+		}
+		assert(t, vcl, expect)
+	})
+	t.Run("without semicolon at the end", func(t *testing.T) {
+		input := `// a
+include /* b */"feature_mod"/* c */ // d`
+		expect := &ast.VCL{
+			Statements: []ast.Statement{
+				&ast.IncludeStatement{
+					Meta: ast.New(T, 0, comments("// a"), comments("/* c */", "// d")),
+					Module: &ast.String{
+						Meta:  ast.New(T, 0, comments("/* b */")),
+						Value: "feature_mod",
+					},
+				},
+			},
+		}
+
+		vcl, err := New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Errorf("%+v", err)
+		}
+		assert(t, vcl, expect)
+	})
+}
+
 func TestParseSetStatement(t *testing.T) {
 	t.Run("simple assign", func(t *testing.T) {
 		operators := []string{
@@ -191,6 +258,57 @@ func TestParseSetStatement(t *testing.T) {
 		}
 		assert(t, vcl, expect)
 	})
+}
+
+func TestParseSetStatementWithComplexComment(t *testing.T) {
+	input := `sub vcl_recv {
+	// a
+	set /* a */ req.http.Host /* b */= /* c */"example." /* d */req.http.User-Agent /* e */; // f
+}`
+	expect := &ast.VCL{
+		Statements: []ast.Statement{
+			&ast.SubroutineDeclaration{
+				Meta: ast.New(T, 0),
+				Name: &ast.Ident{
+					Meta:  ast.New(T, 0),
+					Value: "vcl_recv",
+				},
+				Block: &ast.BlockStatement{
+					Meta: ast.New(T, 1),
+					Statements: []ast.Statement{
+						&ast.SetStatement{
+							Meta: ast.New(T, 1, comments("// a"), comments("// f")),
+							Ident: &ast.Ident{
+								Meta:  ast.New(T, 1, comments("/* a */"), comments("/* b */")),
+								Value: "req.http.Host",
+							},
+							Operator: &ast.Operator{
+								Meta:     ast.New(T, 1),
+								Operator: "=",
+							},
+							Value: &ast.InfixExpression{
+								Meta:     ast.New(T, 1, comments(), comments("/* e */")),
+								Operator: "+",
+								Left: &ast.String{
+									Meta:  ast.New(T, 1, comments("/* c */"), comments("/* d */")),
+									Value: "example.",
+								},
+								Right: &ast.Ident{
+									Meta:  ast.New(T, 1, comments(), comments("/* e */")),
+									Value: "req.http.User-Agent",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	vcl, err := New(lexer.NewFromString(input)).ParseVCL()
+	if err != nil {
+		t.Errorf("%+v", err)
+	}
+	assert(t, vcl, expect)
 }
 
 func TestParseIfStatement(t *testing.T) {
@@ -495,12 +613,14 @@ sub vcl_recv {
 										},
 									},
 								},
-								AlternativeComments: comments("// Leading comment"),
-								Alternative: &ast.BlockStatement{
-									Meta: ast.New(T, 2, comments(), comments("// Trailing comment")),
-									Statements: []ast.Statement{
-										&ast.RestartStatement{
-											Meta: ast.New(T, 2),
+								Alternative: &ast.ElseStatement{
+									Meta: ast.New(T, 1, comments("// Leading comment")),
+									Consequence: &ast.BlockStatement{
+										Meta: ast.New(T, 2, comments(), comments("// Trailing comment")),
+										Statements: []ast.Statement{
+											&ast.RestartStatement{
+												Meta: ast.New(T, 2),
+											},
 										},
 									},
 								},
@@ -587,11 +707,14 @@ sub vcl_recv {
 										},
 									},
 								},
-								Alternative: &ast.BlockStatement{
-									Meta: ast.New(T, 2),
-									Statements: []ast.Statement{
-										&ast.RestartStatement{
-											Meta: ast.New(T, 2),
+								Alternative: &ast.ElseStatement{
+									Meta: ast.New(T, 1),
+									Consequence: &ast.BlockStatement{
+										Meta: ast.New(T, 2),
+										Statements: []ast.Statement{
+											&ast.RestartStatement{
+												Meta: ast.New(T, 2),
+											},
 										},
 									},
 								},
@@ -678,11 +801,14 @@ sub vcl_recv {
 										},
 									},
 								},
-								Alternative: &ast.BlockStatement{
-									Meta: ast.New(T, 2),
-									Statements: []ast.Statement{
-										&ast.RestartStatement{
-											Meta: ast.New(T, 2),
+								Alternative: &ast.ElseStatement{
+									Meta: ast.New(T, 1),
+									Consequence: &ast.BlockStatement{
+										Meta: ast.New(T, 2),
+										Statements: []ast.Statement{
+											&ast.RestartStatement{
+												Meta: ast.New(T, 2),
+											},
 										},
 									},
 								},
@@ -769,11 +895,14 @@ sub vcl_recv {
 										},
 									},
 								},
-								Alternative: &ast.BlockStatement{
-									Meta: ast.New(T, 2),
-									Statements: []ast.Statement{
-										&ast.RestartStatement{
-											Meta: ast.New(T, 2),
+								Alternative: &ast.ElseStatement{
+									Meta: ast.New(T, 1),
+									Consequence: &ast.BlockStatement{
+										Meta: ast.New(T, 2),
+										Statements: []ast.Statement{
+											&ast.RestartStatement{
+												Meta: ast.New(T, 2),
+											},
 										},
 									},
 								},
@@ -790,24 +919,25 @@ sub vcl_recv {
 		assert(t, vcl, expect)
 	})
 
-	t.Run("Full comments", func(t *testing.T) {
+	t.Run("Complex comments", func(t *testing.T) {
 		input := `
 sub vcl_recv {
-	// If Leading comment
-	if (req.http.Host ~ "example.com") {
+	// a
+	if /* b */ (/* c */req.http.Host /* d */~ /* e */"example.com"/* f */) /* g */{
 		restart;
-		// If Infix comment
-	} // If Trailing comment
-	// Elsif Leading comment
-	elsif (req.http.X-Forwarded-For ~ "192.168.0.1") {
+		// h
+	} // i
+	// j
+	elsif /* k */(/* l */req.http.X-Forwarded-For /* m */ ~ /* n */"192.168.0.1" /* o */) // p
+	{
 		restart;
-		// Elsif Infix comment
+		// q
 	}
-	// Else Leading comment
-	else {
+	// r
+	else /* s */ {
 		restart;
-		// Else Infix comment
-	} // Else Trailing comment
+		// t
+	} // u
 }`
 		expect := &ast.VCL{
 			Statements: []ast.Statement{
@@ -821,21 +951,21 @@ sub vcl_recv {
 						Meta: ast.New(T, 1),
 						Statements: []ast.Statement{
 							&ast.IfStatement{
-								Meta: ast.New(T, 1, comments("// If Leading comment")),
+								Meta: ast.New(T, 1, comments("// a"), comments(), comments("/* b */")),
 								Condition: &ast.InfixExpression{
-									Meta: ast.New(T, 1),
+									Meta: ast.New(T, 1, comments(), comments("/* f */")),
 									Left: &ast.Ident{
-										Meta:  ast.New(T, 1),
+										Meta:  ast.New(T, 1, comments("/* c */"), comments("/* d */")),
 										Value: "req.http.Host",
 									},
 									Operator: "~",
 									Right: &ast.String{
-										Meta:  ast.New(T, 1),
+										Meta:  ast.New(T, 1, comments("/* e */")),
 										Value: "example.com",
 									},
 								},
 								Consequence: &ast.BlockStatement{
-									Meta: ast.New(T, 2, ast.Comments{}, comments("// If Trailing comment"), comments("// If Infix comment")),
+									Meta: ast.New(T, 2, comments("/* g */"), comments("// i"), comments("// h")),
 									Statements: []ast.Statement{
 										&ast.RestartStatement{
 											Meta: ast.New(T, 2),
@@ -844,21 +974,21 @@ sub vcl_recv {
 								},
 								Another: []*ast.IfStatement{
 									{
-										Meta: ast.New(T, 1, comments("// Elsif Leading comment")),
+										Meta: ast.New(T, 1, comments("// j")),
 										Condition: &ast.InfixExpression{
-											Meta: ast.New(T, 1),
+											Meta: ast.New(T, 1, comments(), comments("/* o */")),
 											Left: &ast.Ident{
-												Meta:  ast.New(T, 1),
+												Meta:  ast.New(T, 1, comments("/* l */"), comments("/* m */")),
 												Value: "req.http.X-Forwarded-For",
 											},
 											Operator: "~",
 											Right: &ast.String{
-												Meta:  ast.New(T, 1),
+												Meta:  ast.New(T, 1, comments("/* n */")),
 												Value: "192.168.0.1",
 											},
 										},
 										Consequence: &ast.BlockStatement{
-											Meta: ast.New(T, 2, ast.Comments{}, ast.Comments{}, comments("// Elsif Infix comment")),
+											Meta: ast.New(T, 2, comments("// p"), comments(), comments("// q")),
 											Statements: []ast.Statement{
 												&ast.RestartStatement{
 													Meta: ast.New(T, 2),
@@ -867,11 +997,14 @@ sub vcl_recv {
 										},
 									},
 								},
-								Alternative: &ast.BlockStatement{
-									Meta: ast.New(T, 2, ast.Comments{}, comments("// Else Trailing comment"), comments("// Else Infix comment")),
-									Statements: []ast.Statement{
-										&ast.RestartStatement{
-											Meta: ast.New(T, 2),
+								Alternative: &ast.ElseStatement{
+									Meta: ast.New(T, 1, comments("// r"), comments(), comments("/* s */")),
+									Consequence: &ast.BlockStatement{
+										Meta: ast.New(T, 2, comments(), comments("// u"), comments("// t")),
+										Statements: []ast.Statement{
+											&ast.RestartStatement{
+												Meta: ast.New(T, 2),
+											},
 										},
 									},
 								},
@@ -919,9 +1052,12 @@ sub vcl_recv {
 						Statements: []ast.Statement{
 							&ast.SwitchStatement{
 								Meta: ast.New(T, 1, comments("// Switch")),
-								Control: &ast.Ident{
-									Meta:  ast.New(T, 1),
-									Value: "req.http.host",
+								Control: &ast.SwitchControl{
+									Meta: ast.New(T, 1),
+									Expression: &ast.Ident{
+										Meta:  ast.New(T, 1),
+										Value: "req.http.host",
+									},
 								},
 								Default: 1,
 								Cases: []*ast.CaseStatement{
@@ -1009,13 +1145,16 @@ sub vcl_recv {
 						Statements: []ast.Statement{
 							&ast.SwitchStatement{
 								Meta: ast.New(T, 1, comments("// Switch")),
-								Control: &ast.FunctionCallExpression{
+								Control: &ast.SwitchControl{
 									Meta: ast.New(T, 1),
-									Function: &ast.Ident{
-										Meta:  ast.New(T, 1),
-										Value: "uuid.version4",
+									Expression: &ast.FunctionCallExpression{
+										Meta: ast.New(T, 1),
+										Function: &ast.Ident{
+											Meta:  ast.New(T, 1),
+											Value: "uuid.version4",
+										},
+										Arguments: []ast.Expression{},
 									},
-									Arguments: []ast.Expression{},
 								},
 								Default: -1,
 								Cases: []*ast.CaseStatement{
@@ -1076,9 +1215,12 @@ sub vcl_recv {
 						Statements: []ast.Statement{
 							&ast.SwitchStatement{
 								Meta: ast.New(T, 1, comments("// Switch")),
-								Control: &ast.Boolean{
-									Meta:  ast.New(T, 1),
-									Value: true,
+								Control: &ast.SwitchControl{
+									Meta: ast.New(T, 1),
+									Expression: &ast.Boolean{
+										Meta:  ast.New(T, 1),
+										Value: true,
+									},
 								},
 								Default: 1,
 								Cases: []*ast.CaseStatement{
@@ -1243,19 +1385,19 @@ sub vcl_recv {
 	t.Run("Full comments", func(t *testing.T) {
 		input := `// Subroutine
 sub vcl_recv {
-	// Switch Leading comment
-	switch (req.http.Host) {
-	// Case1 Leading comment
-	case "1": // Case1 Trailing comment
+	// a
+	switch /* b */(/* c */req.http.Host /* d */) /* e */{
+	// f
+	case /* g */"1" /* h */: // i
 		esi;
-		// Break1 Leading comment
-		break; // Break1 Trailing comment
-	// Default Leading comment
-	default: // Default Trailing comment
+		// j
+		break /* k */; // l
+	// m
+	default /* n */: // o
 		esi;
 		break;
-	// Switch Infix comment
-	} // Switch Trailing comment
+	// p
+	} // q
 }`
 		expect := &ast.VCL{
 			Statements: []ast.Statement{
@@ -1269,20 +1411,23 @@ sub vcl_recv {
 						Meta: ast.New(T, 1),
 						Statements: []ast.Statement{
 							&ast.SwitchStatement{
-								Meta: ast.New(T, 1, comments("// Switch Leading comment"), comments("// Switch Trailing comment"), comments("// Switch Infix comment")),
-								Control: &ast.Ident{
-									Meta:  ast.New(T, 1),
-									Value: "req.http.Host",
+								Meta: ast.New(T, 1, comments("// a"), comments("// q"), comments("// p")),
+								Control: &ast.SwitchControl{
+									Meta: ast.New(T, 1, comments("/* b */"), comments("/* e */")),
+									Expression: &ast.Ident{
+										Meta:  ast.New(T, 1, comments("/* c */"), comments("/* d */")),
+										Value: "req.http.Host",
+									},
 								},
 								Default: 1,
 								Cases: []*ast.CaseStatement{
 									{
-										Meta: ast.New(T, 2, comments("// Case1 Leading comment"), comments("// Case1 Trailing comment")),
+										Meta: ast.New(T, 2, comments("// f"), comments("// i")),
 										Test: &ast.InfixExpression{
-											Meta:     ast.New(T, 2),
+											Meta:     ast.New(T, 2, comments("/* g */"), comments("/* h */")),
 											Operator: "==",
 											Right: &ast.String{
-												Meta:  ast.New(T, 2),
+												Meta:  ast.New(T, 2, comments("/* g */"), comments("/* h */")),
 												Value: "1",
 											},
 										},
@@ -1291,12 +1436,12 @@ sub vcl_recv {
 												Meta: ast.New(T, 2),
 											},
 											&ast.BreakStatement{
-												Meta: ast.New(T, 2, comments("// Break1 Leading comment"), comments("// Break1 Trailing comment")),
+												Meta: ast.New(T, 2, comments("// j"), comments("// l"), comments("/* k */")),
 											},
 										},
 									},
 									{
-										Meta: ast.New(T, 2, comments("// Default Leading comment"), comments("// Default Trailing comment")),
+										Meta: ast.New(T, 2, comments("// m"), comments("// o"), comments("/* n */")),
 										Statements: []ast.Statement{
 											&ast.EsiStatement{
 												Meta: ast.New(T, 2),
@@ -1325,7 +1470,7 @@ func TestParseUnsetStatement(t *testing.T) {
 	input := `// Subroutine
 sub vcl_recv {
 	// Leading comment
-	unset req.http.Host; // Trailing comment
+	unset /* Infix1 */ req.http.Host /* Infix2 */; // Trailing comment
 }`
 	expect := &ast.VCL{
 		Statements: []ast.Statement{
@@ -1341,7 +1486,7 @@ sub vcl_recv {
 						&ast.UnsetStatement{
 							Meta: ast.New(T, 1, comments("// Leading comment"), comments("// Trailing comment")),
 							Ident: &ast.Ident{
-								Meta:  ast.New(T, 1),
+								Meta:  ast.New(T, 1, comments("/* Infix1 */"), comments("/* Infix2 */")),
 								Value: "req.http.Host",
 							},
 						},
@@ -1362,7 +1507,7 @@ func TestParseAddStatement(t *testing.T) {
 		input := `// Subroutine
 sub vcl_recv {
 	// Leading comment
-	add req.http.Cookie:session = "example.com"; // Trailing comment
+	add /* a */ req.http.Cookie:session /* b */= /* c */ "example.com" /* d */; // Trailing comment
 }`
 		expect := &ast.VCL{
 			Statements: []ast.Statement{
@@ -1378,7 +1523,7 @@ sub vcl_recv {
 							&ast.AddStatement{
 								Meta: ast.New(T, 1, comments("// Leading comment"), comments("// Trailing comment")),
 								Ident: &ast.Ident{
-									Meta:  ast.New(T, 1),
+									Meta:  ast.New(T, 1, comments("/* a */"), comments("/* b */")),
 									Value: "req.http.Cookie:session",
 								},
 								Operator: &ast.Operator{
@@ -1386,7 +1531,7 @@ sub vcl_recv {
 									Operator: "=",
 								},
 								Value: &ast.String{
-									Meta:  ast.New(T, 1),
+									Meta:  ast.New(T, 1, comments("/* c */"), comments("/* d */")),
 									Value: "example.com",
 								},
 							},
@@ -1468,7 +1613,7 @@ func TestCallStatement(t *testing.T) {
 		input := `// Subroutine
 		sub vcl_recv {
 			// Leading comment
-			call feature_mod_recv; // Trailing comment
+			call /* a */ feature_mod_recv /* b */; // Trailing comment
 		}`
 		expect := &ast.VCL{
 			Statements: []ast.Statement{
@@ -1484,7 +1629,7 @@ func TestCallStatement(t *testing.T) {
 							&ast.CallStatement{
 								Meta: ast.New(T, 1, comments("// Leading comment"), comments("// Trailing comment")),
 								Subroutine: &ast.Ident{
-									Meta:  ast.New(T, 1),
+									Meta:  ast.New(T, 1, comments("/* a */"), comments("/* b */")),
 									Value: "feature_mod_recv",
 								},
 							},
@@ -1503,7 +1648,7 @@ func TestCallStatement(t *testing.T) {
 		input := `// Subroutine
 		sub vcl_recv {
 			// Leading comment
-			call feature_mod_recv(); // Trailing comment
+			call /* a */feature_mod_recv() /* b */; // Trailing comment
 		}`
 		expect := &ast.VCL{
 			Statements: []ast.Statement{
@@ -1519,7 +1664,7 @@ func TestCallStatement(t *testing.T) {
 							&ast.CallStatement{
 								Meta: ast.New(T, 1, comments("// Leading comment"), comments("// Trailing comment")),
 								Subroutine: &ast.Ident{
-									Meta:  ast.New(T, 1),
+									Meta:  ast.New(T, 1, comments("/* a */"), comments("/* b */")),
 									Value: "feature_mod_recv",
 								},
 							},
@@ -1537,44 +1682,85 @@ func TestCallStatement(t *testing.T) {
 }
 
 func TestDeclareStatement(t *testing.T) {
-	input := `// Subroutine
+	t.Run("Basic parse", func(t *testing.T) {
+		input := `// Subroutine
 sub vcl_recv {
 	// Leading comment
 	declare local var.foo STRING; // Trailing comment
 }`
 
-	expect := &ast.VCL{
-		Statements: []ast.Statement{
-			&ast.SubroutineDeclaration{
-				Meta: ast.New(T, 0, comments("// Subroutine")),
-				Name: &ast.Ident{
-					Meta:  ast.New(T, 0),
-					Value: "vcl_recv",
-				},
-				Block: &ast.BlockStatement{
-					Meta: ast.New(T, 1),
-					Statements: []ast.Statement{
-						&ast.DeclareStatement{
-							Meta: ast.New(T, 1, comments("// Leading comment"), comments("// Trailing comment")),
-							Name: &ast.Ident{
-								Meta:  ast.New(T, 1),
-								Value: "var.foo",
-							},
-							ValueType: &ast.Ident{
-								Meta:  ast.New(T, 1),
-								Value: "STRING",
+		expect := &ast.VCL{
+			Statements: []ast.Statement{
+				&ast.SubroutineDeclaration{
+					Meta: ast.New(T, 0, comments("// Subroutine")),
+					Name: &ast.Ident{
+						Meta:  ast.New(T, 0),
+						Value: "vcl_recv",
+					},
+					Block: &ast.BlockStatement{
+						Meta: ast.New(T, 1),
+						Statements: []ast.Statement{
+							&ast.DeclareStatement{
+								Meta: ast.New(T, 1, comments("// Leading comment"), comments("// Trailing comment")),
+								Name: &ast.Ident{
+									Meta:  ast.New(T, 1),
+									Value: "var.foo",
+								},
+								ValueType: &ast.Ident{
+									Meta:  ast.New(T, 1),
+									Value: "STRING",
+								},
 							},
 						},
 					},
 				},
 			},
-		},
-	}
-	vcl, err := New(lexer.NewFromString(input)).ParseVCL()
-	if err != nil {
-		t.Errorf("%+v", err)
-	}
-	assert(t, vcl, expect)
+		}
+		vcl, err := New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Errorf("%+v", err)
+		}
+		assert(t, vcl, expect)
+	})
+	t.Run("Full comments", func(t *testing.T) {
+		input := `sub vcl_recv {
+	// a
+	declare /* b */ local /* c */var.foo /* d */STRING /* e */; // e
+}`
+
+		expect := &ast.VCL{
+			Statements: []ast.Statement{
+				&ast.SubroutineDeclaration{
+					Meta: ast.New(T, 0),
+					Name: &ast.Ident{
+						Meta:  ast.New(T, 0),
+						Value: "vcl_recv",
+					},
+					Block: &ast.BlockStatement{
+						Meta: ast.New(T, 1),
+						Statements: []ast.Statement{
+							&ast.DeclareStatement{
+								Meta: ast.New(T, 1, comments("// a"), comments("// e"), comments("/* b */")),
+								Name: &ast.Ident{
+									Meta:  ast.New(T, 1, comments("/* c */"), comments("/* d */")),
+									Value: "var.foo",
+								},
+								ValueType: &ast.Ident{
+									Meta:  ast.New(T, 1, comments(), comments("/* e */")),
+									Value: "STRING",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		vcl, err := New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Errorf("%+v", err)
+		}
+		assert(t, vcl, expect)
+	})
 }
 
 func TestErrorStatement(t *testing.T) {
@@ -1754,15 +1940,97 @@ sub vcl_recv {
 		}
 		assert(t, vcl, expect)
 	})
+
+	t.Run("Full comments without argument", func(t *testing.T) {
+		input := `sub vcl_recv {
+	// a
+	error /* b */ 750 /* c */; // d
+}`
+		expect := &ast.VCL{
+			Statements: []ast.Statement{
+				&ast.SubroutineDeclaration{
+					Meta: ast.New(T, 0),
+					Name: &ast.Ident{
+						Meta:  ast.New(T, 0),
+						Value: "vcl_recv",
+					},
+					Block: &ast.BlockStatement{
+						Meta: ast.New(T, 1),
+						Statements: []ast.Statement{
+							&ast.ErrorStatement{
+								Meta: ast.New(T, 1, comments("// a"), comments("// d")),
+								Code: &ast.Integer{
+									Meta:  ast.New(T, 1, comments("/* b */"), comments("/* c */")),
+									Value: 750,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		vcl, err := New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Errorf("%+v", err)
+		}
+		assert(t, vcl, expect)
+	})
+
+	t.Run("Full comments with arguments", func(t *testing.T) {
+		input := `sub vcl_recv {
+	// a
+	error /* b */ 750 /* c */"/foobar/" /* d */ req.http.Foo /* e */; // f
+}`
+		expect := &ast.VCL{
+			Statements: []ast.Statement{
+				&ast.SubroutineDeclaration{
+					Meta: ast.New(T, 0),
+					Name: &ast.Ident{
+						Meta:  ast.New(T, 0),
+						Value: "vcl_recv",
+					},
+					Block: &ast.BlockStatement{
+						Meta: ast.New(T, 1),
+						Statements: []ast.Statement{
+							&ast.ErrorStatement{
+								Meta: ast.New(T, 1, comments("// a"), comments("// f")),
+								Code: &ast.Integer{
+									Meta:  ast.New(T, 1, comments("/* b */")),
+									Value: 750,
+								},
+								Argument: &ast.InfixExpression{
+									Meta: ast.New(T, 1, comments(), comments("/* e */")),
+									Left: &ast.String{
+										Meta:  ast.New(T, 1, comments("/* c */"), comments("/* d */")),
+										Value: "/foobar/",
+									},
+									Operator: "+",
+									Right: &ast.Ident{
+										Meta:  ast.New(T, 1, comments(), comments("/* e */")),
+										Value: "req.http.Foo",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		vcl, err := New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Errorf("%+v", err)
+		}
+		assert(t, vcl, expect)
+	})
 }
 
 func TestLogStatement(t *testing.T) {
 	input := `// Subroutine
 sub vcl_recv {
 	// Leading comment
-	log {"syslog "}
-		{" fastly-log :: "} {"	timestamp:"}
-		req.http.Timestamp
+	log /* a */ {"syslog "} // b
+		{" fastly-log :: "} /* c */ {"	timestamp:"}
+		req.http.Timestamp // d
 	; // Trailing comment
 }`
 	expect := &ast.VCL{
@@ -1779,10 +2047,10 @@ sub vcl_recv {
 						&ast.LogStatement{
 							Meta: ast.New(T, 1, comments("// Leading comment"), comments("// Trailing comment")),
 							Value: &ast.InfixExpression{
-								Meta:     ast.New(T, 1),
+								Meta:     ast.New(T, 1, comments(), comments("// d")),
 								Operator: "+",
 								Right: &ast.Ident{
-									Meta:  ast.New(T, 1),
+									Meta:  ast.New(T, 1, comments(), comments("// d")),
 									Value: "req.http.Timestamp",
 								},
 								Left: &ast.InfixExpression{
@@ -1793,14 +2061,14 @@ sub vcl_recv {
 										Value: "	timestamp:",
 									},
 									Left: &ast.InfixExpression{
-										Meta:     ast.New(T, 1),
+										Meta:     ast.New(T, 1, comments(), comments("/* c */")),
 										Operator: "+",
 										Right: &ast.String{
-											Meta:  ast.New(T, 1),
+											Meta:  ast.New(T, 1, comments(), comments("/* c */")),
 											Value: " fastly-log :: ",
 										},
 										Left: &ast.String{
-											Meta:  ast.New(T, 1),
+											Meta:  ast.New(T, 1, comments("/* a */"), comments("// b")),
 											Value: "syslog ",
 										},
 									},
@@ -1820,132 +2088,264 @@ sub vcl_recv {
 }
 
 func TestReturnStatement(t *testing.T) {
-	input := `// Subroutine
+	t.Run("Basic parse", func(t *testing.T) {
+		input := `// Subroutine
 sub vcl_recv {
 	// Leading comment
 	return(deliver); // Trailing comment
 }`
-	var rt ast.Expression
-	rt = &ast.Ident{
-		Meta:  ast.New(T, 1),
-		Value: "deliver",
-	}
-	expect := &ast.VCL{
-		Statements: []ast.Statement{
-			&ast.SubroutineDeclaration{
-				Meta: ast.New(T, 0, comments("// Subroutine")),
-				Name: &ast.Ident{
-					Meta:  ast.New(T, 0),
-					Value: "vcl_recv",
-				},
-				Block: &ast.BlockStatement{
-					Meta: ast.New(T, 1),
-					Statements: []ast.Statement{
-						&ast.ReturnStatement{
-							Meta:             ast.New(T, 1, comments("// Leading comment"), comments("// Trailing comment")),
-							ReturnExpression: &rt,
-							HasParenthesis:   true,
+		expect := &ast.VCL{
+			Statements: []ast.Statement{
+				&ast.SubroutineDeclaration{
+					Meta: ast.New(T, 0, comments("// Subroutine")),
+					Name: &ast.Ident{
+						Meta:  ast.New(T, 0),
+						Value: "vcl_recv",
+					},
+					Block: &ast.BlockStatement{
+						Meta: ast.New(T, 1),
+						Statements: []ast.Statement{
+							&ast.ReturnStatement{
+								Meta: ast.New(T, 1, comments("// Leading comment"), comments("// Trailing comment")),
+								ReturnExpression: &ast.Ident{
+									Meta:  ast.New(T, 1),
+									Value: "deliver",
+								},
+								HasParenthesis:              true,
+								ParenthesisLeadingComments:  comments(),
+								ParenthesisTrailingComments: comments(),
+							},
 						},
 					},
 				},
 			},
-		},
-	}
-	vcl, err := New(lexer.NewFromString(input)).ParseVCL()
-	if err != nil {
-		t.Errorf("%+v", err)
-	}
-	assert(t, vcl, expect)
+		}
+		vcl, err := New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Errorf("%+v", err)
+		}
+		assert(t, vcl, expect)
+	})
+
+	t.Run("Full comments", func(t *testing.T) {
+		input := `sub vcl_recv {
+	// a
+	return /* b */(/* c */lookup/* d */)/* e */; // f
+}`
+		expect := &ast.VCL{
+			Statements: []ast.Statement{
+				&ast.SubroutineDeclaration{
+					Meta: ast.New(T, 0),
+					Name: &ast.Ident{
+						Meta:  ast.New(T, 0),
+						Value: "vcl_recv",
+					},
+					Block: &ast.BlockStatement{
+						Meta: ast.New(T, 1),
+						Statements: []ast.Statement{
+							&ast.ReturnStatement{
+								Meta: ast.New(T, 1, comments("// a"), comments("// f")),
+								ReturnExpression: &ast.Ident{
+									Meta:  ast.New(T, 1, comments("/* c */"), comments("/* d */")),
+									Value: "lookup",
+								},
+								HasParenthesis:              true,
+								ParenthesisLeadingComments:  comments("/* b */"),
+								ParenthesisTrailingComments: comments("/* e */"),
+							},
+						},
+					},
+				},
+			},
+		}
+		vcl, err := New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Errorf("%+v", err)
+		}
+		assert(t, vcl, expect)
+	})
 }
 
 func TestSyntheticStatement(t *testing.T) {
-	input := `// Subroutine
+	t.Run("Basic parse", func(t *testing.T) {
+		input := `// Subroutine
 sub vcl_recv {
 	// Leading comment
 	synthetic {"Access "}
 		{"denied"}; // Trailing comment
 }`
-	expect := &ast.VCL{
-		Statements: []ast.Statement{
-			&ast.SubroutineDeclaration{
-				Meta: ast.New(T, 0, comments("// Subroutine")),
-				Name: &ast.Ident{
-					Meta:  ast.New(T, 0),
-					Value: "vcl_recv",
-				},
-				Block: &ast.BlockStatement{
-					Meta: ast.New(T, 1),
-					Statements: []ast.Statement{
-						&ast.SyntheticStatement{
-							Meta: ast.New(T, 1, comments("// Leading comment"), comments("// Trailing comment")),
-							Value: &ast.InfixExpression{
-								Meta: ast.New(T, 1),
-								Left: &ast.String{
-									Meta:  ast.New(T, 1),
-									Value: "Access ",
-								},
-								Operator: "+",
-								Right: &ast.String{
-									Meta:  ast.New(T, 1),
-									Value: "denied",
+		expect := &ast.VCL{
+			Statements: []ast.Statement{
+				&ast.SubroutineDeclaration{
+					Meta: ast.New(T, 0, comments("// Subroutine")),
+					Name: &ast.Ident{
+						Meta:  ast.New(T, 0),
+						Value: "vcl_recv",
+					},
+					Block: &ast.BlockStatement{
+						Meta: ast.New(T, 1),
+						Statements: []ast.Statement{
+							&ast.SyntheticStatement{
+								Meta: ast.New(T, 1, comments("// Leading comment"), comments("// Trailing comment")),
+								Value: &ast.InfixExpression{
+									Meta: ast.New(T, 1),
+									Left: &ast.String{
+										Meta:  ast.New(T, 1),
+										Value: "Access ",
+									},
+									Operator: "+",
+									Right: &ast.String{
+										Meta:  ast.New(T, 1),
+										Value: "denied",
+									},
 								},
 							},
 						},
 					},
 				},
 			},
-		},
-	}
-	vcl, err := New(lexer.NewFromString(input)).ParseVCL()
-	if err != nil {
-		t.Errorf("%+v", err)
-	}
-	assert(t, vcl, expect)
+		}
+		vcl, err := New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Errorf("%+v", err)
+		}
+		assert(t, vcl, expect)
+	})
+
+	t.Run("Full comments", func(t *testing.T) {
+		input := `sub vcl_recv {
+	// a
+	synthetic /* b */ {"Access "} // c
+		/* d */ {"denied"} /* e */; // f
+}`
+		expect := &ast.VCL{
+			Statements: []ast.Statement{
+				&ast.SubroutineDeclaration{
+					Meta: ast.New(T, 0),
+					Name: &ast.Ident{
+						Meta:  ast.New(T, 0),
+						Value: "vcl_recv",
+					},
+					Block: &ast.BlockStatement{
+						Meta: ast.New(T, 1),
+						Statements: []ast.Statement{
+							&ast.SyntheticStatement{
+								Meta: ast.New(T, 1, comments("// a"), comments("// f")),
+								Value: &ast.InfixExpression{
+									Meta: ast.New(T, 1, comments(), comments("/* e */")),
+									Left: &ast.String{
+										Meta:  ast.New(T, 1, comments("/* b */"), comments("// c", "/* d */")),
+										Value: "Access ",
+									},
+									Operator: "+",
+									Right: &ast.String{
+										Meta:  ast.New(T, 1, comments(), comments("/* e */")),
+										Value: "denied",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		vcl, err := New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Errorf("%+v", err)
+		}
+		assert(t, vcl, expect)
+	})
 }
 
 func TestSyntheticBase64Statement(t *testing.T) {
-	input := `// Subroutine
+	t.Run("Basic parse", func(t *testing.T) {
+		input := `// Subroutine
 sub vcl_recv {
 	// Leading comment
 	synthetic.base64 {"Access "}
 		{"denied"}; // Trailing comment
 }`
-	expect := &ast.VCL{
-		Statements: []ast.Statement{
-			&ast.SubroutineDeclaration{
-				Meta: ast.New(T, 0, comments("// Subroutine")),
-				Name: &ast.Ident{
-					Meta:  ast.New(T, 0),
-					Value: "vcl_recv",
-				},
-				Block: &ast.BlockStatement{
-					Meta: ast.New(T, 1),
-					Statements: []ast.Statement{
-						&ast.SyntheticBase64Statement{
-							Meta: ast.New(T, 1, comments("// Leading comment"), comments("// Trailing comment")),
-							Value: &ast.InfixExpression{
-								Meta: ast.New(T, 1),
-								Left: &ast.String{
-									Meta:  ast.New(T, 1),
-									Value: "Access ",
-								},
-								Operator: "+",
-								Right: &ast.String{
-									Meta:  ast.New(T, 1),
-									Value: "denied",
+		expect := &ast.VCL{
+			Statements: []ast.Statement{
+				&ast.SubroutineDeclaration{
+					Meta: ast.New(T, 0, comments("// Subroutine")),
+					Name: &ast.Ident{
+						Meta:  ast.New(T, 0),
+						Value: "vcl_recv",
+					},
+					Block: &ast.BlockStatement{
+						Meta: ast.New(T, 1),
+						Statements: []ast.Statement{
+							&ast.SyntheticBase64Statement{
+								Meta: ast.New(T, 1, comments("// Leading comment"), comments("// Trailing comment")),
+								Value: &ast.InfixExpression{
+									Meta: ast.New(T, 1),
+									Left: &ast.String{
+										Meta:  ast.New(T, 1),
+										Value: "Access ",
+									},
+									Operator: "+",
+									Right: &ast.String{
+										Meta:  ast.New(T, 1),
+										Value: "denied",
+									},
 								},
 							},
 						},
 					},
 				},
 			},
-		},
-	}
-	vcl, err := New(lexer.NewFromString(input)).ParseVCL()
-	if err != nil {
-		t.Errorf("%+v", err)
-	}
-	assert(t, vcl, expect)
+		}
+		vcl, err := New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Errorf("%+v", err)
+		}
+		assert(t, vcl, expect)
+	})
+
+	t.Run("Full comments", func(t *testing.T) {
+		input := `sub vcl_recv {
+	// a
+	synthetic.base64 /* b */ {"Access "} // c
+		/* d */ {"denied"} /* e */; // f
+}`
+		expect := &ast.VCL{
+			Statements: []ast.Statement{
+				&ast.SubroutineDeclaration{
+					Meta: ast.New(T, 0),
+					Name: &ast.Ident{
+						Meta:  ast.New(T, 0),
+						Value: "vcl_recv",
+					},
+					Block: &ast.BlockStatement{
+						Meta: ast.New(T, 1),
+						Statements: []ast.Statement{
+							&ast.SyntheticBase64Statement{
+								Meta: ast.New(T, 1, comments("// a"), comments("// f")),
+								Value: &ast.InfixExpression{
+									Meta: ast.New(T, 1, comments(), comments("/* e */")),
+									Left: &ast.String{
+										Meta:  ast.New(T, 1, comments("/* b */"), comments("// c", "/* d */")),
+										Value: "Access ",
+									},
+									Operator: "+",
+									Right: &ast.String{
+										Meta:  ast.New(T, 1, comments(), comments("/* e */")),
+										Value: "denied",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		vcl, err := New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Errorf("%+v", err)
+		}
+		assert(t, vcl, expect)
+	})
 }
 
 func TestBlockSyntaxInsideBlockStatement(t *testing.T) {
@@ -2168,6 +2568,50 @@ func TestGotoStatement(t *testing.T) {
 		}
 		assert(t, vcl, expect)
 	})
+
+	t.Run("Full comments", func(t *testing.T) {
+		input := `sub vcl_recv {
+			// a
+			goto /* b */update_and_set /* c */; // d
+			// e
+			update_and_set: // g
+		}`
+		expect := &ast.VCL{
+			Statements: []ast.Statement{
+				&ast.SubroutineDeclaration{
+					Meta: ast.New(T, 0),
+					Name: &ast.Ident{
+						Meta:  ast.New(T, 0),
+						Value: "vcl_recv",
+					},
+					Block: &ast.BlockStatement{
+						Meta: ast.New(T, 1),
+						Statements: []ast.Statement{
+							&ast.GotoStatement{
+								Meta: ast.New(T, 1, comments("// a"), comments("// d")),
+								Destination: &ast.Ident{
+									Meta:  ast.New(T, 1, comments("/* b */"), comments("/* c */")),
+									Value: "update_and_set",
+								},
+							},
+							&ast.GotoDestinationStatement{
+								Meta: ast.New(T, 1, comments("// e"), comments("// g")),
+								Name: &ast.Ident{
+									Meta:  ast.New(T, 1, comments("// e"), comments("// g")),
+									Value: "update_and_set:",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		vcl, err := New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Errorf("%+v", err)
+		}
+		assert(t, vcl, expect)
+	})
 }
 
 func TestFunctionCallStatement(t *testing.T) {
@@ -2195,7 +2639,8 @@ sub vcl_recv {
 									Meta:  ast.New(T, 1, comments("// Function Leading comment"), comments("// Function Trailing comment")),
 									Value: "testFun",
 								},
-								Arguments: []ast.Expression{},
+								Arguments:                  []ast.Expression{},
+								ParenthesisTrailingComment: comments(),
 							},
 						},
 					},
@@ -2246,6 +2691,7 @@ sub vcl_recv {
 										Value: 3,
 									},
 								},
+								ParenthesisTrailingComment: comments(),
 							},
 						},
 					},
@@ -2296,6 +2742,59 @@ sub vcl_recv {
 										Value: 3,
 									},
 								},
+								ParenthesisTrailingComment: comments(),
+							},
+						},
+					},
+				},
+			},
+		}
+		vcl, err := New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Errorf("%+v", err)
+		}
+		assert(t, vcl, expect)
+	})
+
+	t.Run("Full comments", func(t *testing.T) {
+		input := `
+sub vcl_recv {
+	// a
+	std.collect(/* b */test1 /* c */, /* d */"test2" /* e */, /* f */3 /* g */) /* h */; // i
+}`
+
+		expect := &ast.VCL{
+			Statements: []ast.Statement{
+				&ast.SubroutineDeclaration{
+					Meta: ast.New(T, 0),
+					Name: &ast.Ident{
+						Meta:  ast.New(T, 0),
+						Value: "vcl_recv",
+					},
+					Block: &ast.BlockStatement{
+						Meta: ast.New(T, 1),
+						Statements: []ast.Statement{
+							&ast.FunctionCallStatement{
+								Meta: ast.New(T, 1, comments("// a"), comments("// i")),
+								Function: &ast.Ident{
+									Meta:  ast.New(T, 1, comments("// a"), comments("// i")),
+									Value: "std.collect",
+								},
+								Arguments: []ast.Expression{
+									&ast.Ident{
+										Meta:  ast.New(T, 1, comments("/* b */"), comments("/* c */")),
+										Value: "test1",
+									},
+									&ast.String{
+										Meta:  ast.New(T, 1, comments("/* d */"), comments("/* e */")),
+										Value: "test2",
+									},
+									&ast.Integer{
+										Meta:  ast.New(T, 1, comments("/* f */"), comments("/* g */")),
+										Value: 3,
+									},
+								},
+								ParenthesisTrailingComment: comments("/* h */"),
 							},
 						},
 					},


### PR DESCRIPTION
This PR improves more complex comment parsing, which relates to #299 .

The current implementation focuses on the meaning syntax (IDENT, STRING, etc...) so some positions of comments are ignored. It's okay to run linter and interpreter but this is important for a formatter to keep the original VCL including comments.

See https://github.com/ysugimoto/falco/blob/feature/complex-comments/docs/parser.md which defines parser spec, and enables to put comment position.

