### PR TITLE
add linter rule of goto

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -128,6 +128,7 @@ type Context struct {
 	Penaltyboxes      map[string]*types.Penaltybox
 	Ratecounters      map[string]*types.Ratecounter
 	Gotos             map[string]*types.Goto
+	GotoDestinations  map[string]struct{}
 	Identifiers       map[string]struct{}
 	RegexVariables    map[string]int
 	ReturnType        *types.Type
@@ -136,20 +137,21 @@ type Context struct {
 
 func New(opts ...Option) *Context {
 	c := &Context{
-		curMode:        RECV,
-		curName:        "vcl_recv",
-		Acls:           make(map[string]*types.Acl),
-		Backends:       make(map[string]*types.Backend),
-		Tables:         make(map[string]*types.Table),
-		Directors:      make(map[string]*types.Director),
-		Subroutines:    make(map[string]*types.Subroutine),
-		Penaltyboxes:   make(map[string]*types.Penaltybox),
-		Ratecounters:   make(map[string]*types.Ratecounter),
-		Gotos:          make(map[string]*types.Goto),
-		Identifiers:    builtinIdentifiers(),
-		functions:      builtinFunctions(),
-		Variables:      predefinedVariables(),
-		RegexVariables: newRegexMatchedValues(),
+		curMode:          RECV,
+		curName:          "vcl_recv",
+		Acls:             make(map[string]*types.Acl),
+		Backends:         make(map[string]*types.Backend),
+		Tables:           make(map[string]*types.Table),
+		Directors:        make(map[string]*types.Director),
+		Subroutines:      make(map[string]*types.Subroutine),
+		Penaltyboxes:     make(map[string]*types.Penaltybox),
+		Ratecounters:     make(map[string]*types.Ratecounter),
+		Gotos:            make(map[string]*types.Goto),
+		GotoDestinations: make(map[string]struct{}),
+		Identifiers:      builtinIdentifiers(),
+		functions:        builtinFunctions(),
+		Variables:        predefinedVariables(),
+		RegexVariables:   newRegexMatchedValues(),
 	}
 
 	for i := range opts {

--- a/linter/declaration_linter.go
+++ b/linter/declaration_linter.go
@@ -335,6 +335,11 @@ func (l *Linter) lintSubRoutineDeclaration(decl *ast.SubroutineDeclaration, ctx 
 		ctx.CurrentSubroutine = nil
 	}()
 
+	// And reset goto destination statements because goto is not allowed across subroutine
+	defer func() {
+		ctx.GotoDestinations = make(map[string]struct{})
+	}()
+
 	l.lint(decl.Block, cc)
 
 	// We are done linting inside the previous scope so

--- a/linter/errors.go
+++ b/linter/errors.go
@@ -349,6 +349,17 @@ func ProtectedHTTPHeader(m *ast.Meta, name string) *LintError {
 	}
 }
 
+func ForbiddenBackwardJump(gs *ast.GotoStatement) *LintError {
+	return &LintError{
+		Severity: ERROR,
+		Token:    gs.Meta.Token,
+		Message: fmt.Sprintf(
+			`A jump backwards is not allowed. Goto destination "%s" must be defined after this statement`,
+			gs.Destination.Value,
+		),
+	}
+}
+
 type FatalError struct {
 	Lexer *lexer.Lexer
 	Error error

--- a/linter/rules.go
+++ b/linter/rules.go
@@ -68,6 +68,7 @@ const (
 	UNUSED_VARIABLE                      = "unused/variable"
 	UNUSED_GOTO                          = "unused/goto"
 	DISALLOW_EMPTY_RETURN                = "disallow-empty-return"
+	FORBIDDEN_BACKWARD_JUMP              = "goto/forbidden-backward-jump"
 )
 
 var references = map[Rule]string{
@@ -104,4 +105,5 @@ var references = map[Rule]string{
 	SYNTHETIC_BASE64_STATEMENT_SCOPE: "https://developer.fastly.com/reference/vcl/statements/synthetic-base64/",
 	DISALLOW_EMPTY_RETURN:            "https://developer.fastly.com/reference/vcl/subroutines#returning-a-state",
 	UNRECOGNIZE_CALL_SCOPE:           "https://github.com/ysugimoto/falco/blob/main/docs/linter.md#user-defined-subroutine",
+	FORBIDDEN_BACKWARD_JUMP:          "https://fiddle.fastly.dev/fiddle/4814c144",
 }

--- a/linter/statement_linter_test.go
+++ b/linter/statement_linter_test.go
@@ -676,3 +676,16 @@ sub vcl_recv {
 		assertNoError(t, input)
 	})
 }
+
+func TestGotoBackwardJump(t *testing.T) {
+	t.Run("backward jmp is forbidden", func(t *testing.T) {
+		input := `
+	sub foo {
+		BACKWARD:
+		set req.http.Foo = "bar";
+		goto BACKWARD;
+	}
+	`
+		assertError(t, input)
+	})
+}


### PR DESCRIPTION
I found a VCL spec of restriction that the destination of the goto statement must be defined after its statement.

Fiddle: https://fiddle.fastly.dev/fiddle/4814c144