### PR TITLE
use go 1.22.2 and golangci-lint 1.58, fix actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,13 +17,13 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.21.1
+        go-version: 1.22.2
     - name: Run tests
       run: make test
     - name: Lint programs
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v5
       with:
-        version: v1.54
+        version: v1.58
         skip-pkg-cache: true
         skip-build-cache: true
         skip-go-installation: true

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -12,13 +12,13 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.21.1
+        go-version: 1.22.2
     - name: Run tests
       run: make test
     - name: Lint programs
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v5
       with:
-        version: v1.54
+        version: v1.58
         skip-pkg-cache: true
         skip-build-cache: true
         skip-go-installation: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,13 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.1
+          go-version: 1.22.2
       - name: Run tests
         run: make test
       - name: Lint programs
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v5
         with:
-          version: v1.54
+          version: v1.58
           skip-pkg-cache: true
           skip-build-cache: true
           skip-go-installation: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,8 @@ run:
   concurrency: 4
   timeout: 3m
   tests: false
-  skip-dirs:
+issues:
+  exclude-dirs:
     - dist
     - docs
     - .github
@@ -58,63 +59,32 @@ linters-settings:
 
     #see: https://go-critic.github.io/overview#checks-overview
     enabled-checks:
-      - appendAssign
-      - argOrder
-      - assignOp
-      - badCall
-      - badCond
       - boolExprSimplify
       - builtinShadow
-      - captLocal
-      - caseOrder
-      - commentFormatting
-      #- commentedOutCode
-      - defaultCaseOrder
-      - dupArg
-      - dupBranchBody
-      - dupCase
-      - dupSubExpr
-      - elseif
       - emptyFallthrough
       - emptyStringTest
       - equalFold
       - evalOrder
-      - exitAfterDefer
-      - flagDeref
-      - flagName
-      - ifElseChain
       - importShadow
       - indexAlloc
       - initClause
-      - mapKey
       - methodExprCall
       - nestingReduce
       - nilValReturn
       - octalLiteral
-      - offBy1
       - paramTypeCombine
       - ptrToRefParam
       - rangeExprCopy
       - rangeValCopy
-      - regexpMust
       - regexpPattern
-      - singleCaseSwitch
-      - sloppyLen
       - sloppyReassign
       - stringXbytes
-      - switchTrue
       - truncateCmp
       - typeAssertChain
-      - typeSwitchVar
       - typeUnparen
-      - underef
       - unlabelStmt
-      - unlambda
       - unnecessaryBlock
-      - unslice
-      - valSwap
       - weakCond
-      - wrapperFunc
       - yodaStyleExpr
   gocyclo:
     min-complexity: 50

--- a/interpreter/context/option.go
+++ b/interpreter/context/option.go
@@ -20,15 +20,15 @@ func WithSnippets(fs *snippets.Snippets) Option {
 	}
 }
 
