### PR TITLE
Feature/custom syntax

### DIFF
--- a/ast/acl_declaration.go
+++ b/ast/acl_declaration.go
@@ -10,8 +10,8 @@ type AclDeclaration struct {
 	CIDRs []*AclCidr
 }
 
-func (a *AclDeclaration) statement()     {}
-func (a *AclDeclaration) expression()    {}
+func (a *AclDeclaration) Statement()     {}
+func (a *AclDeclaration) Expression()    {}
 func (a *AclDeclaration) GetMeta() *Meta { return a.Meta }
 func (a *AclDeclaration) String() string {
 	var buf bytes.Buffer

--- a/ast/add_statement.go
+++ b/ast/add_statement.go
@@ -11,7 +11,7 @@ type AddStatement struct {
 	Value    Expression
 }
 
-func (a *AddStatement) statement()     {}
+func (a *AddStatement) Statement()     {}
 func (a *AddStatement) GetMeta() *Meta { return a.Meta }
 func (a *AddStatement) String() string {
 	var buf bytes.Buffer

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -14,7 +14,7 @@ type Node interface {
 
 type Statement interface {
 	Node
-	statement()
+	Statement()
 	LeadingComment(combinationMode) string
 	TrailingComment(combinationMode) string
 	InfixComment(combinationMode) string
@@ -22,7 +22,7 @@ type Statement interface {
 
 type Expression interface {
 	Node
-	expression()
+	Expression()
 	LeadingComment(combinationMode) string
 	TrailingComment(combinationMode) string
 	InfixComment(combinationMode) string

--- a/ast/backend_declaration.go
+++ b/ast/backend_declaration.go
@@ -10,8 +10,8 @@ type BackendDeclaration struct {
 	Properties []*BackendProperty
 }
 
-func (b *BackendDeclaration) statement()     {}
-func (b *BackendDeclaration) expression()    {}
+func (b *BackendDeclaration) Statement()     {}
+func (b *BackendDeclaration) Expression()    {}
 func (b *BackendDeclaration) GetMeta() *Meta { return b.Meta }
 func (b *BackendDeclaration) String() string {
 	var buf bytes.Buffer
@@ -37,7 +37,7 @@ type BackendProperty struct {
 	Value Expression
 }
 
-func (p *BackendProperty) expression()    {}
+func (p *BackendProperty) Expression()    {}
 func (p *BackendProperty) GetMeta() *Meta { return p.Meta }
 func (p *BackendProperty) String() string {
 	var buf bytes.Buffer
@@ -59,7 +59,7 @@ type BackendProbeObject struct {
 	Values []*BackendProperty
 }
 
-func (o *BackendProbeObject) expression()    {}
+func (o *BackendProbeObject) Expression()    {}
 func (o *BackendProbeObject) GetMeta() *Meta { return o.Meta }
 func (o *BackendProbeObject) String() string {
 	var buf bytes.Buffer

--- a/ast/block_statement.go
+++ b/ast/block_statement.go
@@ -9,7 +9,7 @@ type BlockStatement struct {
 	Statements []Statement
 }
 
-func (b *BlockStatement) statement()     {}
+func (b *BlockStatement) Statement()     {}
 func (b *BlockStatement) GetMeta() *Meta { return b.Meta }
 func (b *BlockStatement) String() string {
 	var buf bytes.Buffer

--- a/ast/break_statement.go
+++ b/ast/break_statement.go
@@ -8,7 +8,7 @@ type BreakStatement struct {
 	*Meta
 }
 
-func (r *BreakStatement) statement()     {}
+func (r *BreakStatement) Statement()     {}
 func (r *BreakStatement) GetMeta() *Meta { return r.Meta }
 func (r *BreakStatement) String() string {
 	var buf bytes.Buffer

--- a/ast/call_statement.go
+++ b/ast/call_statement.go
@@ -9,7 +9,7 @@ type CallStatement struct {
 	Subroutine *Ident
 }
 
-func (c *CallStatement) statement()     {}
+func (c *CallStatement) Statement()     {}
 func (c *CallStatement) GetMeta() *Meta { return c.Meta }
 func (c *CallStatement) String() string {
 	var buf bytes.Buffer

--- a/ast/case_statement.go
+++ b/ast/case_statement.go
@@ -11,7 +11,7 @@ type CaseStatement struct {
 	Fallthrough bool
 }
 
-func (s *CaseStatement) statement()     {}
+func (s *CaseStatement) Statement()     {}
 func (s *CaseStatement) GetMeta() *Meta { return s.Meta }
 func (s *CaseStatement) String() string {
 	var buf bytes.Buffer

--- a/ast/custom_statement.go
+++ b/ast/custom_statement.go
@@ -1,0 +1,9 @@
+package ast
+
+// CustomStatement represents user-defined statement.
+// The CustomStatement that will be defined externally must be implemented some methods
+// to be enable type assertion.
+type CustomStatement interface {
+	Statement
+	Literal() string
+}

--- a/ast/declare_statement.go
+++ b/ast/declare_statement.go
@@ -10,7 +10,7 @@ type DeclareStatement struct {
 	ValueType *Ident
 }
 
-func (d *DeclareStatement) statement()     {}
+func (d *DeclareStatement) Statement()     {}
 func (d *DeclareStatement) GetMeta() *Meta { return d.Meta }
 func (d *DeclareStatement) String() string {
 	var buf bytes.Buffer

--- a/ast/director_declaration.go
+++ b/ast/director_declaration.go
@@ -11,7 +11,7 @@ type DirectorDeclaration struct {
 	Properties   []Expression
 }
 
-func (d *DirectorDeclaration) statement()     {}
+func (d *DirectorDeclaration) Statement()     {}
 func (d *DirectorDeclaration) GetMeta() *Meta { return d.Meta }
 func (d *DirectorDeclaration) String() string {
 	var buf bytes.Buffer
@@ -42,7 +42,7 @@ type DirectorProperty struct {
 	Value Expression
 }
 
-func (d *DirectorProperty) expression()    {}
+func (d *DirectorProperty) Expression()    {}
 func (d *DirectorProperty) GetMeta() *Meta { return d.Meta }
 func (d *DirectorProperty) String() string {
 	var buf bytes.Buffer
@@ -63,7 +63,7 @@ type DirectorBackendObject struct {
 	Values []*DirectorProperty
 }
 
-func (d *DirectorBackendObject) expression()    {}
+func (d *DirectorBackendObject) Expression()    {}
 func (d *DirectorBackendObject) GetMeta() *Meta { return d.Meta }
 func (d *DirectorBackendObject) String() string {
 	var buf bytes.Buffer

--- a/ast/error_statement.go
+++ b/ast/error_statement.go
@@ -10,7 +10,7 @@ type ErrorStatement struct {
 	Argument Expression
 }
 
-func (e *ErrorStatement) statement()     {}
+func (e *ErrorStatement) Statement()     {}
 func (e *ErrorStatement) GetMeta() *Meta { return e.Meta }
 func (e *ErrorStatement) String() string {
 	var buf bytes.Buffer

--- a/ast/esi_statement.go
+++ b/ast/esi_statement.go
@@ -8,7 +8,7 @@ type EsiStatement struct {
 	*Meta
 }
 
-func (e *EsiStatement) statement()     {}
+func (e *EsiStatement) Statement()     {}
 func (e *EsiStatement) GetMeta() *Meta { return e.Meta }
 func (e *EsiStatement) String() string {
 	var buf bytes.Buffer

--- a/ast/fallthrough_statement.go
+++ b/ast/fallthrough_statement.go
@@ -8,7 +8,7 @@ type FallthroughStatement struct {
 	*Meta
 }
 
-func (r *FallthroughStatement) statement()     {}
+func (r *FallthroughStatement) Statement()     {}
 func (r *FallthroughStatement) GetMeta() *Meta { return r.Meta }
 func (r *FallthroughStatement) String() string {
 	var buf bytes.Buffer

--- a/ast/functioncall_expression.go
+++ b/ast/functioncall_expression.go
@@ -10,7 +10,7 @@ type FunctionCallExpression struct {
 	Arguments []Expression
 }
 
-func (f *FunctionCallExpression) expression()    {}
+func (f *FunctionCallExpression) Expression()    {}
 func (f *FunctionCallExpression) GetMeta() *Meta { return f.Meta }
 func (f *FunctionCallExpression) String() string {
 	var buf bytes.Buffer

--- a/ast/functioncall_statement.go
+++ b/ast/functioncall_statement.go
@@ -10,7 +10,7 @@ type FunctionCallStatement struct {
 	Arguments []Expression
 }
 
-func (fc *FunctionCallStatement) statement()     {}
+func (fc *FunctionCallStatement) Statement()     {}
 func (fc *FunctionCallStatement) GetMeta() *Meta { return fc.Meta }
 func (fc *FunctionCallStatement) String() string {
 	var buf bytes.Buffer

--- a/ast/goto_destination_statement.go
+++ b/ast/goto_destination_statement.go
@@ -9,7 +9,7 @@ type GotoDestinationStatement struct {
 	Name *Ident
 }
 
-func (gd *GotoDestinationStatement) statement()     {}
+func (gd *GotoDestinationStatement) Statement()     {}
 func (gd *GotoDestinationStatement) GetMeta() *Meta { return gd.Meta }
 func (gd *GotoDestinationStatement) String() string {
 	var buf bytes.Buffer

--- a/ast/goto_statement.go
+++ b/ast/goto_statement.go
@@ -9,7 +9,7 @@ type GotoStatement struct {
 	Destination *Ident
 }
 
-func (g *GotoStatement) statement()     {}
+func (g *GotoStatement) Statement()     {}
 func (g *GotoStatement) GetMeta() *Meta { return g.Meta }
 func (g *GotoStatement) String() string {
 	var buf bytes.Buffer

--- a/ast/grouped_expression.go
+++ b/ast/grouped_expression.go
@@ -9,7 +9,7 @@ type GroupedExpression struct {
 	Right Expression
 }
 
-func (g *GroupedExpression) expression()    {}
+func (g *GroupedExpression) Expression()    {}
 func (g *GroupedExpression) GetMeta() *Meta { return g.Meta }
 func (g *GroupedExpression) String() string {
 	var buf bytes.Buffer

--- a/ast/if_expression.go
+++ b/ast/if_expression.go
@@ -11,7 +11,7 @@ type IfExpression struct {
 	Alternative Expression
 }
 
-func (i *IfExpression) expression()    {}
+func (i *IfExpression) Expression()    {}
 func (i *IfExpression) GetMeta() *Meta { return i.Meta }
 func (i *IfExpression) String() string {
 	var buf bytes.Buffer

--- a/ast/if_statement.go
+++ b/ast/if_statement.go
@@ -13,7 +13,7 @@ type IfStatement struct {
 	Alternative *ElseStatement
 }
 
-func (i *IfStatement) statement()     {}
+func (i *IfStatement) Statement()     {}
 func (i *IfStatement) GetMeta() *Meta { return i.Meta }
 func (i *IfStatement) String() string {
 	var buf bytes.Buffer
@@ -62,7 +62,7 @@ type ElseStatement struct {
 	Consequence *BlockStatement
 }
 
-func (e *ElseStatement) statement()     {}
+func (e *ElseStatement) Statement()     {}
 func (e *ElseStatement) GetMeta() *Meta { return e.Meta }
 func (e *ElseStatement) String() string {
 	var buf bytes.Buffer

--- a/ast/import_statement.go
+++ b/ast/import_statement.go
@@ -9,7 +9,7 @@ type ImportStatement struct {
 	Name *Ident
 }
 
-func (i *ImportStatement) statement()     {}
+func (i *ImportStatement) Statement()     {}
 func (i *ImportStatement) GetMeta() *Meta { return i.Meta }
 func (i *ImportStatement) String() string {
 	var buf bytes.Buffer

--- a/ast/include_statement.go
+++ b/ast/include_statement.go
@@ -9,7 +9,7 @@ type IncludeStatement struct {
 	Module *String
 }
 
-func (i *IncludeStatement) statement()     {}
+func (i *IncludeStatement) Statement()     {}
 func (i *IncludeStatement) GetMeta() *Meta { return i.Meta }
 func (i *IncludeStatement) String() string {
 	var buf bytes.Buffer

--- a/ast/infix_expression.go
+++ b/ast/infix_expression.go
@@ -11,7 +11,7 @@ type InfixExpression struct {
 	Right    Expression
 }
 
-func (i *InfixExpression) expression()    {}
+func (i *InfixExpression) Expression()    {}
 func (i *InfixExpression) GetMeta() *Meta { return i.Meta }
 func (i *InfixExpression) String() string {
 	var buf bytes.Buffer

--- a/ast/log_statement.go
+++ b/ast/log_statement.go
@@ -9,7 +9,7 @@ type LogStatement struct {
 	Value Expression
 }
 
-func (l *LogStatement) statement()     {}
+func (l *LogStatement) Statement()     {}
 func (l *LogStatement) GetMeta() *Meta { return l.Meta }
 func (l *LogStatement) String() string {
 	var buf bytes.Buffer

--- a/ast/penaltybox_declaration.go
+++ b/ast/penaltybox_declaration.go
@@ -8,7 +8,7 @@ type PenaltyboxDeclaration struct {
 	Block *BlockStatement
 }
 
-func (p *PenaltyboxDeclaration) statement()     {}
+func (p *PenaltyboxDeclaration) Statement()     {}
 func (p *PenaltyboxDeclaration) GetMeta() *Meta { return p.Meta }
 func (p *PenaltyboxDeclaration) String() string {
 	var buf bytes.Buffer

--- a/ast/postfix_expression.go
+++ b/ast/postfix_expression.go
@@ -10,7 +10,7 @@ type PostfixExpression struct {
 	Operator string
 }
 
-func (i *PostfixExpression) expression()    {}
+func (i *PostfixExpression) Expression()    {}
 func (i *PostfixExpression) GetMeta() *Meta { return i.Meta }
 func (i *PostfixExpression) String() string {
 	var buf bytes.Buffer

--- a/ast/prefix_expression.go
+++ b/ast/prefix_expression.go
@@ -10,7 +10,7 @@ type PrefixExpression struct {
 	Right    Expression
 }
 
-func (p *PrefixExpression) expression()    {}
+func (p *PrefixExpression) Expression()    {}
 func (p *PrefixExpression) GetMeta() *Meta { return p.Meta }
 func (p *PrefixExpression) String() string {
 	var buf bytes.Buffer

--- a/ast/ratecounter_declaration.go
+++ b/ast/ratecounter_declaration.go
@@ -8,7 +8,7 @@ type RatecounterDeclaration struct {
 	Block *BlockStatement
 }
 
-func (r *RatecounterDeclaration) statement()     {}
+func (r *RatecounterDeclaration) Statement()     {}
 func (r *RatecounterDeclaration) GetMeta() *Meta { return r.Meta }
 func (r *RatecounterDeclaration) String() string {
 	var buf bytes.Buffer

--- a/ast/remove_statement.go
+++ b/ast/remove_statement.go
@@ -9,7 +9,7 @@ type RemoveStatement struct {
 	Ident *Ident
 }
 
-func (r *RemoveStatement) statement()     {}
+func (r *RemoveStatement) Statement()     {}
 func (r *RemoveStatement) GetMeta() *Meta { return r.Meta }
 func (r *RemoveStatement) String() string {
 	var buf bytes.Buffer

--- a/ast/restart_statement.go
+++ b/ast/restart_statement.go
@@ -8,7 +8,7 @@ type RestartStatement struct {
 	*Meta
 }
 
-func (r *RestartStatement) statement()     {}
+func (r *RestartStatement) Statement()     {}
 func (r *RestartStatement) GetMeta() *Meta { return r.Meta }
 func (r *RestartStatement) String() string {
 	var buf bytes.Buffer

--- a/ast/return_statement.go
+++ b/ast/return_statement.go
@@ -12,7 +12,7 @@ type ReturnStatement struct {
 	ParenthesisTrailingComments Comments
 }
 
-func (r *ReturnStatement) statement()     {}
+func (r *ReturnStatement) Statement()     {}
 func (r *ReturnStatement) GetMeta() *Meta { return r.Meta }
 func (r *ReturnStatement) String() string {
 	var buf bytes.Buffer

--- a/ast/set_statement.go
+++ b/ast/set_statement.go
@@ -11,7 +11,7 @@ type SetStatement struct {
 	Value    Expression
 }
 
-func (s *SetStatement) statement()     {}
+func (s *SetStatement) Statement()     {}
 func (s *SetStatement) GetMeta() *Meta { return s.Meta }
 func (s *SetStatement) String() string {
 	var buf bytes.Buffer

--- a/ast/subroutine_declaration.go
+++ b/ast/subroutine_declaration.go
@@ -11,7 +11,7 @@ type SubroutineDeclaration struct {
 	ReturnType *Ident
 }
 
-func (s *SubroutineDeclaration) statement()     {}
+func (s *SubroutineDeclaration) Statement()     {}
 func (s *SubroutineDeclaration) GetMeta() *Meta { return s.Meta }
 func (s *SubroutineDeclaration) String() string {
 	var buf bytes.Buffer

--- a/ast/switch_statement.go
+++ b/ast/switch_statement.go
@@ -9,7 +9,7 @@ type SwitchStatement struct {
 	Default int
 }
 
-func (s *SwitchStatement) statement()     {}
+func (s *SwitchStatement) Statement()     {}
 func (s *SwitchStatement) GetMeta() *Meta { return s.Meta }
 func (s *SwitchStatement) String() string {
 	var buf bytes.Buffer
@@ -37,7 +37,7 @@ type SwitchControl struct {
 	Expression Expression
 }
 
-func (s *SwitchControl) statement()     {}
+func (s *SwitchControl) Statement()     {}
 func (s *SwitchControl) GetMeta() *Meta { return s.Meta }
 func (s *SwitchControl) String() string {
 	var buf bytes.Buffer

--- a/ast/synthetic_base64_statement.go
+++ b/ast/synthetic_base64_statement.go
@@ -9,7 +9,7 @@ type SyntheticBase64Statement struct {
 	Value Expression
 }
 
-func (s *SyntheticBase64Statement) statement()     {}
+func (s *SyntheticBase64Statement) Statement()     {}
 func (s *SyntheticBase64Statement) GetMeta() *Meta { return s.Meta }
 func (s *SyntheticBase64Statement) String() string {
 	var buf bytes.Buffer

--- a/ast/synthetic_statement.go
+++ b/ast/synthetic_statement.go
@@ -9,7 +9,7 @@ type SyntheticStatement struct {
 	Value Expression
 }
 
-func (s *SyntheticStatement) statement()     {}
+func (s *SyntheticStatement) Statement()     {}
 func (s *SyntheticStatement) GetMeta() *Meta { return s.Meta }
 func (s *SyntheticStatement) String() string {
 	var buf bytes.Buffer

--- a/ast/table_declaration.go
+++ b/ast/table_declaration.go
@@ -11,7 +11,7 @@ type TableDeclaration struct {
 	Properties []*TableProperty
 }
 
-func (t *TableDeclaration) statement()     {}
+func (t *TableDeclaration) Statement()     {}
 func (t *TableDeclaration) GetMeta() *Meta { return t.Meta }
 func (t *TableDeclaration) String() string {
 	var buf bytes.Buffer

--- a/ast/unset_statement.go
+++ b/ast/unset_statement.go
@@ -9,7 +9,7 @@ type UnsetStatement struct {
 	Ident *Ident
 }
 
-func (u *UnsetStatement) statement()     {}
+func (u *UnsetStatement) Statement()     {}
 func (u *UnsetStatement) GetMeta() *Meta { return u.Meta }
 func (u *UnsetStatement) String() string {
 	var buf bytes.Buffer

--- a/ast/vcl_types.go
+++ b/ast/vcl_types.go
@@ -10,7 +10,7 @@ type Ident struct {
 	Value string
 }
 
-func (i *Ident) expression()    {}
+func (i *Ident) Expression()    {}
 func (i *Ident) GetMeta() *Meta { return i.Meta }
 func (i *Ident) String() string {
 	return strings.TrimSpace(i.LeadingComment(inline) + i.Value + i.TrailingComment(inline))
@@ -21,7 +21,7 @@ type IP struct {
 	Value string
 }
 
-func (i *IP) expression()    {}
+func (i *IP) Expression()    {}
 func (i *IP) GetMeta() *Meta { return i.Meta }
 func (i *IP) String() string {
 	return strings.TrimSpace(i.LeadingComment(inline) + i.Value + i.TrailingComment(inline))
@@ -32,7 +32,7 @@ type Boolean struct {
 	Value bool
 }
 
-func (b *Boolean) expression()    {}
+func (b *Boolean) Expression()    {}
 func (b *Boolean) GetMeta() *Meta { return b.Meta }
 func (b *Boolean) String() string {
 	return strings.TrimSpace(
@@ -45,7 +45,7 @@ type Integer struct {
 	Value int64
 }
 
-func (i *Integer) expression()    {}
+func (i *Integer) Expression()    {}
 func (i *Integer) GetMeta() *Meta { return i.Meta }
 func (i *Integer) String() string {
 	return strings.TrimSpace(
@@ -58,7 +58,7 @@ type String struct {
 	Value string
 }
 
-func (s *String) expression()    {}
+func (s *String) Expression()    {}
 func (s *String) GetMeta() *Meta { return s.Meta }
 func (s *String) String() string {
 	if s.Token.Offset == 4 { // offset=4 means bracket string
@@ -76,7 +76,7 @@ type Float struct {
 	Value float64
 }
 
-func (f *Float) expression()    {}
+func (f *Float) Expression()    {}
 func (f *Float) GetMeta() *Meta { return f.Meta }
 func (f *Float) String() string {
 	return strings.TrimSpace(
@@ -89,7 +89,7 @@ type RTime struct {
 	Value string
 }
 
-func (r *RTime) expression()    {}
+func (r *RTime) Expression()    {}
 func (r *RTime) GetMeta() *Meta { return r.Meta }
 func (r *RTime) String() string {
 	return strings.TrimSpace(r.LeadingComment(inline) + r.Value + r.TrailingComment(inline))

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -678,3 +678,23 @@ func TestPeekToken(t *testing.T) {
 		t.Errorf(`Assertion failed, diff= %s`, diff)
 	}
 }
+
+func TestCustomToken(t *testing.T) {
+	input := `describe foo {}`
+	l := NewFromString(input, WithCustomTokens("describe"))
+
+	expects := []token.Token{
+		{Type: token.CUSTOM, Literal: "describe", Line: 1, Position: 1},
+		{Type: token.IDENT, Literal: "foo", Line: 1, Position: 10},
+		{Type: token.LEFT_BRACE, Literal: "{", Line: 1, Position: 14},
+		{Type: token.RIGHT_BRACE, Literal: "}", Line: 1, Position: 15},
+		{Type: token.EOF, Literal: "", Line: 1, Position: 16},
+	}
+	for i, tt := range expects {
+		tok := l.NextToken()
+
+		if diff := cmp.Diff(tt, tok, cmpopts.IgnoreFields(token.Token{}, "Offset")); diff != "" {
+			t.Errorf(`Tests[%d] failed, diff= %s`, i, diff)
+		}
+	}
+}

--- a/lexer/option.go
+++ b/lexer/option.go
@@ -4,6 +4,7 @@ type OptionFunc func(o *Option)
 
 type Option struct {
 	Filename string
+	Customs  map[string]struct{}
 	// more field if exists
 }
 
@@ -13,9 +14,18 @@ func WithFile(filename string) OptionFunc {
 	}
 }
 
+func WithCustomTokens(idents ...string) OptionFunc {
+	return func(o *Option) {
+		for i := range idents {
+			o.Customs[idents[i]] = struct{}{}
+		}
+	}
+}
+
 func collect(opts []OptionFunc) *Option {
 	o := &Option{
 		Filename: "",
+		Customs:  make(map[string]struct{}),
 	}
 
 	for i := range opts {

--- a/linter/custom_linter.go
+++ b/linter/custom_linter.go
@@ -1,0 +1,21 @@
+package linter
+
+import (
+	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/types"
+)
+
+type CustomLinter interface {
+	Literal() string
+	Lint(*Linter) types.Type
+}
+
+func (l *Linter) CustomLint(stmt ast.CustomStatement) types.Type {
+	v, ok := l.customLinters[stmt.Literal()]
+	if !ok {
+		// If custom linter is not registered, skip linting
+		return types.NeverType
+	}
+	// Lint statement by CustomLinter implementation
+	return v.Lint(l)
+}

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -265,6 +265,10 @@ func (l *Linter) lint(node ast.Node, ctx *context.Context) types.Type {
 	case *ast.FunctionCallExpression:
 		return l.lintFunctionCallExpression(t, ctx)
 	default:
+		// Custom statement won't be linted
+		if _, ok := node.(ast.CustomStatement); ok {
+			break
+		}
 		l.Error(fmt.Errorf("Unexpected node: %s", node.String()))
 	}
 	return types.NeverType

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -23,14 +23,20 @@ type Linter struct {
 	includexLexers map[string]*lexer.Lexer
 	ignore         *ignore
 	conf           *config.LinterConfig
+
+	customLinters map[string]CustomLinter
 }
 
-func New(c *config.LinterConfig) *Linter {
-	return &Linter{
+func New(c *config.LinterConfig, opts ...optionFunc) *Linter {
+	l := &Linter{
 		includexLexers: make(map[string]*lexer.Lexer),
 		ignore:         &ignore{},
 		conf:           c,
 	}
+	for i := range opts {
+		opts[i](l)
+	}
+	return l
 }
 
 func (l *Linter) Lexers() map[string]*lexer.Lexer {

--- a/linter/option.go
+++ b/linter/option.go
@@ -1,0 +1,11 @@
+package linter
+
+type optionFunc func(l *Linter)
+
+func WithCustomLinters(ls ...CustomLinter) optionFunc {
+	return func(l *Linter) {
+		for i := range ls {
+			l.customLinters[ls[i].Literal()] = ls[i]
+		}
+	}
+}

--- a/parser/custom_parser.go
+++ b/parser/custom_parser.go
@@ -1,0 +1,19 @@
+package parser
+
+import (
+	"github.com/ysugimoto/falco/ast"
+)
+
+type CustomParser interface {
+	Literal() string
+	Parse(*Parser) (ast.CustomStatement, error)
+}
+
+func (p *Parser) ParseCustomToken() (ast.CustomStatement, error) {
+	v, ok := p.customParsers[p.curToken.Token.Literal]
+	if !ok {
+		return nil, UnexpectedToken(p.curToken)
+	}
+	// Parse tokens by CustomParser implementation
+	return v.Parse(p)
+}

--- a/parser/custom_parser_test.go
+++ b/parser/custom_parser_test.go
@@ -1,0 +1,239 @@
+package parser
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/lexer"
+	"github.com/ysugimoto/falco/token"
+)
+
+type DescribeStatement struct {
+	*ast.Meta
+	Name        *ast.Ident
+	BeforeEach  ast.CustomStatement
+	Subroutines []*ast.SubroutineDeclaration
+}
+
+func (d *DescribeStatement) Statement() {}
+func (d *DescribeStatement) Literal() string {
+	return "describe"
+}
+func (d *DescribeStatement) GetMeta() *ast.Meta {
+	return d.Meta
+}
+func (d *DescribeStatement) String() string {
+	var buf bytes.Buffer
+
+	buf.WriteString(d.LeadingComment("\n"))
+	buf.WriteString("describe ")
+	buf.WriteString(d.Name.String())
+	buf.WriteString(" {\n")
+	if d.BeforeEach != nil {
+		buf.WriteString(d.BeforeEach.String())
+		buf.WriteString("\n")
+	}
+
+	for _, sub := range d.Subroutines {
+		buf.WriteString(sub.String())
+	}
+	buf.WriteString(d.InfixComment("\n"))
+	buf.WriteString("}")
+	buf.WriteString(d.TrailingComment(" "))
+
+	return buf.String()
+}
+
+type DescribeParser struct{}
+
+func (d *DescribeParser) Literal() string {
+	return "describe"
+}
+func (d *DescribeParser) Parse(p *Parser) (ast.CustomStatement, error) {
+	stmt := &DescribeStatement{
+		Meta: p.curToken,
+	}
+	if !p.ExpectPeek(token.IDENT) {
+		return nil, UnexpectedToken(p.PeekToken(), token.IDENT)
+	}
+	stmt.Name = p.ParseIdent()
+	if !p.ExpectPeek(token.LEFT_BRACE) {
+		return nil, UnexpectedToken(p.PeekToken(), token.LEFT_BRACE)
+	}
+	SwapLeadingTrailing(p.curToken, stmt.Name.Meta)
+	p.NextToken()
+
+	for !p.PeekTokenIs(token.RIGHT_BRACE) {
+		tok := p.CurToken()
+		switch tok.Token.Type {
+		case token.SUBROUTINE:
+			sub, err := p.ParseSubroutineDeclaration()
+			if err != nil {
+				return nil, errors.WithStack(err)
+			}
+			stmt.Subroutines = append(stmt.Subroutines, sub)
+		case token.CUSTOM:
+			cs, err := p.ParseCustomToken()
+			if err != nil {
+				return nil, errors.WithStack(err)
+			}
+			if cs.Literal() == "before_each" {
+				stmt.BeforeEach = cs
+			}
+		default:
+			return nil, UnexpectedToken(p.CurToken())
+		}
+	}
+
+	p.NextToken() // point to RIGHT_BRACE
+	SwapLeadingInfix(p.curToken, stmt.Meta)
+	stmt.Meta.Trailing = p.Trailing()
+
+	return stmt, nil
+}
+
+type BeforeEachStatement struct {
+	*ast.Meta
+	Block *ast.BlockStatement
+}
+
+func (b *BeforeEachStatement) Statement() {}
+func (b *BeforeEachStatement) Literal() string {
+	return "before_each"
+}
+func (b *BeforeEachStatement) GetMeta() *ast.Meta {
+	return b.Meta
+}
+
+func (b *BeforeEachStatement) String() string {
+	var buf bytes.Buffer
+
+	buf.WriteString(b.LeadingComment("\n"))
+	buf.WriteString("before_each ")
+	if v := b.InfixComment(" "); v != "" {
+		buf.WriteString(v + " ")
+	}
+	buf.WriteString(b.Block.String())
+	buf.WriteString(b.TrailingComment(" "))
+
+	return buf.String()
+}
+
+type BeforeEachParser struct{}
+
+func (b *BeforeEachParser) Literal() string {
+	return "before_each"
+}
+func (b *BeforeEachParser) Parse(p *Parser) (ast.CustomStatement, error) {
+	stmt := &BeforeEachStatement{
+		Meta: p.curToken,
+	}
+	if !p.ExpectPeek(token.LEFT_BRACE) {
+		return nil, UnexpectedToken(p.PeekToken(), token.LEFT_BRACE)
+	}
+	SwapLeadingInfix(p.curToken, stmt.Meta)
+	var err error
+	if stmt.Block, err = p.ParseBlockStatement(); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	// point to next declaretion/statement start
+	p.NextToken()
+	return stmt, nil
+}
+
+func TestParseCustomToken(t *testing.T) {
+	input := `// Leading comment
+describe foo {
+  before_each {
+	set req.http.Foo = "bar";
+  }
+
+  sub test_foo_recv {
+	set req.http.Bar = "baz";
+  }
+} // Trailing comment`
+	expect := &ast.VCL{
+		Statements: []ast.Statement{
+			&DescribeStatement{
+				Meta: ast.New(T, 0, comments("// Leading comment"), comments("// Trailing comment")),
+				Name: &ast.Ident{
+					Meta:  ast.New(T, 0),
+					Value: "foo",
+				},
+				BeforeEach: &BeforeEachStatement{
+					Meta: ast.New(T, 1),
+					Block: &ast.BlockStatement{
+						Meta: ast.New(T, 2),
+						Statements: []ast.Statement{
+							&ast.SetStatement{
+								Meta: ast.New(T, 2),
+								Ident: &ast.Ident{
+									Meta:  ast.New(T, 2),
+									Value: "req.http.Foo",
+								},
+								Operator: &ast.Operator{
+									Meta:     ast.New(T, 2),
+									Operator: "=",
+								},
+								Value: &ast.String{
+									Meta:  ast.New(T, 2),
+									Value: "bar",
+								},
+							},
+						},
+					},
+				},
+				Subroutines: []*ast.SubroutineDeclaration{
+					&ast.SubroutineDeclaration{
+						Meta: &ast.Meta{
+							Token:              T,
+							Nest:               1,
+							PreviousEmptyLines: 1,
+							Leading:            ast.Comments{},
+							Infix:              ast.Comments{},
+							Trailing:           ast.Comments{},
+						},
+						Name: &ast.Ident{
+							Meta:  ast.New(T, 1),
+							Value: "test_foo_recv",
+						},
+						Block: &ast.BlockStatement{
+							Meta: ast.New(T, 2),
+							Statements: []ast.Statement{
+								&ast.SetStatement{
+									Meta: ast.New(T, 2),
+									Ident: &ast.Ident{
+										Meta:  ast.New(T, 2),
+										Value: "req.http.Bar",
+									},
+									Operator: &ast.Operator{
+										Meta:     ast.New(T, 2),
+										Operator: "=",
+									},
+									Value: &ast.String{
+										Meta:  ast.New(T, 2),
+										Value: "baz",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cps := []CustomParser{
+		&DescribeParser{},
+		&BeforeEachParser{},
+	}
+	// l := lexer.NewFromString(input, lexer.WithCustomToken("describe", "before_each"))
+	vcl, err := New(lexer.NewFromString(input), WithCustomParser(cps...)).ParseVCL()
+	if err != nil {
+		t.Errorf("%+v", err)
+	}
+	assert(t, vcl, expect)
+}

--- a/parser/custom_parser_test.go
+++ b/parser/custom_parser_test.go
@@ -230,7 +230,6 @@ describe foo {
 		&DescribeParser{},
 		&BeforeEachParser{},
 	}
-	// l := lexer.NewFromString(input, lexer.WithCustomToken("describe", "before_each"))
 	vcl, err := New(lexer.NewFromString(input), WithCustomParser(cps...)).ParseVCL()
 	if err != nil {
 		t.Errorf("%+v", err)

--- a/parser/declaration_parser.go
+++ b/parser/declaration_parser.go
@@ -6,128 +6,128 @@ import (
 	"github.com/ysugimoto/falco/token"
 )
 
-func (p *Parser) parseAclDeclaration() (*ast.AclDeclaration, error) {
+func (p *Parser) ParseAclDeclaration() (*ast.AclDeclaration, error) {
 	acl := &ast.AclDeclaration{
 		Meta: p.curToken,
 	}
 
-	if !p.expectPeek(token.IDENT) {
+	if !p.ExpectPeek(token.IDENT) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, token.IDENT))
 	}
-	acl.Name = p.parseIdent()
+	acl.Name = p.ParseIdent()
 
-	if !p.expectPeek(token.LEFT_BRACE) {
+	if !p.ExpectPeek(token.LEFT_BRACE) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, token.LEFT_BRACE))
 	}
-	swapLeadingTrailing(p.curToken, acl.Name.Meta)
+	SwapLeadingTrailing(p.curToken, acl.Name.Meta)
 
-	for !p.peekTokenIs(token.RIGHT_BRACE) {
-		p.nextToken() // point to CIDR start
-		cidr, err := p.parseAclCidr()
+	for !p.PeekTokenIs(token.RIGHT_BRACE) {
+		p.NextToken() // point to CIDR start
+		cidr, err := p.ParseAclCidr()
 		if err != nil {
 			return nil, errors.WithStack(err)
 		} else if cidr != nil {
 			acl.CIDRs = append(acl.CIDRs, cidr)
 		}
 	}
-	p.nextToken() // point to RIGHT BRACE
+	p.NextToken() // point to RIGHT BRACE
 
 	// RIGHT_BRACE leading comments are ACL infix comments
-	swapLeadingInfix(p.curToken, acl.Meta)
-	acl.Meta.Trailing = p.trailing()
+	SwapLeadingInfix(p.curToken, acl.Meta)
+	acl.Meta.Trailing = p.Trailing()
 
 	return acl, nil
 }
 
-func (p *Parser) parseAclCidr() (*ast.AclCidr, error) {
+func (p *Parser) ParseAclCidr() (*ast.AclCidr, error) {
 	cidr := &ast.AclCidr{
 		Meta: p.curToken,
 	}
 
 	// Set inverse if "!" token exists
 	var err error
-	if p.curTokenIs(token.NOT) {
+	if p.CurTokenIs(token.NOT) {
 		cidr.Inverse = &ast.Boolean{
 			Meta:  clearComments(p.curToken),
 			Value: true,
 		}
-		p.nextToken() // point to IP token
+		p.NextToken() // point to IP token
 	}
 
-	if !p.curTokenIs(token.STRING) {
+	if !p.CurTokenIs(token.STRING) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, token.STRING))
 	}
-	cidr.IP = p.parseIP()
+	cidr.IP = p.ParseIP()
 	// If inverse is not set, leading comment should be set as CIDR node leading comment
 	if cidr.Inverse == nil {
 		cidr.IP.Meta = clearComments(cidr.IP.Meta)
 	}
 
-	// If SLASH token is found on peek token, need to parse CIDR mask bit
-	if p.peekTokenIs(token.SLASH) {
-		p.nextToken() // point to SLASH
-		if !p.expectPeek(token.INT) {
+	// If SLASH token is found on peek token, need to Parse CIDR mask bit
+	if p.PeekTokenIs(token.SLASH) {
+		p.NextToken() // point to SLASH
+		if !p.ExpectPeek(token.INT) {
 			return nil, errors.WithStack(UnexpectedToken(p.peekToken, token.INT))
 		}
 
-		cidr.Mask, err = p.parseInteger()
+		cidr.Mask, err = p.ParseInteger()
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
 	}
 
-	if !p.peekTokenIs(token.SEMICOLON) {
+	if !p.PeekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	p.nextToken() // point to semicolon
+	p.NextToken() // point to semicolon
 
 	// semicolon leading comment will attach whatever IP or Mask
 	if cidr.Mask != nil {
-		swapLeadingTrailing(p.curToken, cidr.Mask.Meta)
+		SwapLeadingTrailing(p.curToken, cidr.Mask.Meta)
 	} else {
-		swapLeadingTrailing(p.curToken, cidr.IP.Meta)
+		SwapLeadingTrailing(p.curToken, cidr.IP.Meta)
 	}
-	cidr.Meta.Trailing = p.trailing()
+	cidr.Meta.Trailing = p.Trailing()
 
 	return cidr, nil
 }
 
-func (p *Parser) parseBackendDeclaration() (*ast.BackendDeclaration, error) {
+func (p *Parser) ParseBackendDeclaration() (*ast.BackendDeclaration, error) {
 	b := &ast.BackendDeclaration{
 		Meta: p.curToken,
 	}
 
-	if !p.expectPeek(token.IDENT) {
+	if !p.ExpectPeek(token.IDENT) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "IDENT"))
 	}
-	b.Name = p.parseIdent()
+	b.Name = p.ParseIdent()
 
-	if !p.expectPeek(token.LEFT_BRACE) {
+	if !p.ExpectPeek(token.LEFT_BRACE) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "LEFT_BRACE"))
 	}
-	swapLeadingTrailing(p.curToken, b.Name.Meta)
+	SwapLeadingTrailing(p.curToken, b.Name.Meta)
 
-	for !p.peekTokenIs(token.RIGHT_BRACE) {
-		prop, err := p.parseBackendProperty()
+	for !p.PeekTokenIs(token.RIGHT_BRACE) {
+		prop, err := p.ParseBackendProperty()
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
 		b.Properties = append(b.Properties, prop)
 	}
 
-	if !p.peekTokenIs(token.RIGHT_BRACE) {
+	if !p.PeekTokenIs(token.RIGHT_BRACE) {
 		return nil, errors.WithStack(UnexpectedToken(p.curToken, "RIGHT_BRACE"))
 	}
 
-	swapLeadingInfix(p.peekToken, b.Meta)
-	p.nextToken()
-	b.Meta.Trailing = p.trailing()
+	SwapLeadingInfix(p.peekToken, b.Meta)
+	p.NextToken()
+	b.Meta.Trailing = p.Trailing()
 
 	return b, nil
 }
 
-func (p *Parser) parseBackendProperty() (*ast.BackendProperty, error) {
-	if !p.expectPeek(token.DOT) {
+func (p *Parser) ParseBackendProperty() (*ast.BackendProperty, error) {
+	if !p.ExpectPeek(token.DOT) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "DOT"))
 	}
 
@@ -135,92 +135,92 @@ func (p *Parser) parseBackendProperty() (*ast.BackendProperty, error) {
 		Meta: p.curToken,
 	}
 
-	if !p.expectPeek(token.IDENT) {
+	if !p.ExpectPeek(token.IDENT) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "IDENT"))
 	}
-	prop.Key = p.parseIdent()
+	prop.Key = p.ParseIdent()
 
-	if !p.expectPeek(token.ASSIGN) {
+	if !p.ExpectPeek(token.ASSIGN) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "ASSIGN"))
 	}
-	swapLeadingTrailing(p.curToken, prop.Key.Meta)
-	p.nextToken() // point to right token
+	SwapLeadingTrailing(p.curToken, prop.Key.Meta)
+	p.NextToken() // point to right token
 
 	// When current token is "{", property key should be ".probe"
-	if p.curTokenIs(token.LEFT_BRACE) {
+	if p.CurTokenIs(token.LEFT_BRACE) {
 		probe := &ast.BackendProbeObject{
 			Meta: p.curToken,
 		}
 
-		for !p.peekTokenIs(token.RIGHT_BRACE) {
-			pp, err := p.parseBackendProperty()
+		for !p.PeekTokenIs(token.RIGHT_BRACE) {
+			pp, err := p.ParseBackendProperty()
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
 			probe.Values = append(probe.Values, pp)
 		}
 
-		p.nextToken() // point to RIGHT_BRACE
-		swapLeadingInfix(p.curToken, probe.Meta)
-		probe.Meta.Trailing = p.trailing()
+		p.NextToken() // point to RIGHT_BRACE
+		SwapLeadingInfix(p.curToken, probe.Meta)
+		probe.Meta.Trailing = p.Trailing()
 		prop.Value = probe
 		return prop, nil
 	}
 
-	// Otherwise, parse expression
-	exp, err := p.parseExpression(LOWEST)
+	// Otherwise, Parse expression
+	exp, err := p.ParseExpression(LOWEST)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 	prop.Value = exp
 
-	if !p.peekTokenIs(token.SEMICOLON) {
+	if !p.PeekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	p.nextToken() // point to SEMICOLON
-	prop.Meta.Trailing = p.trailing()
+	p.NextToken() // point to SEMICOLON
+	prop.Meta.Trailing = p.Trailing()
 
 	return prop, nil
 }
 
-func (p *Parser) parseDirectorDeclaration() (*ast.DirectorDeclaration, error) {
+func (p *Parser) ParseDirectorDeclaration() (*ast.DirectorDeclaration, error) {
 	d := &ast.DirectorDeclaration{
 		Meta: p.curToken,
 	}
 
 	// director name
-	if !p.expectPeek(token.IDENT) {
+	if !p.ExpectPeek(token.IDENT) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "IDENT"))
 	}
-	d.Name = p.parseIdent()
+	d.Name = p.ParseIdent()
 
 	// director type
-	if !p.expectPeek(token.IDENT) {
+	if !p.ExpectPeek(token.IDENT) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "IDENT"))
 	}
-	swapLeadingTrailing(p.curToken, d.Name.Meta)
+	SwapLeadingTrailing(p.curToken, d.Name.Meta)
 
-	d.DirectorType = p.parseIdent()
+	d.DirectorType = p.ParseIdent()
 
-	if !p.expectPeek(token.LEFT_BRACE) {
+	if !p.ExpectPeek(token.LEFT_BRACE) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "LEFT_BRACE"))
 	}
-	swapLeadingTrailing(p.curToken, d.DirectorType.Meta)
+	SwapLeadingTrailing(p.curToken, d.DirectorType.Meta)
 
 	// Parse declaration
-	for !p.peekTokenIs(token.RIGHT_BRACE) {
+	for !p.PeekTokenIs(token.RIGHT_BRACE) {
 		var prop ast.Expression
 		var err error
 
 		switch p.peekToken.Token.Type {
 		case token.DOT:
 			// single property definition like ".quorum = 10%;"
-			p.nextToken()
-			prop, err = p.parseDirectorProperty()
+			p.NextToken()
+			prop, err = p.ParseDirectorProperty()
 		case token.LEFT_BRACE:
-			p.nextToken()
+			p.NextToken()
 			// object definition e.g. { .backend = F_origin_1; .weight = 1; }
-			prop, err = p.parseDirectorBackend()
+			prop, err = p.ParseDirectorBackend()
 		default:
 			err = errors.WithStack(UnexpectedToken(p.peekToken))
 		}
@@ -230,53 +230,53 @@ func (p *Parser) parseDirectorDeclaration() (*ast.DirectorDeclaration, error) {
 		d.Properties = append(d.Properties, prop)
 	}
 
-	swapLeadingInfix(p.peekToken, d.Meta)
-	p.nextToken() // point to RIGHT_BRACE
-	d.Meta.Trailing = p.trailing()
+	SwapLeadingInfix(p.peekToken, d.Meta)
+	p.NextToken() // point to RIGHT_BRACE
+	d.Meta.Trailing = p.Trailing()
 
 	return d, nil
 }
 
-func (p *Parser) parseDirectorProperty() (ast.Expression, error) {
+func (p *Parser) ParseDirectorProperty() (ast.Expression, error) {
 	prop := &ast.DirectorProperty{
 		Meta: p.curToken,
 	}
 
 	// token may token.BACKEND because backend object has ".backend" property key
-	if !p.expectPeek(token.IDENT) && !p.expectPeek(token.BACKEND) {
+	if !p.ExpectPeek(token.IDENT) && !p.ExpectPeek(token.BACKEND) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "IDENT"))
 	}
-	prop.Key = p.parseIdent()
+	prop.Key = p.ParseIdent()
 
-	if !p.expectPeek(token.ASSIGN) {
+	if !p.ExpectPeek(token.ASSIGN) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "ASSIGN"))
 	}
-	swapLeadingTrailing(p.curToken, prop.Key.Meta)
+	SwapLeadingTrailing(p.curToken, prop.Key.Meta)
 
-	p.nextToken() // point to expression start token
+	p.NextToken() // point to expression start token
 
-	exp, err := p.parseExpression(LOWEST)
+	exp, err := p.ParseExpression(LOWEST)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 	prop.Value = exp
 
-	if !p.peekTokenIs(token.SEMICOLON) {
+	if !p.PeekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	p.nextToken() // point to SEMICOLON
-	prop.Meta.Trailing = p.trailing()
+	p.NextToken() // point to SEMICOLON
+	prop.Meta.Trailing = p.Trailing()
 
 	return prop, nil
 }
 
-func (p *Parser) parseDirectorBackend() (ast.Expression, error) {
+func (p *Parser) ParseDirectorBackend() (ast.Expression, error) {
 	backend := &ast.DirectorBackendObject{
 		Meta: p.curToken,
 	}
 
-	for !p.peekTokenIs(token.RIGHT_BRACE) {
-		if !p.expectPeek(token.DOT) {
+	for !p.PeekTokenIs(token.RIGHT_BRACE) {
+		if !p.ExpectPeek(token.DOT) {
 			return nil, errors.WithStack(UnexpectedToken(p.peekToken, "DOT"))
 		}
 
@@ -285,88 +285,88 @@ func (p *Parser) parseDirectorBackend() (ast.Expression, error) {
 		}
 
 		// token may token.BACKEND because backend object has ".backend" property key
-		if !p.expectPeek(token.IDENT) && !p.expectPeek(token.BACKEND) {
+		if !p.ExpectPeek(token.IDENT) && !p.ExpectPeek(token.BACKEND) {
 			return nil, errors.WithStack(UnexpectedToken(p.peekToken, "IDENT"))
 		}
-		prop.Key = p.parseIdent()
+		prop.Key = p.ParseIdent()
 
-		if !p.expectPeek(token.ASSIGN) {
+		if !p.ExpectPeek(token.ASSIGN) {
 			return nil, errors.WithStack(UnexpectedToken(p.peekToken, "ASSIGN"))
 		}
-		swapLeadingTrailing(p.curToken, prop.Key.Meta)
+		SwapLeadingTrailing(p.curToken, prop.Key.Meta)
 
-		p.nextToken() // point to expression start token
+		p.NextToken() // point to expression start token
 
-		exp, err := p.parseExpression(LOWEST)
+		exp, err := p.ParseExpression(LOWEST)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
 		prop.Value = exp
 
-		if !p.peekTokenIs(token.SEMICOLON) {
+		if !p.PeekTokenIs(token.SEMICOLON) {
 			return nil, errors.WithStack(MissingSemicolon(p.curToken))
 		}
-		prop.Meta.Trailing = p.trailing()
-		p.nextToken() // point to SEMICOLON
+		prop.Meta.Trailing = p.Trailing()
+		p.NextToken() // point to SEMICOLON
 
 		backend.Values = append(backend.Values, prop)
 	}
 
-	swapLeadingInfix(p.peekToken, backend.Meta)
-	p.nextToken() // point to RIGHT_BRACE
-	backend.Meta.Trailing = p.trailing()
+	SwapLeadingInfix(p.peekToken, backend.Meta)
+	p.NextToken() // point to RIGHT_BRACE
+	backend.Meta.Trailing = p.Trailing()
 
 	return backend, nil
 }
 
-func (p *Parser) parseTableDeclaration() (*ast.TableDeclaration, error) {
+func (p *Parser) ParseTableDeclaration() (*ast.TableDeclaration, error) {
 	t := &ast.TableDeclaration{
 		Meta:       p.curToken,
 		Properties: []*ast.TableProperty{},
 	}
 
-	if !p.expectPeek(token.IDENT) {
+	if !p.ExpectPeek(token.IDENT) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "IDENT"))
 	}
-	t.Name = p.parseIdent()
-	swapLeadingTrailing(p.peekToken, t.Name.Meta)
+	t.Name = p.ParseIdent()
+	SwapLeadingTrailing(p.peekToken, t.Name.Meta)
 
 	// Table value type is optional
-	if p.peekTokenIs(token.IDENT) {
-		p.nextToken()
-		t.ValueType = p.parseIdent()
+	if p.PeekTokenIs(token.IDENT) {
+		p.NextToken()
+		t.ValueType = p.ParseIdent()
 	}
 
-	if !p.expectPeek(token.LEFT_BRACE) {
+	if !p.ExpectPeek(token.LEFT_BRACE) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "LEFT_BRACE"))
 	}
 
 	if t.ValueType != nil {
-		swapLeadingTrailing(p.curToken, t.ValueType.Meta)
+		SwapLeadingTrailing(p.curToken, t.ValueType.Meta)
 	} else {
-		swapLeadingTrailing(p.curToken, t.Name.Meta)
+		SwapLeadingTrailing(p.curToken, t.Name.Meta)
 	}
 
-	for !p.peekTokenIs(token.RIGHT_BRACE) {
-		prop, err := p.parseTableProperty()
+	for !p.PeekTokenIs(token.RIGHT_BRACE) {
+		prop, err := p.ParseTableProperty()
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
 		t.Properties = append(t.Properties, prop)
 	}
 
-	swapLeadingInfix(p.peekToken, t.Meta)
-	p.nextToken() // point to RIGHT_BRACE
-	t.Meta.Trailing = p.trailing()
+	SwapLeadingInfix(p.peekToken, t.Meta)
+	p.NextToken() // point to RIGHT_BRACE
+	t.Meta.Trailing = p.Trailing()
 
 	return t, nil
 }
 
-func (p *Parser) parseTableProperty() (*ast.TableProperty, error) {
-	if !p.expectPeek(token.STRING) {
+func (p *Parser) ParseTableProperty() (*ast.TableProperty, error) {
+	if !p.ExpectPeek(token.STRING) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "STRING"))
 	}
-	key, err := p.parseString()
+	key, err := p.ParseString()
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -376,40 +376,40 @@ func (p *Parser) parseTableProperty() (*ast.TableProperty, error) {
 	}
 	prop.Key.Meta = clearComments(prop.Key.Meta)
 
-	if !p.expectPeek(token.COLON) {
+	if !p.ExpectPeek(token.COLON) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "COLON"))
 	}
-	swapLeadingTrailing(p.curToken, prop.Key.Meta)
+	SwapLeadingTrailing(p.curToken, prop.Key.Meta)
 
-	p.nextToken() // point to table value token
+	p.NextToken() // point to table value token
 
 	switch p.curToken.Token.Type {
 	case token.IDENT:
-		prop.Value = p.parseIdent()
+		prop.Value = p.ParseIdent()
 	case token.STRING:
 		var err error
-		prop.Value, err = p.parseString()
+		prop.Value, err = p.ParseString()
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
 	case token.ACL, token.BACKEND:
-		prop.Value = p.parseIdent()
+		prop.Value = p.ParseIdent()
 	case token.TRUE, token.FALSE:
-		prop.Value = p.parseBoolean()
+		prop.Value = p.ParseBoolean()
 	case token.FLOAT:
-		if v, err := p.parseFloat(); err != nil {
+		if v, err := p.ParseFloat(); err != nil {
 			return nil, errors.WithStack(err)
 		} else {
 			prop.Value = v
 		}
 	case token.INT:
-		if v, err := p.parseInteger(); err != nil {
+		if v, err := p.ParseInteger(); err != nil {
 			return nil, errors.WithStack(err)
 		} else {
 			prop.Value = v
 		}
 	case token.RTIME:
-		if v, err := p.parseRTime(); err != nil {
+		if v, err := p.ParseRTime(); err != nil {
 			return nil, errors.WithStack(err)
 		} else {
 			prop.Value = v
@@ -419,18 +419,18 @@ func (p *Parser) parseTableProperty() (*ast.TableProperty, error) {
 	}
 
 	// Tailing process: the last table property may not need COLON,
-	// so we have to be able to parse these case (COLON exists or not)
+	// so we have to be able to Parse these case (COLON exists or not)
 	switch p.peekToken.Token.Type {
 	case token.COMMA:
-		// usual case, user should add trailing comma for east properties :)
+		// usual case, user should add Trailing comma for east properties :)
 		prop.HasComma = true
-		p.nextToken() // point to COMMA
-		swapLeadingTrailing(p.curToken, prop.Value.GetMeta())
-		prop.Meta.Trailing = p.trailing()
+		p.NextToken() // point to COMMA
+		SwapLeadingTrailing(p.curToken, prop.Value.GetMeta())
+		prop.Meta.Trailing = p.Trailing()
 	case token.RIGHT_BRACE:
 		// if peed token is RIGHT_BRACE, it means table declaration end. if also be valid
-		// Note that in this case, we could not parse trailing comment. it is parsed as declaration infix comment.
-		prop.Meta.Trailing = p.trailing()
+		// Note that in this case, we could not Parse Trailing comment. it is Parsed as declaration infix comment.
+		prop.Meta.Trailing = p.Trailing()
 
 		// DO NOT advance token!
 
@@ -442,82 +442,82 @@ func (p *Parser) parseTableProperty() (*ast.TableProperty, error) {
 	return prop, nil
 }
 
-func (p *Parser) parseSubroutineDeclaration() (*ast.SubroutineDeclaration, error) {
+func (p *Parser) ParseSubroutineDeclaration() (*ast.SubroutineDeclaration, error) {
 	s := &ast.SubroutineDeclaration{
 		Meta: p.curToken,
 	}
 
-	if !p.expectPeek(token.IDENT) {
+	if !p.ExpectPeek(token.IDENT) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "IDENT"))
 	}
-	s.Name = p.parseIdent()
+	s.Name = p.ParseIdent()
 
 	// Custom subroutines might be returning a type
 	// https://developer.fastly.com/reference/vcl/subroutines/
 	// we dont need to validate the type here, linter will do that later.
-	if p.expectPeek(token.IDENT) {
-		swapLeadingTrailing(p.curToken, s.Name.Meta)
-		s.ReturnType = p.parseIdent()
+	if p.ExpectPeek(token.IDENT) {
+		SwapLeadingTrailing(p.curToken, s.Name.Meta)
+		s.ReturnType = p.ParseIdent()
 	}
 
-	if !p.expectPeek(token.LEFT_BRACE) {
+	if !p.ExpectPeek(token.LEFT_BRACE) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "LEFT_BRACE"))
 	}
 	if s.ReturnType != nil {
-		swapLeadingTrailing(p.curToken, s.ReturnType.Meta)
+		SwapLeadingTrailing(p.curToken, s.ReturnType.Meta)
 	} else {
-		swapLeadingTrailing(p.curToken, s.Name.Meta)
+		SwapLeadingTrailing(p.curToken, s.Name.Meta)
 	}
 
 	var err error
-	if s.Block, err = p.parseBlockStatement(); err != nil {
+	if s.Block, err = p.ParseBlockStatement(); err != nil {
 		return nil, errors.WithStack(err)
 	}
-	// After block statement is parsed, cursor should point to RIGHT_BRACE, end of block statement
+	// After block statement is Parsed, cursor should point to RIGHT_BRACE, end of block statement
 
 	return s, nil
 }
 
-func (p *Parser) parsePenaltyboxDeclaration() (*ast.PenaltyboxDeclaration, error) {
+func (p *Parser) ParsePenaltyboxDeclaration() (*ast.PenaltyboxDeclaration, error) {
 	pb := &ast.PenaltyboxDeclaration{
 		Meta: p.curToken,
 	}
 
-	if !p.expectPeek(token.IDENT) {
+	if !p.ExpectPeek(token.IDENT) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "IDENT"))
 	}
-	pb.Name = p.parseIdent()
+	pb.Name = p.ParseIdent()
 
-	if !p.expectPeek(token.LEFT_BRACE) {
+	if !p.ExpectPeek(token.LEFT_BRACE) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "LEFT_BRACE"))
 	}
-	swapLeadingTrailing(p.curToken, pb.Name.Meta)
+	SwapLeadingTrailing(p.curToken, pb.Name.Meta)
 
 	var err error
-	if pb.Block, err = p.parseBlockStatement(); err != nil {
+	if pb.Block, err = p.ParseBlockStatement(); err != nil {
 		return nil, errors.WithStack(err)
 	}
 
 	return pb, nil
 }
 
-func (p *Parser) parseRatecounterDeclaration() (*ast.RatecounterDeclaration, error) {
+func (p *Parser) ParseRatecounterDeclaration() (*ast.RatecounterDeclaration, error) {
 	r := &ast.RatecounterDeclaration{
 		Meta: p.curToken,
 	}
 
-	if !p.expectPeek(token.IDENT) {
+	if !p.ExpectPeek(token.IDENT) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "IDENT"))
 	}
-	r.Name = p.parseIdent()
+	r.Name = p.ParseIdent()
 
-	if !p.expectPeek(token.LEFT_BRACE) {
+	if !p.ExpectPeek(token.LEFT_BRACE) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "LEFT_BRACE"))
 	}
-	swapLeadingTrailing(p.curToken, r.Name.Meta)
+	SwapLeadingTrailing(p.curToken, r.Name.Meta)
 
 	var err error
-	if r.Block, err = p.parseBlockStatement(); err != nil {
+	if r.Block, err = p.ParseBlockStatement(); err != nil {
 		return nil, errors.WithStack(err)
 	}
 

--- a/parser/expression_parser.go
+++ b/parser/expression_parser.go
@@ -8,50 +8,45 @@ import (
 
 func (p *Parser) registerExpressionParsers() {
 	p.prefixParsers = map[token.TokenType]prefixParser{
-		token.IDENT:      func() (ast.Expression, error) { return p.parseIdent(), nil },
-		token.STRING:     func() (ast.Expression, error) { return p.parseString() },
-		token.INT:        func() (ast.Expression, error) { return p.parseInteger() },
-		token.FLOAT:      func() (ast.Expression, error) { return p.parseFloat() },
-		token.RTIME:      func() (ast.Expression, error) { return p.parseRTime() },
-		token.NOT:        func() (ast.Expression, error) { return p.parsePrefixExpression() },
-		token.MINUS:      func() (ast.Expression, error) { return p.parsePrefixExpression() },
-		token.PLUS:       func() (ast.Expression, error) { return p.parsePrefixExpression() },
-		token.TRUE:       func() (ast.Expression, error) { return p.parseBoolean(), nil },
-		token.FALSE:      func() (ast.Expression, error) { return p.parseBoolean(), nil },
-		token.LEFT_PAREN: func() (ast.Expression, error) { return p.parseGroupedExpression() },
-		token.IF:         func() (ast.Expression, error) { return p.parseIfExpression() },
-		token.ERROR:      func() (ast.Expression, error) { return p.parseIdent(), nil },
-		token.RESTART:    func() (ast.Expression, error) { return p.parseIdent(), nil },
+		token.IDENT:      func() (ast.Expression, error) { return p.ParseIdent(), nil },
+		token.STRING:     func() (ast.Expression, error) { return p.ParseString() },
+		token.INT:        func() (ast.Expression, error) { return p.ParseInteger() },
+		token.FLOAT:      func() (ast.Expression, error) { return p.ParseFloat() },
+		token.RTIME:      func() (ast.Expression, error) { return p.ParseRTime() },
+		token.NOT:        func() (ast.Expression, error) { return p.ParsePrefixExpression() },
+		token.MINUS:      func() (ast.Expression, error) { return p.ParsePrefixExpression() },
+		token.PLUS:       func() (ast.Expression, error) { return p.ParsePrefixExpression() },
+		token.TRUE:       func() (ast.Expression, error) { return p.ParseBoolean(), nil },
+		token.FALSE:      func() (ast.Expression, error) { return p.ParseBoolean(), nil },
+		token.LEFT_PAREN: func() (ast.Expression, error) { return p.ParseGroupedExpression() },
+		token.IF:         func() (ast.Expression, error) { return p.ParseIfExpression() },
+		token.ERROR:      func() (ast.Expression, error) { return p.ParseIdent(), nil },
+		token.RESTART:    func() (ast.Expression, error) { return p.ParseIdent(), nil },
 	}
 	p.infixParsers = map[token.TokenType]infixParser{
-		token.IF:                 p.parseInfixStringConcatExpression,
-		token.PLUS:               p.parseInfixStringConcatExpression,
-		token.STRING:             p.parseInfixStringConcatExpression,
-		token.IDENT:              p.parseInfixStringConcatExpression,
-		token.MINUS:              p.parseInfixExpression,
-		token.EQUAL:              p.parseInfixExpression,
-		token.NOT_EQUAL:          p.parseInfixExpression,
-		token.GREATER_THAN:       p.parseInfixExpression,
-		token.GREATER_THAN_EQUAL: p.parseInfixExpression,
-		token.LESS_THAN:          p.parseInfixExpression,
-		token.LESS_THAN_EQUAL:    p.parseInfixExpression,
-		token.REGEX_MATCH:        p.parseInfixExpression,
-		token.NOT_REGEX_MATCH:    p.parseInfixExpression,
-		token.LEFT_PAREN:         p.parseFunctionCallExpression,
-		token.AND:                p.parseInfixExpression,
-		token.OR:                 p.parseInfixExpression,
+		token.IF:                 p.ParseInfixStringConcatExpression,
+		token.PLUS:               p.ParseInfixStringConcatExpression,
+		token.STRING:             p.ParseInfixStringConcatExpression,
+		token.IDENT:              p.ParseInfixStringConcatExpression,
+		token.MINUS:              p.ParseInfixExpression,
+		token.EQUAL:              p.ParseInfixExpression,
+		token.NOT_EQUAL:          p.ParseInfixExpression,
+		token.GREATER_THAN:       p.ParseInfixExpression,
+		token.GREATER_THAN_EQUAL: p.ParseInfixExpression,
+		token.LESS_THAN:          p.ParseInfixExpression,
+		token.LESS_THAN_EQUAL:    p.ParseInfixExpression,
+		token.REGEX_MATCH:        p.ParseInfixExpression,
+		token.NOT_REGEX_MATCH:    p.ParseInfixExpression,
+		token.LEFT_PAREN:         p.ParseFunctionCallExpression,
+		token.AND:                p.ParseInfixExpression,
+		token.OR:                 p.ParseInfixExpression,
 	}
 	p.postfixParsers = map[token.TokenType]postfixParser{
-		token.PERCENT: p.parsePostfixExpression,
+		token.PERCENT: p.ParsePostfixExpression,
 	}
 }
 
-// Expose global function to be called externally
 func (p *Parser) ParseExpression(precedence int) (ast.Expression, error) {
-	return p.parseExpression(precedence)
-}
-
-func (p *Parser) parseExpression(precedence int) (ast.Expression, error) {
 	// Note: trim comment inside expression list
 	// For example:
 	// if (req.http.Foo && /* comment */ req.http.Bar) { ... } // -> trim  /* comment */ token
@@ -71,11 +66,11 @@ func (p *Parser) parseExpression(precedence int) (ast.Expression, error) {
 	}
 
 	// same as prefix expression
-	for !p.peekTokenIs(token.SEMICOLON) && precedence < p.peekPrecedence() {
+	for !p.PeekTokenIs(token.SEMICOLON) && precedence < p.peekPrecedence() {
 		infix, ok := p.infixParsers[p.peekToken.Token.Type]
 		if !ok {
 			if postfix, ok := p.postfixParsers[p.peekToken.Token.Type]; ok {
-				p.nextToken()
+				p.NextToken()
 				left, err = postfix(left)
 				if err != nil {
 					return nil, errors.WithStack(err)
@@ -84,8 +79,8 @@ func (p *Parser) parseExpression(precedence int) (ast.Expression, error) {
 			}
 			return left, nil
 		}
-		swapLeadingTrailing(p.peekToken, left.GetMeta())
-		p.nextToken()
+		SwapLeadingTrailing(p.peekToken, left.GetMeta())
+		p.NextToken()
 		left, err = infix(left)
 		if err != nil {
 			return nil, errors.WithStack(err)
@@ -93,21 +88,21 @@ func (p *Parser) parseExpression(precedence int) (ast.Expression, error) {
 		continue
 	}
 
-	if p.peekTokenIs(token.SEMICOLON) {
-		swapLeadingTrailing(p.peekToken, left.GetMeta())
+	if p.PeekTokenIs(token.SEMICOLON) {
+		SwapLeadingTrailing(p.peekToken, left.GetMeta())
 	}
 
 	return left, nil
 }
 
-func (p *Parser) parsePrefixExpression() (*ast.PrefixExpression, error) {
+func (p *Parser) ParsePrefixExpression() (*ast.PrefixExpression, error) {
 	exp := &ast.PrefixExpression{
 		Meta:     p.curToken,
 		Operator: p.curToken.Token.Literal,
 	}
 
-	p.nextToken() // point to expression start
-	right, err := p.parseExpression(PREFIX)
+	p.NextToken() // point to expression start
+	right, err := p.ParseExpression(PREFIX)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -116,69 +111,69 @@ func (p *Parser) parsePrefixExpression() (*ast.PrefixExpression, error) {
 	return exp, nil
 }
 
-func (p *Parser) parseGroupedExpression() (*ast.GroupedExpression, error) {
+func (p *Parser) ParseGroupedExpression() (*ast.GroupedExpression, error) {
 	exp := &ast.GroupedExpression{
 		Meta: p.curToken,
 	}
 
-	p.nextToken() // point to expression start
-	right, err := p.parseExpression(LOWEST)
+	p.NextToken() // point to expression start
+	right, err := p.ParseExpression(LOWEST)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 	exp.Right = right
 
-	if !p.expectPeek(token.RIGHT_PAREN) {
+	if !p.ExpectPeek(token.RIGHT_PAREN) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "RIGHT_PAREN"))
 	}
 
 	return exp, nil
 }
 
-func (p *Parser) parseIfExpression() (*ast.IfExpression, error) {
+func (p *Parser) ParseIfExpression() (*ast.IfExpression, error) {
 	exp := &ast.IfExpression{
 		Meta: p.curToken,
 	}
 
-	if !p.expectPeek(token.LEFT_PAREN) {
+	if !p.ExpectPeek(token.LEFT_PAREN) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "LEFT_PAREN"))
 	}
 
-	p.nextToken() // point to condition expression start
-	cond, err := p.parseExpression(LOWEST)
+	p.NextToken() // point to condition expression start
+	cond, err := p.ParseExpression(LOWEST)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 	exp.Condition = cond
 
-	if !p.expectPeek(token.COMMA) {
+	if !p.ExpectPeek(token.COMMA) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "COMMA"))
 	}
 
-	p.nextToken() // point to consequence expression
-	exp.Consequence, err = p.parseExpression(LOWEST)
+	p.NextToken() // point to consequence expression
+	exp.Consequence, err = p.ParseExpression(LOWEST)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 
-	if !p.expectPeek(token.COMMA) {
+	if !p.ExpectPeek(token.COMMA) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "COMMA"))
 	}
 
-	p.nextToken() // point to alternative expression
-	exp.Alternative, err = p.parseExpression(LOWEST)
+	p.NextToken() // point to alternative expression
+	exp.Alternative, err = p.ParseExpression(LOWEST)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 
-	if !p.expectPeek(token.RIGHT_PAREN) {
+	if !p.ExpectPeek(token.RIGHT_PAREN) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "RIGHT_PAREN"))
 	}
 
 	return exp, nil
 }
 
-func (p *Parser) parseInfixExpression(left ast.Expression) (ast.Expression, error) {
+func (p *Parser) ParseInfixExpression(left ast.Expression) (ast.Expression, error) {
 	exp := &ast.InfixExpression{
 		Meta:     p.curToken, // point to operator token
 		Operator: p.curToken.Token.Literal,
@@ -186,8 +181,8 @@ func (p *Parser) parseInfixExpression(left ast.Expression) (ast.Expression, erro
 	}
 
 	precedence := p.curPrecedence()
-	p.nextToken() // point to right expression start
-	right, err := p.parseExpression(precedence)
+	p.NextToken() // point to right expression start
+	right, err := p.ParseExpression(precedence)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -196,7 +191,7 @@ func (p *Parser) parseInfixExpression(left ast.Expression) (ast.Expression, erro
 	return exp, nil
 }
 
-func (p *Parser) parseInfixStringConcatExpression(left ast.Expression) (ast.Expression, error) {
+func (p *Parser) ParseInfixStringConcatExpression(left ast.Expression) (ast.Expression, error) {
 	exp := &ast.InfixExpression{
 		Meta: p.curToken,
 		// VCL can concat string without "+" operator, consecutive token.
@@ -206,7 +201,7 @@ func (p *Parser) parseInfixStringConcatExpression(left ast.Expression) (ast.Expr
 	}
 
 	precedence := p.curPrecedence()
-	right, err := p.parseExpression(precedence)
+	right, err := p.ParseExpression(precedence)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -215,7 +210,7 @@ func (p *Parser) parseInfixStringConcatExpression(left ast.Expression) (ast.Expr
 	return exp, nil
 }
 
-func (p *Parser) parsePostfixExpression(left ast.Expression) (ast.Expression, error) {
+func (p *Parser) ParsePostfixExpression(left ast.Expression) (ast.Expression, error) {
 	exp := &ast.PostfixExpression{
 		Meta: p.curToken,
 		Left: left,
@@ -225,7 +220,7 @@ func (p *Parser) parsePostfixExpression(left ast.Expression) (ast.Expression, er
 	return exp, nil
 }
 
-func (p *Parser) parseFunctionCallExpression(fn ast.Expression) (ast.Expression, error) {
+func (p *Parser) ParseFunctionCallExpression(fn ast.Expression) (ast.Expression, error) {
 	ident, ok := fn.(*ast.Ident)
 	if !ok {
 		return nil, errors.New("Function name must be IDENT")
@@ -235,7 +230,7 @@ func (p *Parser) parseFunctionCallExpression(fn ast.Expression) (ast.Expression,
 		Function: ident,
 	}
 
-	args, err := p.parseFunctionArgumentExpressions()
+	args, err := p.ParseFunctionArgumentExpressions()
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -244,36 +239,36 @@ func (p *Parser) parseFunctionCallExpression(fn ast.Expression) (ast.Expression,
 	return exp, nil
 }
 
-func (p *Parser) parseFunctionArgumentExpressions() ([]ast.Expression, error) {
+func (p *Parser) ParseFunctionArgumentExpressions() ([]ast.Expression, error) {
 	list := []ast.Expression{}
 
-	if p.peekTokenIs(token.RIGHT_PAREN) {
-		p.nextToken() // point to RIGHT_PAREN, means nothing argument is specified
+	if p.PeekTokenIs(token.RIGHT_PAREN) {
+		p.NextToken() // point to RIGHT_PAREN, means nothing argument is specified
 		return list, nil
 	}
 
-	p.nextToken() // point to first argument expression
-	item, err := p.parseExpression(LOWEST)
+	p.NextToken() // point to first argument expression
+	item, err := p.ParseExpression(LOWEST)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 	list = append(list, item)
 
-	for p.peekTokenIs(token.COMMA) {
-		p.nextToken() // point to COMMA
-		swapLeadingTrailing(p.curToken, list[len(list)-1].GetMeta())
-		p.nextToken() // point to next argument expression
-		item, err := p.parseExpression(LOWEST)
+	for p.PeekTokenIs(token.COMMA) {
+		p.NextToken() // point to COMMA
+		SwapLeadingTrailing(p.curToken, list[len(list)-1].GetMeta())
+		p.NextToken() // point to next argument expression
+		item, err := p.ParseExpression(LOWEST)
 		if err != nil {
 			return nil, err
 		}
 		list = append(list, item)
 	}
 
-	if !p.expectPeek(token.RIGHT_PAREN) {
+	if !p.ExpectPeek(token.RIGHT_PAREN) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "RIGHT_PAREN"))
 	}
-	swapLeadingTrailing(p.curToken, list[len(list)-1].GetMeta())
+	SwapLeadingTrailing(p.curToken, list[len(list)-1].GetMeta())
 
 	return list, nil
 }

--- a/parser/helper.go
+++ b/parser/helper.go
@@ -51,12 +51,12 @@ func isAssignmentOperator(t token.Token) bool {
 }
 
 // Comment control helper
-func swapLeadingTrailing(from, to *ast.Meta) {
+func SwapLeadingTrailing(from, to *ast.Meta) {
 	to.Trailing = append(to.Trailing, from.Leading...)
 	from.Leading = ast.Comments{}
 }
 
-func swapLeadingInfix(from, to *ast.Meta) {
+func SwapLeadingInfix(from, to *ast.Meta) {
 	to.Infix = append(to.Infix, from.Leading...)
 	from.Leading = ast.Comments{}
 }

--- a/parser/option.go
+++ b/parser/option.go
@@ -1,0 +1,11 @@
+package parser
+
+type ParserOption func(p *Parser)
+
+func WithCustomParser(cps ...CustomParser) ParserOption {
+	return func(p *Parser) {
+		for i := range cps {
+			p.customParsers[cps[i].Literal()] = cps[i]
+		}
+	}
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -57,29 +57,41 @@ type Parser struct {
 	prefixParsers  map[token.TokenType]prefixParser
 	infixParsers   map[token.TokenType]infixParser
 	postfixParsers map[token.TokenType]postfixParser
+	customParsers  map[string]CustomParser
 }
 
-func New(l *lexer.Lexer) *Parser {
+func New(l *lexer.Lexer, opts ...ParserOption) *Parser {
 	p := &Parser{
-		l: l,
+		l:             l,
+		customParsers: make(map[string]CustomParser),
+	}
+	for i := range opts {
+		opts[i](p)
 	}
 
 	p.registerExpressionParsers()
 
-	p.nextToken()
-	p.nextToken()
+	// Register custom lexer tokens for each custom parsers
+	var literals []string
+	for literal := range p.customParsers {
+		literals = append(literals, literal)
+	}
+	l.RegisterCustomTokens(literals...)
+
+	p.NextToken()
+	p.NextToken()
 
 	return p
 }
 
-func (p *Parser) nextToken() {
+func (p *Parser) NextToken() {
 	p.prevToken = p.curToken
 	p.curToken = p.peekToken
 
-	p.readPeek()
+	p.ReadPeek()
 }
 
-func (p *Parser) readPeek() {
+func (p *Parser) ReadPeek() {
 	leading := ast.Comments{}
 	var prefixedLineFeed bool
 	var previousEmptyLines int
@@ -120,7 +132,7 @@ func (p *Parser) readPeek() {
 	}
 }
 
-func (p *Parser) trailing() ast.Comments {
+func (p *Parser) Trailing() ast.Comments {
 	cs := ast.Comments{}
 	// Divide trailing comment for current node and leading comment for next node
 	if len(p.peekToken.Leading) > 0 {
@@ -137,23 +149,31 @@ func (p *Parser) trailing() ast.Comments {
 	return cs
 }
 
-func (p *Parser) prevTokenIs(t token.TokenType) bool {
+func (p *Parser) PeekToken() *ast.Meta {
+	return p.peekToken
+}
+
+func (p *Parser) CurToken() *ast.Meta {
+	return p.curToken
+}
+
+func (p *Parser) PrevTokenIs(t token.TokenType) bool {
 	return p.prevToken.Token.Type == t
 }
 
-func (p *Parser) curTokenIs(t token.TokenType) bool {
+func (p *Parser) CurTokenIs(t token.TokenType) bool {
 	return p.curToken.Token.Type == t
 }
 
-func (p *Parser) peekTokenIs(t token.TokenType) bool {
+func (p *Parser) PeekTokenIs(t token.TokenType) bool {
 	return p.peekToken.Token.Type == t
 }
 
-func (p *Parser) expectPeek(t token.TokenType) bool {
-	if !p.peekTokenIs(t) {
+func (p *Parser) ExpectPeek(t token.TokenType) bool {
+	if !p.PeekTokenIs(t) {
 		return false
 	}
-	p.nextToken()
+	p.NextToken()
 	return true
 }
 
@@ -174,8 +194,8 @@ func (p *Parser) peekPrecedence() int {
 func (p *Parser) ParseVCL() (*ast.VCL, error) {
 	vcl := &ast.VCL{}
 
-	for !p.curTokenIs(token.EOF) {
-		stmt, err := p.parse()
+	for !p.CurTokenIs(token.EOF) {
+		stmt, err := p.Parse()
 		if err != nil {
 			return nil, err
 		} else if stmt != nil {
@@ -186,29 +206,31 @@ func (p *Parser) ParseVCL() (*ast.VCL, error) {
 	return vcl, nil
 }
 
-func (p *Parser) parse() (ast.Statement, error) {
+func (p *Parser) Parse() (ast.Statement, error) {
 	var stmt ast.Statement
 	var err error
 
 	switch p.curToken.Token.Type {
 	case token.ACL:
-		stmt, err = p.parseAclDeclaration()
+		stmt, err = p.ParseAclDeclaration()
 	case token.IMPORT:
-		stmt, err = p.parseImportStatement()
+		stmt, err = p.ParseImportStatement()
 	case token.INCLUDE:
-		stmt, err = p.parseIncludeStatement()
+		stmt, err = p.ParseIncludeStatement()
 	case token.BACKEND:
-		stmt, err = p.parseBackendDeclaration()
+		stmt, err = p.ParseBackendDeclaration()
 	case token.DIRECTOR:
-		stmt, err = p.parseDirectorDeclaration()
+		stmt, err = p.ParseDirectorDeclaration()
 	case token.TABLE:
-		stmt, err = p.parseTableDeclaration()
+		stmt, err = p.ParseTableDeclaration()
 	case token.SUBROUTINE:
-		stmt, err = p.parseSubroutineDeclaration()
+		stmt, err = p.ParseSubroutineDeclaration()
 	case token.PENALTYBOX:
-		stmt, err = p.parsePenaltyboxDeclaration()
+		stmt, err = p.ParsePenaltyboxDeclaration()
 	case token.RATECOUNTER:
-		stmt, err = p.parseRatecounterDeclaration()
+		stmt, err = p.ParseRatecounterDeclaration()
+	case token.CUSTOM:
+		stmt, err = p.ParseCustomToken()
 	default:
 		err = UnexpectedToken(p.curToken)
 	}
@@ -216,17 +238,17 @@ func (p *Parser) parse() (ast.Statement, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	p.nextToken()
+	p.NextToken()
 	return stmt, nil
 }
 
 // ParseSnippetVCL is used for snippet parsing.
-// VCL snippet is a piece of vcl code so we should parse like BlockStatement inside,
+// VCL snippet is a piece of vcl code so we should Parse like BlockStatement inside,
 // and returns slice of statement.
 func (p *Parser) ParseSnippetVCL() ([]ast.Statement, error) {
 	var statements []ast.Statement
 
-	for !p.peekTokenIs(token.EOF) {
+	for !p.PeekTokenIs(token.EOF) {
 		var stmt ast.Statement
 		var err error
 
@@ -241,46 +263,46 @@ func (p *Parser) ParseSnippetVCL() ([]ast.Statement, error) {
 		// }
 		// ```
 		case token.LEFT_BRACE:
-			stmt, err = p.parseBlockStatement()
+			stmt, err = p.ParseBlockStatement()
 		case token.SET:
-			stmt, err = p.parseSetStatement()
+			stmt, err = p.ParseSetStatement()
 		case token.UNSET:
-			stmt, err = p.parseUnsetStatement()
+			stmt, err = p.ParseUnsetStatement()
 		case token.REMOVE:
-			stmt, err = p.parseRemoveStatement()
+			stmt, err = p.ParseRemoveStatement()
 		case token.ADD:
-			stmt, err = p.parseAddStatement()
+			stmt, err = p.ParseAddStatement()
 		case token.CALL:
-			stmt, err = p.parseCallStatement()
+			stmt, err = p.ParseCallStatement()
 		case token.DECLARE:
-			stmt, err = p.parseDeclareStatement()
+			stmt, err = p.ParseDeclareStatement()
 		case token.ERROR:
-			stmt, err = p.parseErrorStatement()
+			stmt, err = p.ParseErrorStatement()
 		case token.ESI:
-			stmt, err = p.parseEsiStatement()
+			stmt, err = p.ParseEsiStatement()
 		case token.LOG:
-			stmt, err = p.parseLogStatement()
+			stmt, err = p.ParseLogStatement()
 		case token.RESTART:
-			stmt, err = p.parseRestartStatement()
+			stmt, err = p.ParseRestartStatement()
 		case token.RETURN:
-			stmt, err = p.parseReturnStatement()
+			stmt, err = p.ParseReturnStatement()
 		case token.SYNTHETIC:
-			stmt, err = p.parseSyntheticStatement()
+			stmt, err = p.ParseSyntheticStatement()
 		case token.SYNTHETIC_BASE64:
-			stmt, err = p.parseSyntheticBase64Statement()
+			stmt, err = p.ParseSyntheticBase64Statement()
 		case token.IF:
-			stmt, err = p.parseIfStatement()
+			stmt, err = p.ParseIfStatement()
 		case token.GOTO:
-			stmt, err = p.parseGotoStatement()
+			stmt, err = p.ParseGotoStatement()
 		case token.INCLUDE:
-			stmt, err = p.parseIncludeStatement()
+			stmt, err = p.ParseIncludeStatement()
 		case token.IDENT:
 			// Check if the current ident is a function call
-			if p.peekTokenIs(token.LEFT_PAREN) {
-				stmt, err = p.parseFunctionCall()
+			if p.PeekTokenIs(token.LEFT_PAREN) {
+				stmt, err = p.ParseFunctionCall()
 			} else {
 				// Could be a goto destination
-				stmt, err = p.parseGotoDestination()
+				stmt, err = p.ParseGotoDestination()
 			}
 		default:
 			err = UnexpectedToken(p.peekToken)
@@ -290,9 +312,9 @@ func (p *Parser) ParseSnippetVCL() ([]ast.Statement, error) {
 			return nil, errors.WithStack(err)
 		}
 		statements = append(statements, stmt)
-		p.nextToken() // point to statement
+		p.NextToken() // point to statement
 	}
 
-	p.nextToken() // point to EOF
+	p.NextToken() // point to EOF
 	return statements, nil
 }

--- a/parser/statement_parser.go
+++ b/parser/statement_parser.go
@@ -6,11 +6,11 @@ import (
 	"github.com/ysugimoto/falco/token"
 )
 
-func (p *Parser) parseStatement() (ast.Statement, error) {
+func (p *Parser) ParseStatement() (ast.Statement, error) {
 	var stmt ast.Statement
 	var err error
 
-	p.nextToken() // point to statement
+	p.NextToken() // point to statement
 	switch p.curToken.Token.Type {
 	// https://github.com/ysugimoto/falco/issues/17
 	// VCL accepts block syntax:
@@ -22,52 +22,54 @@ func (p *Parser) parseStatement() (ast.Statement, error) {
 	// }
 	// ```
 	case token.LEFT_BRACE:
-		stmt, err = p.parseBlockStatement()
+		stmt, err = p.ParseBlockStatement()
 	case token.SET:
-		stmt, err = p.parseSetStatement()
+		stmt, err = p.ParseSetStatement()
 	case token.UNSET:
-		stmt, err = p.parseUnsetStatement()
+		stmt, err = p.ParseUnsetStatement()
 	case token.REMOVE:
-		stmt, err = p.parseRemoveStatement()
+		stmt, err = p.ParseRemoveStatement()
 	case token.ADD:
-		stmt, err = p.parseAddStatement()
+		stmt, err = p.ParseAddStatement()
 	case token.CALL:
-		stmt, err = p.parseCallStatement()
+		stmt, err = p.ParseCallStatement()
 	case token.DECLARE:
-		stmt, err = p.parseDeclareStatement()
+		stmt, err = p.ParseDeclareStatement()
 	case token.ERROR:
-		stmt, err = p.parseErrorStatement()
+		stmt, err = p.ParseErrorStatement()
 	case token.ESI:
-		stmt, err = p.parseEsiStatement()
+		stmt, err = p.ParseEsiStatement()
 	case token.LOG:
-		stmt, err = p.parseLogStatement()
+		stmt, err = p.ParseLogStatement()
 	case token.RESTART:
-		stmt, err = p.parseRestartStatement()
+		stmt, err = p.ParseRestartStatement()
 	case token.RETURN:
-		stmt, err = p.parseReturnStatement()
+		stmt, err = p.ParseReturnStatement()
 	case token.SYNTHETIC:
-		stmt, err = p.parseSyntheticStatement()
+		stmt, err = p.ParseSyntheticStatement()
 	case token.SYNTHETIC_BASE64:
-		stmt, err = p.parseSyntheticBase64Statement()
+		stmt, err = p.ParseSyntheticBase64Statement()
 	case token.IF:
-		stmt, err = p.parseIfStatement()
+		stmt, err = p.ParseIfStatement()
 	case token.SWITCH:
-		stmt, err = p.parseSwitchStatement()
+		stmt, err = p.ParseSwitchStatement()
 	case token.GOTO:
-		stmt, err = p.parseGotoStatement()
+		stmt, err = p.ParseGotoStatement()
 	case token.INCLUDE:
-		stmt, err = p.parseIncludeStatement()
+		stmt, err = p.ParseIncludeStatement()
 	case token.BREAK:
-		stmt, err = p.parseBreakStatement()
+		stmt, err = p.ParseBreakStatement()
 	case token.FALLTHROUGH:
-		stmt, err = p.parseFallthroughStatement()
+		stmt, err = p.ParseFallthroughStatement()
+	case token.CUSTOM:
+		stmt, err = p.ParseCustomToken()
 	case token.IDENT:
 		// Check if the current ident is a function call
-		if p.peekTokenIs(token.LEFT_PAREN) {
-			stmt, err = p.parseFunctionCall()
+		if p.PeekTokenIs(token.LEFT_PAREN) {
+			stmt, err = p.ParseFunctionCall()
 		} else {
 			// Could be a goto destination
-			stmt, err = p.parseGotoDestination()
+			stmt, err = p.ParseGotoDestination()
 			if err != nil {
 				// raise an error on the current token
 				err = UnexpectedToken(p.curToken)
@@ -82,52 +84,52 @@ func (p *Parser) parseStatement() (ast.Statement, error) {
 	return stmt, nil
 }
 
-func (p *Parser) parseImportStatement() (*ast.ImportStatement, error) {
+func (p *Parser) ParseImportStatement() (*ast.ImportStatement, error) {
 	i := &ast.ImportStatement{
 		Meta: p.curToken,
 	}
 
-	if !p.expectPeek(token.IDENT) {
+	if !p.ExpectPeek(token.IDENT) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "IDENT"))
 	}
-	i.Name = p.parseIdent()
+	i.Name = p.ParseIdent()
 
-	if !p.peekTokenIs(token.SEMICOLON) {
+	if !p.PeekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	p.nextToken() // point to SEMICOLON
-	swapLeadingTrailing(p.curToken, i.Name.Meta)
-	i.Meta.Trailing = p.trailing()
+	p.NextToken() // point to SEMICOLON
+	SwapLeadingTrailing(p.curToken, i.Name.Meta)
+	i.Meta.Trailing = p.Trailing()
 
 	return i, nil
 }
 
-func (p *Parser) parseIncludeStatement() (ast.Statement, error) {
+func (p *Parser) ParseIncludeStatement() (ast.Statement, error) {
 	i := &ast.IncludeStatement{
 		Meta: p.curToken,
 	}
 
-	if !p.expectPeek(token.STRING) {
+	if !p.ExpectPeek(token.STRING) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "STRING"))
 	}
 	var err error
-	i.Module, err = p.parseString()
+	i.Module, err = p.ParseString()
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 
 	// Semicolons are actually not required at the end of include lines
 	// either works on fastly.
-	if p.peekTokenIs(token.SEMICOLON) {
-		p.nextToken() // point to SEMICOLON
-		swapLeadingTrailing(p.curToken, i.Module.Meta)
+	if p.PeekTokenIs(token.SEMICOLON) {
+		p.NextToken() // point to SEMICOLON
+		SwapLeadingTrailing(p.curToken, i.Module.Meta)
 	}
-	i.Meta.Trailing = p.trailing()
+	i.Meta.Trailing = p.Trailing()
 
 	return i, nil
 }
 
-func (p *Parser) parseBlockStatement() (*ast.BlockStatement, error) {
+func (p *Parser) ParseBlockStatement() (*ast.BlockStatement, error) {
 	// Note: block statement is used for declaration/statement inside like subroutine, if, elseif, else
 	// on start this statement, current token must point start of LEFT_BRACE
 	// and after on end this statement, current token must point end of RIGHT_BRACE
@@ -136,8 +138,8 @@ func (p *Parser) parseBlockStatement() (*ast.BlockStatement, error) {
 		Statements: []ast.Statement{},
 	}
 
-	for !p.peekTokenIs(token.RIGHT_BRACE) {
-		stmt, err := p.parseStatement()
+	for !p.PeekTokenIs(token.RIGHT_BRACE) {
+		stmt, err := p.ParseStatement()
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
@@ -148,199 +150,199 @@ func (p *Parser) parseBlockStatement() (*ast.BlockStatement, error) {
 		b.Statements = append(b.Statements, stmt)
 	}
 
-	p.nextToken() // point to RIGHT_BRACE
-	b.Meta.Trailing = p.trailing()
+	p.NextToken() // point to RIGHT_BRACE
+	b.Meta.Trailing = p.Trailing()
 
 	// RIGHT_BRACE leading comments are block infix comments
-	swapLeadingInfix(p.curToken, b.Meta)
+	SwapLeadingInfix(p.curToken, b.Meta)
 
 	return b, nil
 }
 
-func (p *Parser) parseSetStatement() (*ast.SetStatement, error) {
+func (p *Parser) ParseSetStatement() (*ast.SetStatement, error) {
 	stmt := &ast.SetStatement{
 		Meta: p.curToken,
 	}
 
-	if !p.expectPeek(token.IDENT) {
+	if !p.ExpectPeek(token.IDENT) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "IDENT"))
 	}
-	stmt.Ident = p.parseIdent()
+	stmt.Ident = p.ParseIdent()
 
 	if !isAssignmentOperator(p.peekToken.Token) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, assignmentOperatorLiterals...))
 	}
-	p.nextToken() // point to assignment operator
-	swapLeadingTrailing(p.curToken, stmt.Ident.Meta)
+	p.NextToken() // point to assignment operator
+	SwapLeadingTrailing(p.curToken, stmt.Ident.Meta)
 
 	stmt.Operator = &ast.Operator{
 		Meta:     p.curToken,
 		Operator: p.curToken.Token.Literal,
 	}
-	p.nextToken() // point to right expression start
+	p.NextToken() // point to right expression start
 
-	exp, err := p.parseExpression(LOWEST)
+	exp, err := p.ParseExpression(LOWEST)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 	stmt.Value = exp
 
-	if !p.peekTokenIs(token.SEMICOLON) {
+	if !p.PeekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	p.nextToken() // point to SEMICOLON
-	swapLeadingTrailing(p.curToken, stmt.Value.GetMeta())
-	stmt.Meta.Trailing = p.trailing()
+	p.NextToken() // point to SEMICOLON
+	SwapLeadingTrailing(p.curToken, stmt.Value.GetMeta())
+	stmt.Meta.Trailing = p.Trailing()
 
 	return stmt, nil
 }
 
-func (p *Parser) parseUnsetStatement() (*ast.UnsetStatement, error) {
+func (p *Parser) ParseUnsetStatement() (*ast.UnsetStatement, error) {
 	stmt := &ast.UnsetStatement{
 		Meta: p.curToken,
 	}
 
-	if !p.expectPeek(token.IDENT) {
+	if !p.ExpectPeek(token.IDENT) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "IDENT"))
 	}
-	stmt.Ident = p.parseIdent()
+	stmt.Ident = p.ParseIdent()
 
-	if !p.peekTokenIs(token.SEMICOLON) {
+	if !p.PeekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	p.nextToken() // point to SEMICOLON
-	swapLeadingTrailing(p.curToken, stmt.Ident.GetMeta())
-	stmt.Meta.Trailing = p.trailing()
+	p.NextToken() // point to SEMICOLON
+	SwapLeadingTrailing(p.curToken, stmt.Ident.GetMeta())
+	stmt.Meta.Trailing = p.Trailing()
 
 	return stmt, nil
 }
 
-func (p *Parser) parseRemoveStatement() (*ast.RemoveStatement, error) {
+func (p *Parser) ParseRemoveStatement() (*ast.RemoveStatement, error) {
 	stmt := &ast.RemoveStatement{
 		Meta: p.curToken,
 	}
 
-	if !p.expectPeek(token.IDENT) {
+	if !p.ExpectPeek(token.IDENT) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "IDENT"))
 	}
-	stmt.Ident = p.parseIdent()
+	stmt.Ident = p.ParseIdent()
 
-	if !p.peekTokenIs(token.SEMICOLON) {
+	if !p.PeekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	p.nextToken() // point to SEMICOLON
-	swapLeadingTrailing(p.curToken, stmt.Ident.GetMeta())
-	stmt.Meta.Trailing = p.trailing()
+	p.NextToken() // point to SEMICOLON
+	SwapLeadingTrailing(p.curToken, stmt.Ident.GetMeta())
+	stmt.Meta.Trailing = p.Trailing()
 
 	return stmt, nil
 }
 
-func (p *Parser) parseAddStatement() (*ast.AddStatement, error) {
+func (p *Parser) ParseAddStatement() (*ast.AddStatement, error) {
 	stmt := &ast.AddStatement{
 		Meta: p.curToken,
 	}
 
-	if !p.expectPeek(token.IDENT) {
+	if !p.ExpectPeek(token.IDENT) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "IDENT"))
 	}
-	stmt.Ident = p.parseIdent()
+	stmt.Ident = p.ParseIdent()
 
 	if !isAssignmentOperator(p.peekToken.Token) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, assignmentOperatorLiterals...))
 	}
-	p.nextToken() // pojnt to assignment operator
-	swapLeadingTrailing(p.curToken, stmt.Ident.Meta)
+	p.NextToken() // pojnt to assignment operator
+	SwapLeadingTrailing(p.curToken, stmt.Ident.Meta)
 
 	stmt.Operator = &ast.Operator{
 		Meta:     p.curToken,
 		Operator: p.curToken.Token.Literal,
 	}
-	p.nextToken() // start expression token
+	p.NextToken() // start expression token
 
-	exp, err := p.parseExpression(LOWEST)
+	exp, err := p.ParseExpression(LOWEST)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 	stmt.Value = exp
 
-	if !p.peekTokenIs(token.SEMICOLON) {
+	if !p.PeekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	p.nextToken() // point to SEMICOLON
-	swapLeadingTrailing(p.curToken, stmt.Value.GetMeta())
-	stmt.Meta.Trailing = p.trailing()
+	p.NextToken() // point to SEMICOLON
+	SwapLeadingTrailing(p.curToken, stmt.Value.GetMeta())
+	stmt.Meta.Trailing = p.Trailing()
 
 	return stmt, nil
 }
 
-func (p *Parser) parseCallStatement() (*ast.CallStatement, error) {
+func (p *Parser) ParseCallStatement() (*ast.CallStatement, error) {
 	stmt := &ast.CallStatement{
 		Meta: p.curToken,
 	}
 
-	if !p.expectPeek(token.IDENT) {
+	if !p.ExpectPeek(token.IDENT) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "IDENT"))
 	}
-	stmt.Subroutine = p.parseIdent()
+	stmt.Subroutine = p.ParseIdent()
 
 	// Parse functions with ()
-	if p.peekTokenIs(token.LEFT_PAREN) {
-		p.nextToken() // point to the token to check if it is RIGHT_PAREN
-		if !p.peekTokenIs(token.RIGHT_PAREN) {
+	if p.PeekTokenIs(token.LEFT_PAREN) {
+		p.NextToken() // point to the token to check if it is RIGHT_PAREN
+		if !p.PeekTokenIs(token.RIGHT_PAREN) {
 			return nil, errors.WithStack(UnexpectedToken(p.curToken))
 		}
-		p.nextToken() // point to RIGHT_PAREN
+		p.NextToken() // point to RIGHT_PAREN
 	}
 
-	if !p.peekTokenIs(token.SEMICOLON) {
+	if !p.PeekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
 
-	p.nextToken() // point to SEMICOLON
-	swapLeadingTrailing(p.curToken, stmt.Subroutine.GetMeta())
-	stmt.Meta.Trailing = p.trailing()
+	p.NextToken() // point to SEMICOLON
+	SwapLeadingTrailing(p.curToken, stmt.Subroutine.GetMeta())
+	stmt.Meta.Trailing = p.Trailing()
 
 	return stmt, nil
 }
 
-func (p *Parser) parseDeclareStatement() (*ast.DeclareStatement, error) {
+func (p *Parser) ParseDeclareStatement() (*ast.DeclareStatement, error) {
 	stmt := &ast.DeclareStatement{
 		Meta: p.curToken,
 	}
 
 	// Declare Syntax is declare [IDENT:"local"] [IDENT:variable name] [IDENT:VCL type]
-	if !p.expectPeek(token.IDENT) {
+	if !p.ExpectPeek(token.IDENT) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "IDENT"))
 	}
 	if p.curToken.Token.Literal != "local" {
 		return nil, errors.WithStack(UnexpectedToken(p.curToken, "local"))
 	}
-	swapLeadingInfix(p.curToken, stmt.Meta)
+	SwapLeadingInfix(p.curToken, stmt.Meta)
 
 	// Variable Name
-	if !p.expectPeek(token.IDENT) {
+	if !p.ExpectPeek(token.IDENT) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "IDENT"))
 	}
-	stmt.Name = p.parseIdent()
+	stmt.Name = p.ParseIdent()
 
 	// Variable Type
-	if !p.expectPeek(token.IDENT) {
+	if !p.ExpectPeek(token.IDENT) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "IDENT"))
 	}
-	swapLeadingTrailing(p.curToken, stmt.Name.Meta)
-	stmt.ValueType = p.parseIdent()
+	SwapLeadingTrailing(p.curToken, stmt.Name.Meta)
+	stmt.ValueType = p.ParseIdent()
 
-	if !p.peekTokenIs(token.SEMICOLON) {
+	if !p.PeekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	p.nextToken() // point to SEMICOLON
-	swapLeadingTrailing(p.curToken, stmt.ValueType.Meta)
-	stmt.Meta.Trailing = p.trailing()
+	p.NextToken() // point to SEMICOLON
+	SwapLeadingTrailing(p.curToken, stmt.ValueType.Meta)
+	stmt.Meta.Trailing = p.Trailing()
 
 	return stmt, nil
 }
 
-func (p *Parser) parseErrorStatement() (*ast.ErrorStatement, error) {
+func (p *Parser) ParseErrorStatement() (*ast.ErrorStatement, error) {
 	stmt := &ast.ErrorStatement{
 		Meta: p.curToken,
 	}
@@ -349,16 +351,16 @@ func (p *Parser) parseErrorStatement() (*ast.ErrorStatement, error) {
 	var err error
 	switch p.peekToken.Token.Type {
 	case token.INT:
-		p.nextToken()
-		stmt.Code, err = p.parseInteger()
+		p.NextToken()
+		stmt.Code, err = p.ParseInteger()
 	case token.IDENT:
-		p.nextToken()
-		if p.peekTokenIs(token.LEFT_PAREN) {
-			i := p.parseIdent()
-			p.nextToken()
-			stmt.Code, err = p.parseFunctionCallExpression(i)
+		p.NextToken()
+		if p.PeekTokenIs(token.LEFT_PAREN) {
+			i := p.ParseIdent()
+			p.NextToken()
+			stmt.Code, err = p.ParseFunctionCallExpression(i)
 		} else {
-			stmt.Code = p.parseIdent()
+			stmt.Code = p.ParseIdent()
 		}
 	case token.SEMICOLON: // without code and response like "error;"
 		break
@@ -370,87 +372,87 @@ func (p *Parser) parseErrorStatement() (*ast.ErrorStatement, error) {
 	}
 
 	// Optional expression, error statement argument
-	if !p.peekTokenIs(token.SEMICOLON) {
-		p.nextToken()
-		stmt.Argument, err = p.parseExpression(LOWEST)
+	if !p.PeekTokenIs(token.SEMICOLON) {
+		p.NextToken()
+		stmt.Argument, err = p.ParseExpression(LOWEST)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
 	}
 
-	if !p.peekTokenIs(token.SEMICOLON) {
+	if !p.PeekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	p.nextToken() // point to SEMICOLON
+	p.NextToken() // point to SEMICOLON
 
 	switch {
-	// If argument exists, attach comment to it as trailing
+	// If argument exists, attach comment to it as Trailing
 	case stmt.Argument != nil:
-		swapLeadingTrailing(p.curToken, stmt.Argument.GetMeta())
-	// If code exists, attach comment to it as trailing
+		SwapLeadingTrailing(p.curToken, stmt.Argument.GetMeta())
+	// If code exists, attach comment to it as Trailing
 	case stmt.Code != nil:
-		swapLeadingTrailing(p.curToken, stmt.Code.GetMeta())
-	// Otherwise, attach comment to the statement as trailing
+		SwapLeadingTrailing(p.curToken, stmt.Code.GetMeta())
+	// Otherwise, attach comment to the statement as Trailing
 	default:
-		swapLeadingTrailing(p.curToken, stmt.Meta)
+		SwapLeadingTrailing(p.curToken, stmt.Meta)
 	}
-	stmt.Meta.Trailing = p.trailing()
+	stmt.Meta.Trailing = p.Trailing()
 
 	return stmt, nil
 }
 
-func (p *Parser) parseEsiStatement() (*ast.EsiStatement, error) {
+func (p *Parser) ParseEsiStatement() (*ast.EsiStatement, error) {
 	stmt := &ast.EsiStatement{
 		Meta: p.curToken,
 	}
 
-	if !p.peekTokenIs(token.SEMICOLON) {
+	if !p.PeekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	p.nextToken() // point to SEMICOLON
-	swapLeadingInfix(p.curToken, stmt.Meta)
-	stmt.Meta.Trailing = p.trailing()
+	p.NextToken() // point to SEMICOLON
+	SwapLeadingInfix(p.curToken, stmt.Meta)
+	stmt.Meta.Trailing = p.Trailing()
 
 	return stmt, nil
 }
 
-func (p *Parser) parseLogStatement() (*ast.LogStatement, error) {
+func (p *Parser) ParseLogStatement() (*ast.LogStatement, error) {
 	stmt := &ast.LogStatement{
 		Meta: p.curToken,
 	}
 
-	p.nextToken() // point to log value expression
-	value, err := p.parseExpression(LOWEST)
+	p.NextToken() // point to log value expression
+	value, err := p.ParseExpression(LOWEST)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 	stmt.Value = value
 
-	if !p.peekTokenIs(token.SEMICOLON) {
+	if !p.PeekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	p.nextToken() // point to SEMICOLON
-	stmt.Meta.Trailing = p.trailing()
+	p.NextToken() // point to SEMICOLON
+	stmt.Meta.Trailing = p.Trailing()
 
 	return stmt, nil
 }
 
-func (p *Parser) parseRestartStatement() (*ast.RestartStatement, error) {
+func (p *Parser) ParseRestartStatement() (*ast.RestartStatement, error) {
 	stmt := &ast.RestartStatement{
 		Meta: p.curToken,
 	}
 
-	if !p.peekTokenIs(token.SEMICOLON) {
+	if !p.PeekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	p.nextToken() // point to SEMICOLON
-	swapLeadingInfix(p.curToken, stmt.Meta)
-	stmt.Meta.Trailing = p.trailing()
+	p.NextToken() // point to SEMICOLON
+	SwapLeadingInfix(p.curToken, stmt.Meta)
+	stmt.Meta.Trailing = p.Trailing()
 
 	return stmt, nil
 }
 
-func (p *Parser) parseReturnStatement() (*ast.ReturnStatement, error) {
+func (p *Parser) ParseReturnStatement() (*ast.ReturnStatement, error) {
 	stmt := &ast.ReturnStatement{
 		Meta:                        p.curToken,
 		HasParenthesis:              false,
@@ -460,31 +462,31 @@ func (p *Parser) parseReturnStatement() (*ast.ReturnStatement, error) {
 
 	// return statement may not have argument
 	// https://developer.fastly.com/reference/vcl/statements/return/
-	if p.peekTokenIs(token.SEMICOLON) {
-		p.nextToken() // point to SEMICOLON
-		swapLeadingInfix(p.curToken, stmt.Meta)
-		stmt.Meta.Trailing = p.trailing()
+	if p.PeekTokenIs(token.SEMICOLON) {
+		p.NextToken() // point to SEMICOLON
+		SwapLeadingInfix(p.curToken, stmt.Meta)
+		stmt.Meta.Trailing = p.Trailing()
 		return stmt, nil
 	}
 
-	hasLeftParen := p.peekTokenIs(token.LEFT_PAREN)
+	hasLeftParen := p.PeekTokenIs(token.LEFT_PAREN)
 	if hasLeftParen {
 		stmt.HasParenthesis = true
-		p.nextToken() // point to left parenthesis
+		p.NextToken() // point to left parenthesis
 		stmt.ParenthesisLeadingComments = p.curToken.Leading
 	}
-	p.nextToken() // point to expression
+	p.NextToken() // point to expression
 
-	expression, err := p.parseExpression(LOWEST)
+	expression, err := p.ParseExpression(LOWEST)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 	stmt.ReturnExpression = expression
 
-	hasRightParen := p.peekTokenIs(token.RIGHT_PAREN)
+	hasRightParen := p.PeekTokenIs(token.RIGHT_PAREN)
 	if hasRightParen {
-		p.nextToken() // point to right parenthesis
-		swapLeadingTrailing(p.curToken, stmt.ReturnExpression.GetMeta())
+		p.NextToken() // point to right parenthesis
+		SwapLeadingTrailing(p.curToken, stmt.ReturnExpression.GetMeta())
 	}
 	if hasLeftParen != hasRightParen {
 		return nil, errors.WithStack(&ParseError{
@@ -493,91 +495,91 @@ func (p *Parser) parseReturnStatement() (*ast.ReturnStatement, error) {
 		})
 	}
 
-	if !p.peekTokenIs(token.SEMICOLON) {
+	if !p.PeekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	p.nextToken() // point to SEMICOLON
+	p.NextToken() // point to SEMICOLON
 	if hasRightParen {
 		stmt.ParenthesisTrailingComments = p.curToken.Leading
 	} else {
-		swapLeadingTrailing(p.curToken, stmt.ReturnExpression.GetMeta())
+		SwapLeadingTrailing(p.curToken, stmt.ReturnExpression.GetMeta())
 	}
-	stmt.Meta.Trailing = p.trailing()
+	stmt.Meta.Trailing = p.Trailing()
 
 	return stmt, nil
 }
 
-func (p *Parser) parseSyntheticStatement() (*ast.SyntheticStatement, error) {
+func (p *Parser) ParseSyntheticStatement() (*ast.SyntheticStatement, error) {
 	stmt := &ast.SyntheticStatement{
 		Meta: p.curToken,
 	}
 
-	p.nextToken() // point to synthetic value expression
-	value, err := p.parseExpression(LOWEST)
+	p.NextToken() // point to synthetic value expression
+	value, err := p.ParseExpression(LOWEST)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 	stmt.Value = value
 
-	if !p.peekTokenIs(token.SEMICOLON) {
+	if !p.PeekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	p.nextToken() // point to SEMICOLON
-	stmt.Meta.Trailing = p.trailing()
+	p.NextToken() // point to SEMICOLON
+	stmt.Meta.Trailing = p.Trailing()
 
 	return stmt, nil
 }
 
-func (p *Parser) parseSyntheticBase64Statement() (*ast.SyntheticBase64Statement, error) {
+func (p *Parser) ParseSyntheticBase64Statement() (*ast.SyntheticBase64Statement, error) {
 	stmt := &ast.SyntheticBase64Statement{
 		Meta: p.curToken,
 	}
 
-	p.nextToken()
-	value, err := p.parseExpression(LOWEST)
+	p.NextToken()
+	value, err := p.ParseExpression(LOWEST)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 	stmt.Value = value
 
-	if !p.peekTokenIs(token.SEMICOLON) {
+	if !p.PeekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	p.nextToken() // point to SEMICOLON
-	stmt.Meta.Trailing = p.trailing()
+	p.NextToken() // point to SEMICOLON
+	stmt.Meta.Trailing = p.Trailing()
 
 	return stmt, nil
 }
 
-func (p *Parser) parseIfStatement() (*ast.IfStatement, error) {
+func (p *Parser) ParseIfStatement() (*ast.IfStatement, error) {
 	stmt := &ast.IfStatement{
 		Keyword: "if",
 		Meta:    p.curToken,
 	}
 
-	if !p.expectPeek(token.LEFT_PAREN) {
+	if !p.ExpectPeek(token.LEFT_PAREN) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "LEFT_PAREN"))
 	}
-	swapLeadingInfix(p.curToken, stmt.Meta)
+	SwapLeadingInfix(p.curToken, stmt.Meta)
 
-	p.nextToken() // point to condition expression
-	cond, err := p.parseExpression(LOWEST)
+	p.NextToken() // point to condition expression
+	cond, err := p.ParseExpression(LOWEST)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 	stmt.Condition = cond
 
-	if !p.expectPeek(token.RIGHT_PAREN) {
+	if !p.ExpectPeek(token.RIGHT_PAREN) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "RIGHT_PAREN"))
 	}
-	swapLeadingTrailing(p.curToken, stmt.Condition.GetMeta())
+	SwapLeadingTrailing(p.curToken, stmt.Condition.GetMeta())
 
-	if !p.expectPeek(token.LEFT_BRACE) {
+	if !p.ExpectPeek(token.LEFT_BRACE) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "LEFT_BRACE"))
 	}
 
-	// parse Consequence block
-	stmt.Consequence, err = p.parseBlockStatement()
+	// Parse Consequence block
+	stmt.Consequence, err = p.ParseBlockStatement()
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -587,16 +589,16 @@ func (p *Parser) parseIfStatement() (*ast.IfStatement, error) {
 	for {
 		switch p.peekToken.Token.Type {
 		case token.ELSE: // else
-			p.nextToken() // point to ELSE
+			p.NextToken() // point to ELSE
 
 			// If more peek token is IF, it should be "else if"
-			if p.peekTokenIs(token.IF) { // else if
+			if p.PeekTokenIs(token.IF) { // else if
 				// The leading comment of else if node is exists in "ELSE" token
 				// so store the comment before forward token
 				leading := p.curToken.Leading
 
-				p.nextToken() // point to IF
-				another, err := p.parseAnotherIfStatement("else if")
+				p.NextToken() // point to IF
+				another, err := p.ParseAnotherIfStatement("else if")
 				if err != nil {
 					return nil, errors.WithStack(err)
 				}
@@ -612,11 +614,11 @@ func (p *Parser) parseIfStatement() (*ast.IfStatement, error) {
 				Meta: p.curToken,
 			}
 			// Next token must be LEFT_BRACE
-			if !p.expectPeek(token.LEFT_BRACE) {
+			if !p.ExpectPeek(token.LEFT_BRACE) {
 				return nil, errors.WithStack(UnexpectedToken(p.peekToken, "LEFT_BRACE"))
 			}
-			swapLeadingInfix(p.curToken, stmt.Alternative.Meta)
-			stmt.Alternative.Consequence, err = p.parseBlockStatement()
+			SwapLeadingInfix(p.curToken, stmt.Alternative.Meta)
+			stmt.Alternative.Consequence, err = p.ParseBlockStatement()
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
@@ -624,8 +626,8 @@ func (p *Parser) parseIfStatement() (*ast.IfStatement, error) {
 			goto FINISH
 		// Note: VCL could define "else if" statement with "elseif", "elsif" keyword
 		case token.ELSEIF, token.ELSIF: // elseif, elsif
-			p.nextToken() // point to ELSEIF/ELSIF
-			another, err := p.parseAnotherIfStatement(p.peekToken.Token.Literal)
+			p.NextToken() // point to ELSEIF/ELSIF
+			another, err := p.ParseAnotherIfStatement(p.peekToken.Token.Literal)
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
@@ -636,40 +638,40 @@ func (p *Parser) parseIfStatement() (*ast.IfStatement, error) {
 		goto FINISH
 	}
 FINISH:
-	stmt.Meta.Trailing = p.trailing()
+	stmt.Meta.Trailing = p.Trailing()
 	return stmt, nil
 }
 
 // AnotherIfStatement is similar to IfStatement but is not culious about alternative.
-func (p *Parser) parseAnotherIfStatement(keyword string) (*ast.IfStatement, error) {
+func (p *Parser) ParseAnotherIfStatement(keyword string) (*ast.IfStatement, error) {
 	stmt := &ast.IfStatement{
 		Keyword: keyword,
 		Meta:    p.curToken,
 	}
 
-	if !p.expectPeek(token.LEFT_PAREN) {
+	if !p.ExpectPeek(token.LEFT_PAREN) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "LEFT_PAREN"))
 	}
-	swapLeadingInfix(p.curToken, stmt.Meta)
+	SwapLeadingInfix(p.curToken, stmt.Meta)
 
-	p.nextToken() // point to condition expression
-	cond, err := p.parseExpression(LOWEST)
+	p.NextToken() // point to condition expression
+	cond, err := p.ParseExpression(LOWEST)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 	stmt.Condition = cond
 
-	if !p.expectPeek(token.RIGHT_PAREN) {
+	if !p.ExpectPeek(token.RIGHT_PAREN) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "RIGHT_PAREN"))
 	}
-	swapLeadingTrailing(p.curToken, stmt.Condition.GetMeta())
+	SwapLeadingTrailing(p.curToken, stmt.Condition.GetMeta())
 
-	if !p.expectPeek(token.LEFT_BRACE) {
+	if !p.ExpectPeek(token.LEFT_BRACE) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "LEFT_BRACE"))
 	}
 
-	// parse Consequence block
-	stmt.Consequence, err = p.parseBlockStatement()
+	// Parse Consequence block
+	stmt.Consequence, err = p.ParseBlockStatement()
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -677,13 +679,13 @@ func (p *Parser) parseAnotherIfStatement(keyword string) (*ast.IfStatement, erro
 	return stmt, nil
 }
 
-func (p *Parser) parseSwitchStatement() (*ast.SwitchStatement, error) {
+func (p *Parser) ParseSwitchStatement() (*ast.SwitchStatement, error) {
 	stmt := &ast.SwitchStatement{
 		Meta:    p.curToken,
 		Default: -1, // -1 is used to represent a switch without a default case.
 	}
 
-	if !p.expectPeek(token.LEFT_PAREN) {
+	if !p.ExpectPeek(token.LEFT_PAREN) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "LEFT_PAREN"))
 	}
 
@@ -691,53 +693,53 @@ func (p *Parser) parseSwitchStatement() (*ast.SwitchStatement, error) {
 		Meta: p.curToken,
 	}
 
-	p.nextToken() // point at control expression
+	p.NextToken() // point at control expression
 
 	// Switch control expression can be a literal, variable identifier, or
 	// function call.
 	var err error
-	if p.peekTokenIs(token.LEFT_PAREN) {
-		i := p.parseIdent()
-		p.nextToken()
-		control.Expression, err = p.parseFunctionCallExpression(i)
+	if p.PeekTokenIs(token.LEFT_PAREN) {
+		i := p.ParseIdent()
+		p.NextToken()
+		control.Expression, err = p.ParseFunctionCallExpression(i)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
 	} else {
-		if p.curTokenIs(token.IDENT) {
-			control.Expression = p.parseIdent()
+		if p.CurTokenIs(token.IDENT) {
+			control.Expression = p.ParseIdent()
 		} else {
 			// Only string and bool literals can be used as a switch control
 			// expression.
-			if !p.curTokenIs(token.TRUE) && !p.curTokenIs(token.FALSE) && !p.curTokenIs(token.STRING) {
+			if !p.CurTokenIs(token.TRUE) && !p.CurTokenIs(token.FALSE) && !p.CurTokenIs(token.STRING) {
 				return nil, UnexpectedToken(
 					p.curToken,
 					"invalid literal %s for switch control, expect BOOL or STRING",
 					string(p.curToken.Token.Type))
 			}
-			control.Expression, err = p.parseExpression(LOWEST)
+			control.Expression, err = p.ParseExpression(LOWEST)
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
 		}
 	}
 
-	if !p.expectPeek(token.RIGHT_PAREN) {
+	if !p.ExpectPeek(token.RIGHT_PAREN) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "RIGHT_PAREN"))
 	}
-	swapLeadingTrailing(p.curToken, control.Expression.GetMeta())
+	SwapLeadingTrailing(p.curToken, control.Expression.GetMeta())
 
-	if !p.expectPeek(token.LEFT_BRACE) {
+	if !p.ExpectPeek(token.LEFT_BRACE) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "LEFT_BRACE"))
 	}
-	swapLeadingTrailing(p.curToken, control.GetMeta())
+	SwapLeadingTrailing(p.curToken, control.GetMeta())
 	stmt.Control = control
 
 	// Parse case clauses
-	for !p.peekTokenIs(token.RIGHT_BRACE) {
+	for !p.PeekTokenIs(token.RIGHT_BRACE) {
 		t := p.peekToken
-		p.nextToken()
-		clause, err := p.parseCaseStatement()
+		p.NextToken()
+		clause, err := p.ParseCaseStatement()
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
@@ -774,44 +776,44 @@ func (p *Parser) parseSwitchStatement() (*ast.SwitchStatement, error) {
 		return nil, errors.WithStack(FinalFallthrough(ls.GetMeta()))
 	}
 
-	p.nextToken() // point to RIGHT_BRACE
-	swapLeadingInfix(p.curToken, stmt.Meta)
-	stmt.Meta.Trailing = p.trailing()
+	p.NextToken() // point to RIGHT_BRACE
+	SwapLeadingInfix(p.curToken, stmt.Meta)
+	stmt.Meta.Trailing = p.Trailing()
 
 	return stmt, nil
 }
 
-func (p *Parser) parseBreakStatement() (*ast.BreakStatement, error) {
+func (p *Parser) ParseBreakStatement() (*ast.BreakStatement, error) {
 	stmt := &ast.BreakStatement{
 		Meta: p.curToken,
 	}
 
-	if !p.peekTokenIs(token.SEMICOLON) {
+	if !p.PeekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	p.nextToken() // point to SEMICOLON
-	swapLeadingInfix(p.curToken, stmt.Meta)
-	stmt.Meta.Trailing = p.trailing()
+	p.NextToken() // point to SEMICOLON
+	SwapLeadingInfix(p.curToken, stmt.Meta)
+	stmt.Meta.Trailing = p.Trailing()
 
 	return stmt, nil
 }
 
-func (p *Parser) parseFallthroughStatement() (*ast.FallthroughStatement, error) {
+func (p *Parser) ParseFallthroughStatement() (*ast.FallthroughStatement, error) {
 	stmt := &ast.FallthroughStatement{
 		Meta: p.curToken,
 	}
 
-	if !p.peekTokenIs(token.SEMICOLON) {
+	if !p.PeekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	p.nextToken() // point to SEMICOLON
-	swapLeadingInfix(p.curToken, stmt.Meta)
-	stmt.Meta.Trailing = p.trailing()
+	p.NextToken() // point to SEMICOLON
+	SwapLeadingInfix(p.curToken, stmt.Meta)
+	stmt.Meta.Trailing = p.Trailing()
 
 	return stmt, nil
 }
 
-func (p *Parser) parseCaseStatement() (*ast.CaseStatement, error) {
+func (p *Parser) ParseCaseStatement() (*ast.CaseStatement, error) {
 	stmt := &ast.CaseStatement{
 		Meta:       p.curToken,
 		Statements: []ast.Statement{},
@@ -819,21 +821,21 @@ func (p *Parser) parseCaseStatement() (*ast.CaseStatement, error) {
 
 	switch p.curToken.Token.Type {
 	case token.CASE:
-		p.nextToken() // match expression
+		p.NextToken() // match expression
 
 		matchExp := &ast.InfixExpression{
 			Meta: p.curToken,
 		}
 		switch p.curToken.Token.Type {
 		case token.STRING:
-			exp, err := p.parseExpression(LOWEST)
+			exp, err := p.ParseExpression(LOWEST)
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
 			matchExp.Operator = "=="
 			matchExp.Right = exp
 		case token.REGEX_MATCH:
-			exp, err := p.parsePrefixExpression()
+			exp, err := p.ParsePrefixExpression()
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
@@ -851,33 +853,33 @@ func (p *Parser) parseCaseStatement() (*ast.CaseStatement, error) {
 
 	// If stmt.Test is nil, this case is "default"
 	if stmt.Test != nil {
-		swapLeadingInfix(p.curToken, stmt.Meta)
+		SwapLeadingInfix(p.curToken, stmt.Meta)
 	}
 
-	if !p.expectPeek(token.COLON) {
+	if !p.ExpectPeek(token.COLON) {
 		return nil, errors.WithStack(MissingColon(p.curToken))
 	}
 
-	// If stmt.Test is not nil, attach as trailing comment to it
+	// If stmt.Test is not nil, attach as Trailing comment to it
 	if stmt.Test != nil {
-		swapLeadingTrailing(p.curToken, stmt.Test.Right.GetMeta())
+		SwapLeadingTrailing(p.curToken, stmt.Test.Right.GetMeta())
 	} else {
 		// Otherwise, this is the "default" case, attach as infix comment to the statement
-		swapLeadingInfix(p.curToken, stmt.GetMeta())
+		SwapLeadingInfix(p.curToken, stmt.GetMeta())
 	}
 
-	stmt.Meta.Trailing = p.trailing()
+	stmt.Meta.Trailing = p.Trailing()
 
-	for !p.peekTokenIs(token.CASE) && !p.peekTokenIs(token.DEFAULT) && !p.peekTokenIs(token.RIGHT_BRACE) {
-		s, err := p.parseStatement()
+	for !p.PeekTokenIs(token.CASE) && !p.PeekTokenIs(token.DEFAULT) && !p.PeekTokenIs(token.RIGHT_BRACE) {
+		s, err := p.ParseStatement()
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
 		stmt.Statements = append(stmt.Statements, s)
 	}
 
-	if !p.prevTokenIs(token.BREAK) {
-		if !p.prevTokenIs(token.FALLTHROUGH) {
+	if !p.PrevTokenIs(token.BREAK) {
+		if !p.PrevTokenIs(token.FALLTHROUGH) {
 			return nil, errors.WithStack(UnexpectedToken(p.prevToken, "break", "fallthrough"))
 		}
 		stmt.Fallthrough = true
@@ -886,27 +888,27 @@ func (p *Parser) parseCaseStatement() (*ast.CaseStatement, error) {
 	return stmt, nil
 }
 
-func (p *Parser) parseGotoStatement() (*ast.GotoStatement, error) {
+func (p *Parser) ParseGotoStatement() (*ast.GotoStatement, error) {
 	stmt := &ast.GotoStatement{
 		Meta: p.curToken,
 	}
 
-	if !p.expectPeek(token.IDENT) {
+	if !p.ExpectPeek(token.IDENT) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "IDENT"))
 	}
-	stmt.Destination = p.parseIdent()
+	stmt.Destination = p.ParseIdent()
 
-	if !p.peekTokenIs(token.SEMICOLON) {
+	if !p.PeekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
-	p.nextToken() // point to SEMICOLON
-	swapLeadingTrailing(p.curToken, stmt.Destination.Meta)
-	stmt.Meta.Trailing = p.trailing()
+	p.NextToken() // point to SEMICOLON
+	SwapLeadingTrailing(p.curToken, stmt.Destination.Meta)
+	stmt.Meta.Trailing = p.Trailing()
 
 	return stmt, nil
 }
 
-func (p *Parser) parseGotoDestination() (*ast.GotoDestinationStatement, error) {
+func (p *Parser) ParseGotoDestination() (*ast.GotoDestinationStatement, error) {
 	if !isGotoDestination(p.curToken.Token) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, "IDENT"))
 	}
@@ -914,32 +916,32 @@ func (p *Parser) parseGotoDestination() (*ast.GotoDestinationStatement, error) {
 	stmt := &ast.GotoDestinationStatement{
 		Meta: p.curToken,
 	}
-	stmt.Name = p.parseIdent()
-	stmt.Meta.Trailing = p.trailing()
+	stmt.Name = p.ParseIdent()
+	stmt.Meta.Trailing = p.Trailing()
 
 	return stmt, nil
 }
 
-func (p *Parser) parseFunctionCall() (*ast.FunctionCallStatement, error) {
+func (p *Parser) ParseFunctionCall() (*ast.FunctionCallStatement, error) {
 	stmt := &ast.FunctionCallStatement{
 		Meta:     p.curToken,
-		Function: p.parseIdent(),
+		Function: p.ParseIdent(),
 	}
 
-	p.nextToken() // point to LEFT_PAREN
-	args, err := p.parseFunctionArgumentExpressions()
+	p.NextToken() // point to LEFT_PAREN
+	args, err := p.ParseFunctionArgumentExpressions()
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 	stmt.Arguments = args
 
-	if !p.peekTokenIs(token.SEMICOLON) {
+	if !p.PeekTokenIs(token.SEMICOLON) {
 		return nil, errors.WithStack(MissingSemicolon(p.curToken))
 	}
 
-	p.nextToken() // point to SEMICOLON
-	swapLeadingInfix(p.curToken, stmt.Meta)
-	stmt.Meta.Trailing = p.trailing()
+	p.NextToken() // point to SEMICOLON
+	SwapLeadingInfix(p.curToken, stmt.Meta)
+	stmt.Meta.Trailing = p.Trailing()
 
 	return stmt, nil
 }

--- a/parser/vcl_type_parser.go
+++ b/parser/vcl_type_parser.go
@@ -9,26 +9,26 @@ import (
 	"github.com/ysugimoto/falco/token"
 )
 
-func (p *Parser) parseIdent() *ast.Ident {
+func (p *Parser) ParseIdent() *ast.Ident {
 	return &ast.Ident{
 		Meta:  p.curToken,
 		Value: p.curToken.Token.Literal,
 	}
 }
 
-func (p *Parser) parseIP() *ast.IP {
+func (p *Parser) ParseIP() *ast.IP {
 	return &ast.IP{
 		Meta:  p.curToken,
 		Value: p.curToken.Token.Literal,
 	}
 }
 
-func (p *Parser) parseString() (*ast.String, error) {
+func (p *Parser) ParseString() (*ast.String, error) {
 	var err error
-	parsed := p.curToken.Token.Literal
+	Parsed := p.curToken.Token.Literal
 	// Escapes are only expanded in double-quoted strings.
 	if p.curToken.Token.Offset == 2 {
-		parsed, err = decodeStringEscapes(parsed)
+		Parsed, err = decodeStringEscapes(Parsed)
 		if err != nil {
 			return nil, errors.WithStack(InvalidEscape(p.curToken, err.Error()))
 		}
@@ -36,11 +36,11 @@ func (p *Parser) parseString() (*ast.String, error) {
 
 	return &ast.String{
 		Meta:  p.curToken,
-		Value: parsed,
+		Value: Parsed,
 	}, nil
 }
 
-func (p *Parser) parseInteger() (*ast.Integer, error) {
+func (p *Parser) ParseInteger() (*ast.Integer, error) {
 	v, err := strconv.ParseInt(p.curToken.Token.Literal, 10, 64)
 	if err != nil {
 		return nil, errors.WithStack(TypeConversionError(p.curToken, "INTEGER"))
@@ -52,7 +52,7 @@ func (p *Parser) parseInteger() (*ast.Integer, error) {
 	}, nil
 }
 
-func (p *Parser) parseFloat() (*ast.Float, error) {
+func (p *Parser) ParseFloat() (*ast.Float, error) {
 	v, err := strconv.ParseFloat(p.curToken.Token.Literal, 64)
 	if err != nil {
 		return nil, errors.WithStack(TypeConversionError(p.curToken, "FLOAT"))
@@ -65,14 +65,14 @@ func (p *Parser) parseFloat() (*ast.Float, error) {
 }
 
 // nolint: unparam
-func (p *Parser) parseBoolean() *ast.Boolean {
+func (p *Parser) ParseBoolean() *ast.Boolean {
 	return &ast.Boolean{
 		Meta:  p.curToken,
 		Value: p.curToken.Token.Type == token.TRUE,
 	}
 }
 
-func (p *Parser) parseRTime() (*ast.RTime, error) {
+func (p *Parser) ParseRTime() (*ast.RTime, error) {
 	var value string
 
 	literal := p.curToken.Token.Literal

--- a/token/token.go
+++ b/token/token.go
@@ -125,6 +125,11 @@ const (
 	DEFAULT          = "DEFAULT"          // default
 	BREAK            = "BREAK"            // break
 	FALLTHROUGH      = "FALLTHROUGH"      // fallthrough
+
+	// Custom Keywords
+	// This keyword is special usecase for extensible language definition.
+	// Token is processed via custom lexer/parser definition by literal
+	CUSTOM = "CUSTOM"
 )
 
 var keywords = map[string]TokenType{


### PR DESCRIPTION
This PR implements a mechanism of custom token lexer and parser.
It means we can expand VCL language spec (custom declaration, statement, etc)

Of course, this feature should not be enabled as default, so as not to be misunderstood by a VCL user.
For example, I implemented `describe` and `before_each` custom syntax for custom parsing test.

And, to use some parser methods from other packages inside, all parser methods like parseXXX are made publicly.