-func WithMaxBackends(max int) Option {
+func WithMaxBackends(maxBackends int) Option {
 	return func(c *Context) {
-		c.OverrideMaxBackends = max
+		c.OverrideMaxBackends = maxBackends
 	}
 }
 
-func WithMaxAcls(max int) Option {
+func WithMaxAcls(maxAcls int) Option {
 	return func(c *Context) {
-		c.OverrideMaxAcls = max
+		c.OverrideMaxAcls = maxAcls
 	}
 }
 

--- a/interpreter/director.go
+++ b/interpreter/director.go
@@ -362,7 +362,7 @@ func (i *Interpreter) directorBackendConsistentHash(dc *value.DirectorConfig) (*
 	hashTable := make(map[uint32]*value.Backend)
 
 	var healthyBackends int
-	max := uint32(math.Pow(10, 4)) // max 10000
+	maxNum := uint32(math.Pow(10, 4)) // max 10000
 	// Put backends to the circles
 	for _, v := range dc.Backends {
 		if !v.Backend.Healthy.Load() {
@@ -378,7 +378,7 @@ func (i *Interpreter) directorBackendConsistentHash(dc *value.DirectorConfig) (*
 			hash.Write([]byte(v.Backend.Value.Name.Value))
 			hash.Write([]byte(fmt.Sprint(i)))
 			h := hash.Sum(nil)
-			num := binary.BigEndian.Uint32(h[:8]) % max
+			num := binary.BigEndian.Uint32(h[:8]) % maxNum
 			hashTable[num] = v.Backend
 			circles = append(circles, num)
 		}
@@ -406,7 +406,7 @@ func (i *Interpreter) directorBackendConsistentHash(dc *value.DirectorConfig) (*
 		hashKey = sha256.Sum256([]byte(identity))
 	}
 
-	key := binary.BigEndian.Uint32(hashKey[:8]) % max
+	key := binary.BigEndian.Uint32(hashKey[:8]) % maxNum
 	index := sort.Search(len(circles), func(i int) bool {
 		return circles[i] >= key
 	})
@@ -424,8 +424,8 @@ func (i *Interpreter) getBackendByHash(dc *value.DirectorConfig, hash []byte) (*
 
 	var target *value.Backend
 	for m := 4; m <= 16; m += 2 {
-		max := uint64(math.Pow(10, float64(m)))
-		num := binary.BigEndian.Uint64(hash[:8]) % max
+		maxNum := uint64(math.Pow(10, float64(m)))
+		num := binary.BigEndian.Uint64(hash[:8]) % maxNum
 
 		for _, v := range dc.Backends {
 			if !v.Backend.Healthy.Load() {
@@ -433,7 +433,7 @@ func (i *Interpreter) getBackendByHash(dc *value.DirectorConfig, hash []byte) (*
 			}
 			bh := sha256.Sum256([]byte(v.Backend.Value.String()))
 			b := binary.BigEndian.Uint64(bh[:8])
-			if b%(max*10) >= num && b%(max*10) < num+max {
+			if b%(maxNum*10) >= num && b%(maxNum*10) < num+maxNum {
 				target = v.Backend
 				goto DETERMINED
 			}

--- a/interpreter/function/errors/errors.go
+++ b/interpreter/function/errors/errors.go
@@ -29,8 +29,8 @@ func ArgumentNotEnough(name string, expects int, args []value.Value) error {
 	return New(name, "Expects %d arguments but %d provided", expects, len(args))
 }
 
-func ArgumentNotInRange(name string, min, max int, args []value.Value) error {
-	return New(name, "Expects between %d and %d arguments but %d argument provided", min, max, len(args))
+func ArgumentNotInRange(name string, minArgs, maxArgs int, args []value.Value) error {
+	return New(name, "Expects between %d and %d arguments but %d argument provided", minArgs, maxArgs, len(args))
 }
 
 func TypeMismatch(name string, num int, expects, actual value.Type) error {

--- a/interpreter/variable/header.go
+++ b/interpreter/variable/header.go
@@ -133,7 +133,7 @@ func removeCookieByName(r *http.Request, cookieName string) {
 
 		var sub []string
 		var part string
-		for len(line) > 0 { // continue since we have rest
+		for line != "" { // continue since we have rest
 			part, line, _ = strings.Cut(line, ";")
 			trimmedPart := textproto.TrimString(part)
 			if trimmedPart == "" {

--- a/parser/string_escape.go
+++ b/parser/string_escape.go
@@ -106,29 +106,29 @@ func next(r *bufio.Reader) rune {
 // * %XXXX
 // * %{...}
 func codePointEscape(r *bufio.Reader) (string, error) {
-	var min, max int
+	var minPosition, maxPosition int
 
 	// Is the escape a fixed or variable width code point escape.
 	if peek(r) == '{' {
 		next(r)
-		min, max = 1, 6
+		minPosition, maxPosition = 1, 6
 	} else {
-		min, max = 4, 4
+		minPosition, maxPosition = 4, 4
 	}
 
 	// Read at least `min` hex digits up to `max`
 	var x int
-	for n := 0; n < max; n++ {
+	for n := 0; n < maxPosition; n++ {
 		if !isHex(peek(r)) {
-			if n < min {
-				return "", fmt.Errorf("incomplete unicode escape. %d missing digits", min-n)
+			if n < minPosition {
+				return "", fmt.Errorf("incomplete unicode escape. %d missing digits", minPosition-n)
 			}
 			break
 		}
 		x = x*16 + digitVal(next(r))
 	}
 
-	if max == 6 {
+	if maxPosition == 6 {
 		if c := next(r); c != '}' {
 			return "", fmt.Errorf("incomplete %%{xxxx} escape")
 		}


### PR DESCRIPTION
This PR updates go version to 1.22.2 (latest). According to golangci-lint should be updated.