### PR TITLE
Feature/testing syntax

### DIFF
--- a/cmd/falco/main.go
+++ b/cmd/falco/main.go
@@ -318,7 +318,7 @@ func runTest(runner *Runner, rslv resolver.Resolver) error {
 		return nil
 	}
 
-	// shrthand indent making
+	// shorthand indent making
 	indent := func(level int) string {
 		return strings.Repeat(" ", level*2)
 	}
@@ -356,7 +356,11 @@ func runTest(runner *Runner, rslv resolver.Resolver) error {
 		for _, c := range r.Cases {
 			totalCount++
 			if c.Error != nil {
-				writeln(redBold, "%s●  [%s] %s\n", indent(1), c.Scope, c.Name)
+				var prefix string
+				if c.Group != "" {
+					prefix = c.Group + " › "
+				}
+				writeln(redBold, "%s●  [%s] %s%s\n", indent(1), prefix, c.Scope, c.Name)
 				writeln(red, "%s%s", indent(2), c.Error.Error())
 				switch e := c.Error.(type) {
 				case *ife.AssertionError:
@@ -376,24 +380,23 @@ func runTest(runner *Runner, rslv resolver.Resolver) error {
 		}
 	}
 
+	passedColor := white
 	if passedCount > 0 {
-		write(green, "%d passed, ", passedCount)
-	} else {
-		write(white, "%d passed, ", passedCount)
+		passedColor = green
 	}
+	failedColor := white
 	if failedCount > 0 {
-		write(red, "%d failed, ", failedCount)
-	} else {
-		write(white, "%d failed, ", failedCount)
+		failedColor = red
 	}
+	write(passedColor, "%d passed, ", passedCount)
+	write(failedColor, "%d failed, ", failedCount)
 	write(white, "%d total, ", totalCount)
 	writeln(white, "%d assertions", factory.Statistics.Asserts)
 
 	if factory.Statistics.Fails > 0 {
 		return ErrExit
-	} else {
-		return nil
 	}
+	return nil
 }
 
 func runFormat(runner *Runner, rslv resolver.Resolver) error {

--- a/cmd/falco/runner_test.go
+++ b/cmd/falco/runner_test.go
@@ -357,6 +357,12 @@ func TestTester(t *testing.T) {
 			filter: "*assertion.test.vcl",
 			passes: 5,
 		},
+		{
+			name:   "grouping test",
+			main:   "../../examples/testing/group.vcl",
+			filter: "*group.test.vcl",
+			passes: 3,
+		},
 	}
 
 	for _, tt := range tests {

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -108,8 +108,8 @@ You can see many interesting syntaxes, The test case is controlled with annotati
 
 ## Grouped Testing
 
-falco supports special syntax of `describe`, `before_xxx`, and `after_xxx` - jest-like syntax  only for the testing.
-Here is the full example of grouped testing:
+falco supports special syntax of `describe`, `before_[scope]`, and `after_[scope]` - jest like syntax - only for the testing.
+Here is the example of grouped testing:
 
 ```vcl
 // Grouping test

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -106,6 +106,36 @@ sub test_vcl_deliver {
 
 You can see many interesting syntaxes, The test case is controlled with annotation and assertion functions.
 
+## Grouped Testing
+
+falco supports special syntax of `describe`, `before_xxx`, and `after_xxx` - jest-like syntax  only for the testing.
+Here is the full example of grouped testing:
+
+```vcl
+// Grouping test
+describe grouped_tests {
+
+    // run before recv scoped subroutine
+    before_recv {
+        // you can use variables that is enable to access in RECV scope
+        set req.http.BeforeRecv = "1";
+    }
+
+    sub test_recv {
+        // ensure http header which is injected via hook
+        assert.equal(req.http.BeforeRecv, "1");
+        // Do unit testing for RECV scope
+    }
+
+    ...
+}
+```
+
+> [!NOTE]
+> Testing subroutines are stateful through the grouped testing.
+> A interpreter only be initialized for the group, the same interpreter will be used for each testing subroutine.
+> It is useful for testing across scopes but this behavior may be different from the jest one.
+
 ### Scope Recognition
 
 falco recognizes `@scope` annotation for execution scope.

--- a/examples/testing/group.test.vcl
+++ b/examples/testing/group.test.vcl
@@ -1,0 +1,22 @@
+describe group {
+
+  before_recv {
+    set req.http.Before = "1";
+  }
+
+  before_fetch {
+    set req.http.Before = "2";
+  }
+
+  // @scope: recv
+  sub test_recv {
+    assert.equal(req.http.Before, "1");
+    testing.call_subroutine("vcl_recv");
+    assert.equal(req.http.Grouped, "1");
+  }
+
+  // @scope: fetch
+  sub test_fetch {
+    assert.equal(req.http.Before, "2");
+  }
+}

--- a/examples/testing/group.vcl
+++ b/examples/testing/group.vcl
@@ -1,0 +1,4 @@
+sub vcl_recv {
+  #FASTLY RECV
+  set req.http.Grouped = "1";
+}

--- a/interpreter/subroutine.go
+++ b/interpreter/subroutine.go
@@ -12,14 +12,6 @@ import (
 	"github.com/ysugimoto/falco/interpreter/variable"
 )
 
-func (i *Interpreter) ProcessTestSubroutine(scope context.Scope, sub *ast.SubroutineDeclaration) error {
-	i.SetScope(scope)
-	if _, err := i.ProcessSubroutine(sub, DebugPass); err != nil {
-		return errors.WithStack(err)
-	}
-	return nil
-}
-
 func (i *Interpreter) ProcessSubroutine(sub *ast.SubroutineDeclaration, ds DebugState) (State, error) {
 	i.process.Flows = append(i.process.Flows, process.NewFlow(i.ctx, sub))
 

--- a/interpreter/testing.go
+++ b/interpreter/testing.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/ysugimoto/falco/ast"
+	icontext "github.com/ysugimoto/falco/interpreter/context"
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
@@ -55,5 +56,13 @@ func (i *Interpreter) TestProcessInit(r *http.Request) error {
 	}
 	i.ctx.Response = i.cloneResponse(i.ctx.BackendResponse)
 	i.ctx.Object = i.cloneResponse(i.ctx.BackendResponse)
+	return nil
+}
+
+func (i *Interpreter) ProcessTestSubroutine(scope icontext.Scope, sub *ast.SubroutineDeclaration) error {
+	i.SetScope(scope)
+	if _, err := i.ProcessSubroutine(sub, DebugPass); err != nil {
+		return errors.WithStack(err)
+	}
 	return nil
 }

--- a/tester/entity.go
+++ b/tester/entity.go
@@ -9,6 +9,7 @@ import (
 
 type TestCase struct {
 	Name  string
+	Group string
 	Error error
 	Scope string
 	Time  int64 // msec order
@@ -18,10 +19,12 @@ func (t *TestCase) MarshalJSON() ([]byte, error) {
 	v := struct {
 		Name  string `json:"name"`
 		Error string `json:"error,omitempty"`
+		Group string `json:"group,omitempty"`
 		Scope string `json:"scope"`
 		Time  int64  `json:"elapsed_time"`
 	}{
 		Name:  t.Name,
+		Group: t.Group,
 		Scope: t.Scope,
 		Time:  t.Time,
 	}

--- a/tester/syntax/describe.go
+++ b/tester/syntax/describe.go
@@ -1,0 +1,128 @@
+package syntax
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/parser"
+	"github.com/ysugimoto/falco/token"
+)
+
+// Declare DescribeStatement
+type DescribeStatement struct {
+	*ast.Meta
+	Name        *ast.Ident
+	Befores     map[string]*HookStatement
+	Afters      map[string]*HookStatement
+	Subroutines []*ast.SubroutineDeclaration
+}
+
+func (d *DescribeStatement) Statement() {}
+func (d *DescribeStatement) Literal() string {
+	return "describe"
+}
+func (d *DescribeStatement) GetMeta() *ast.Meta {
+	return d.Meta
+}
+func (d *DescribeStatement) String() string {
+	var buf bytes.Buffer
+
+	buf.WriteString(d.LeadingComment("\n"))
+	buf.WriteString("describe ")
+	buf.WriteString(d.Name.String())
+	buf.WriteString(" {\n")
+	for i := range d.Befores {
+		buf.WriteString(d.Befores[i].String())
+		buf.WriteString("\n")
+	}
+	for i := range d.Afters {
+		buf.WriteString(d.Afters[i].String())
+		buf.WriteString("\n")
+	}
+
+	for _, sub := range d.Subroutines {
+		buf.WriteString(sub.String())
+	}
+	buf.WriteString(d.InfixComment("\n"))
+	buf.WriteString("}")
+	buf.WriteString(d.TrailingComment(" "))
+
+	return buf.String()
+}
+
+// Custome parser implementation for "describe" keyword
+type DescribeParser struct{}
+
+func (d *DescribeParser) Literal() string {
+	return "describe"
+}
+func (d *DescribeParser) Parse(p *parser.Parser) (ast.CustomStatement, error) {
+	stmt := &DescribeStatement{
+		Meta:    p.CurToken(),
+		Befores: make(map[string]*HookStatement),
+		Afters:  make(map[string]*HookStatement),
+	}
+	if !p.ExpectPeek(token.IDENT) {
+		return nil, parser.UnexpectedToken(p.PeekToken(), token.IDENT)
+	}
+	stmt.Name = p.ParseIdent()
+	if !p.ExpectPeek(token.LEFT_BRACE) {
+		return nil, parser.UnexpectedToken(p.PeekToken(), token.LEFT_BRACE)
+	}
+	parser.SwapLeadingTrailing(p.CurToken(), stmt.Name.Meta)
+	p.NextToken()
+
+	for !p.CurTokenIs(token.RIGHT_BRACE) {
+		tok := p.CurToken()
+		switch tok.Token.Type {
+		case token.SUBROUTINE:
+			sub, err := p.ParseSubroutineDeclaration()
+			if err != nil {
+				return nil, errors.WithStack(err)
+			}
+			stmt.Subroutines = append(stmt.Subroutines, sub)
+			p.NextToken()
+		case token.CUSTOM:
+			cs, err := p.ParseCustomToken()
+			if err != nil {
+				return nil, errors.WithStack(err)
+			}
+			if t, ok := cs.(*HookStatement); ok {
+				switch {
+				case strings.HasPrefix(t.keyword, "before"):
+					if _, ok := stmt.Befores[t.keyword]; ok {
+						return nil, &parser.ParseError{
+							Token:   t.GetMeta().Token,
+							Message: fmt.Sprintf("%s hook is duplicated", cs.Literal()),
+						}
+					}
+					stmt.Befores[t.keyword] = t
+				case strings.HasPrefix(t.keyword, "after"):
+					if _, ok := stmt.Afters[t.keyword]; ok {
+						return nil, &parser.ParseError{
+							Token:   t.GetMeta().Token,
+							Message: fmt.Sprintf("%s hook is duplicated", cs.Literal()),
+						}
+					}
+					stmt.Afters[t.keyword] = t
+				}
+				p.NextToken()
+				continue
+			}
+			return nil, &parser.ParseError{
+				Token:   p.CurToken().Token,
+				Message: fmt.Sprintf("%s statement could not be placed inside describe", cs.Literal()),
+			}
+		default:
+			return nil, parser.UnexpectedToken(p.CurToken())
+		}
+	}
+
+	parser.SwapLeadingInfix(p.CurToken(), stmt.Meta)
+	stmt.Meta.Trailing = p.Trailing()
+
+	return stmt, nil
+}

--- a/tester/syntax/describe_test.go
+++ b/tester/syntax/describe_test.go
@@ -1,0 +1,230 @@
+package syntax
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/lexer"
+	"github.com/ysugimoto/falco/parser"
+	"github.com/ysugimoto/falco/token"
+)
+
+func meta(nest, prevLine int, leading, infix, trailing string) *ast.Meta {
+	m := &ast.Meta{
+		Token:              token.Token{},
+		Nest:               nest,
+		PreviousEmptyLines: prevLine,
+		Leading:            ast.Comments{},
+		Infix:              ast.Comments{},
+		Trailing:           ast.Comments{},
+	}
+	if leading != "" {
+		m.Leading = ast.Comments{&ast.Comment{Value: leading}}
+	}
+	if infix != "" {
+		m.Infix = ast.Comments{&ast.Comment{Value: infix}}
+	}
+	if trailing != "" {
+		m.Trailing = ast.Comments{&ast.Comment{Value: trailing}}
+	}
+
+	return m
+}
+
+func TestDescribeFullSyntax(t *testing.T) {
+	input := `// Leading comment
+describe foo {
+	// before leading
+	before_recv /* before infix */ {
+		set req.http.TestingState = "before_recv";
+	} // before trailing
+
+	// before leading
+	before_fetch /* before infix */ {
+		set req.http.TestingState = "before_fetch";
+	} // before trailing
+
+	// after leading
+	after_recv /* after infix */ {
+		set req.http.TestingState = "after_recv";
+	} // after trailing
+
+	// after leading
+	after_fetch /* after infix */ {
+		set req.http.TestingState = "after_fetch";
+	} // after trailing
+
+	sub test_foo_recv {
+		set req.http.Bar = "baz";
+	}
+} // Trailing comment
+
+sub test_recv {}
+`
+
+	expect := &ast.VCL{
+		Statements: []ast.Statement{
+			&DescribeStatement{
+				Meta: meta(0, 0, "// Leading comment", "", "// Trailing comment"),
+				Name: &ast.Ident{
+					Meta:  meta(0, 0, "", "", ""),
+					Value: "foo",
+				},
+				Befores: map[string]*HookStatement{
+					"before_recv": {
+						Meta: meta(1, 0, "// before leading", "/* before infix */", ""),
+						Block: &ast.BlockStatement{
+							Meta: meta(2, 0, "", "", "// before trailing"),
+							Statements: []ast.Statement{
+								&ast.SetStatement{
+									Meta: meta(2, 0, "", "", ""),
+									Ident: &ast.Ident{
+										Meta:  meta(2, 0, "", "", ""),
+										Value: "req.http.TestingState",
+									},
+									Operator: &ast.Operator{
+										Meta:     meta(2, 0, "", "", ""),
+										Operator: "=",
+									},
+									Value: &ast.String{
+										Meta:  meta(2, 0, "", "", ""),
+										Value: "before_recv",
+									},
+								},
+							},
+						},
+					},
+					"before_fetch": {
+						Meta: meta(1, 0, "// before leading", "/* before infix */", ""),
+						Block: &ast.BlockStatement{
+							Meta: meta(2, 0, "", "", "// before trailing"),
+							Statements: []ast.Statement{
+								&ast.SetStatement{
+									Meta: meta(2, 0, "", "", ""),
+									Ident: &ast.Ident{
+										Meta:  meta(2, 0, "", "", ""),
+										Value: "req.http.TestingState",
+									},
+									Operator: &ast.Operator{
+										Meta:     meta(2, 0, "", "", ""),
+										Operator: "=",
+									},
+									Value: &ast.String{
+										Meta:  meta(2, 0, "", "", ""),
+										Value: "before_fetch",
+									},
+								},
+							},
+						},
+					},
+				},
+				Afters: map[string]*HookStatement{
+					"after_recv": {
+						Meta: meta(1, 0, "// after leading", "/* after infix */", ""),
+						Block: &ast.BlockStatement{
+							Meta: meta(2, 0, "", "", "// after trailing"),
+							Statements: []ast.Statement{
+								&ast.SetStatement{
+									Meta: meta(2, 0, "", "", ""),
+									Ident: &ast.Ident{
+										Meta:  meta(2, 0, "", "", ""),
+										Value: "req.http.TestingState",
+									},
+									Operator: &ast.Operator{
+										Meta:     meta(2, 0, "", "", ""),
+										Operator: "=",
+									},
+									Value: &ast.String{
+										Meta:  meta(2, 0, "", "", ""),
+										Value: "after_recv",
+									},
+								},
+							},
+						},
+					},
+					"after_fetch": {
+						Meta: meta(1, 0, "// after leading", "/* after infix */", ""),
+						Block: &ast.BlockStatement{
+							Meta: meta(2, 0, "", "", "// after trailing"),
+							Statements: []ast.Statement{
+								&ast.SetStatement{
+									Meta: meta(2, 0, "", "", ""),
+									Ident: &ast.Ident{
+										Meta:  meta(2, 0, "", "", ""),
+										Value: "req.http.TestingState",
+									},
+									Operator: &ast.Operator{
+										Meta:     meta(2, 0, "", "", ""),
+										Operator: "=",
+									},
+									Value: &ast.String{
+										Meta:  meta(2, 0, "", "", ""),
+										Value: "after_fetch",
+									},
+								},
+							},
+						},
+					},
+				},
+				Subroutines: []*ast.SubroutineDeclaration{
+					{
+						Meta: meta(1, 1, "", "", ""),
+						Name: &ast.Ident{
+							Meta:  meta(1, 0, "", "", ""),
+							Value: "test_foo_recv",
+						},
+						Block: &ast.BlockStatement{
+							Meta: meta(2, 0, "", "", ""),
+							Statements: []ast.Statement{
+								&ast.SetStatement{
+									Meta: meta(2, 0, "", "", ""),
+									Ident: &ast.Ident{
+										Meta:  meta(2, 0, "", "", ""),
+										Value: "req.http.Bar",
+									},
+									Operator: &ast.Operator{
+										Meta:     meta(2, 0, "", "", ""),
+										Operator: "=",
+									},
+									Value: &ast.String{
+										Meta:  meta(2, 0, "", "", ""),
+										Value: "baz",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			&ast.SubroutineDeclaration{
+				Meta: meta(0, 1, "", "", ""),
+				Name: &ast.Ident{
+					Meta:  meta(0, 0, "", "", ""),
+					Value: "test_recv",
+				},
+				Block: &ast.BlockStatement{
+					Meta:       meta(1, 0, "", "", ""),
+					Statements: []ast.Statement{},
+				},
+			},
+		},
+	}
+
+	vcl, err := parser.New(lexer.NewFromString(input), parser.WithCustomParser(CustomParsers()...)).ParseVCL()
+	if err != nil {
+		t.Errorf("%+v", err)
+	}
+
+	if diff := cmp.Diff(vcl, expect,
+		cmpopts.IgnoreFields(ast.Meta{}, "Token"),
+		cmpopts.IgnoreFields(ast.Comment{}, "Token", "PrefixedLineFeed", "PreviousEmptyLines"),
+		cmpopts.IgnoreFields(ast.Ident{}),
+		cmpopts.IgnoreFields(ast.String{}),
+		cmpopts.IgnoreFields(ast.Operator{}),
+		cmpopts.IgnoreUnexported(HookStatement{}),
+	); diff != "" {
+		t.Errorf("Assertion error: diff=%s", diff)
+	}
+}

--- a/tester/syntax/hooks.go
+++ b/tester/syntax/hooks.go
@@ -1,0 +1,62 @@
+package syntax
+
+import (
+	"bytes"
+
+	"github.com/pkg/errors"
+	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/parser"
+	"github.com/ysugimoto/falco/token"
+)
+
+type HookStatement struct {
+	*ast.Meta
+	Block   *ast.BlockStatement
+	keyword string
+}
+
+func (s *HookStatement) Statement() {}
+func (s *HookStatement) Literal() string {
+	return s.keyword
+}
+func (s *HookStatement) GetMeta() *ast.Meta {
+	return s.Meta
+}
+
+func (s *HookStatement) String() string {
+	var buf bytes.Buffer
+
+	buf.WriteString(s.LeadingComment("\n"))
+	buf.WriteString(s.keyword + " ")
+	if v := s.InfixComment(" "); v != "" {
+		buf.WriteString(v + " ")
+	}
+	buf.WriteString(s.Block.String())
+	buf.WriteString(s.TrailingComment(" "))
+
+	return buf.String()
+}
+
+type HookParser struct {
+	keyword string
+}
+
+func (h *HookParser) Literal() string {
+	return h.keyword
+}
+func (h *HookParser) Parse(p *parser.Parser) (ast.CustomStatement, error) {
+	stmt := &HookStatement{
+		Meta:    p.CurToken(),
+		keyword: h.keyword,
+	}
+	if !p.ExpectPeek(token.LEFT_BRACE) {
+		return nil, parser.UnexpectedToken(p.PeekToken(), token.LEFT_BRACE)
+	}
+	parser.SwapLeadingInfix(p.CurToken(), stmt.Meta)
+	var err error
+	if stmt.Block, err = p.ParseBlockStatement(); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return stmt, nil
+}

--- a/tester/syntax/parsers.go
+++ b/tester/syntax/parsers.go
@@ -1,0 +1,32 @@
+package syntax
+
+import "github.com/ysugimoto/falco/parser"
+
+func CustomParsers() []parser.CustomParser {
+	return []parser.CustomParser{
+		// describe keyword
+		&DescribeParser{},
+
+		// before hooks
+		&HookParser{keyword: "before_recv"},
+		&HookParser{keyword: "before_hash"},
+		&HookParser{keyword: "before_hit"},
+		&HookParser{keyword: "before_miss"},
+		&HookParser{keyword: "before_pass"},
+		&HookParser{keyword: "before_fetch"},
+		&HookParser{keyword: "before_error"},
+		&HookParser{keyword: "before_deliver"},
+		&HookParser{keyword: "before_log"},
+
+		// after hooks
+		&HookParser{keyword: "after_recv"},
+		&HookParser{keyword: "after_hash"},
+		&HookParser{keyword: "after_hit"},
+		&HookParser{keyword: "after_miss"},
+		&HookParser{keyword: "after_pass"},
+		&HookParser{keyword: "after_fetch"},
+		&HookParser{keyword: "after_error"},
+		&HookParser{keyword: "after_deliver"},
+		&HookParser{keyword: "after_log"},
+	}
+}

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -1,7 +1,6 @@
 package tester
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -21,6 +20,7 @@ import (
 	"github.com/ysugimoto/falco/parser"
 	"github.com/ysugimoto/falco/resolver"
 	tf "github.com/ysugimoto/falco/tester/function"
+	"github.com/ysugimoto/falco/tester/syntax"
 	tv "github.com/ysugimoto/falco/tester/variable"
 )
 
@@ -103,14 +103,10 @@ func (t *Tester) run(testFile string) (*TestResult, error) {
 	}
 
 	l := lexer.NewFromString(main.Data, lexer.WithFile(main.Name))
-	vcl, err := parser.New(l).ParseVCL()
+	vcl, err := parser.New(l, parser.WithCustomParser(syntax.CustomParsers()...)).ParseVCL()
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-
-	// On testing, incoming HTTP request always mocked
-	mockRequest := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
-	ctx := context.Background()
 
 	errChan := make(chan error)
 	finishChan := make(chan []*TestCase)
@@ -126,35 +122,43 @@ func (t *Tester) run(testFile string) (*TestResult, error) {
 		defs := t.factoryDefinitions(vcl)
 		var cases []*TestCase
 		for _, stmt := range vcl.Statements {
-			// We treat subroutine as testing
-			sub, ok := stmt.(*ast.SubroutineDeclaration)
-			if !ok {
-				continue
-			}
-
-			// Some functions like "testing.table_set()" will take side-effect for another testing subroutine
-			// so we always initialize interpreter, inject testing functions for each subroutine
-			i := t.setupInterpreter(defs)
-
-			if err := i.TestProcessInit(mockRequest.Clone(ctx)); err != nil {
-				errChan <- errors.WithStack(err)
-				return
-			}
-			suite, scopes := t.findTestSuites(sub)
-			for _, s := range scopes {
-				start := time.Now()
-				err := i.ProcessTestSubroutine(s, sub)
-				cases = append(cases, &TestCase{
-					Name:  suite,
-					Error: errors.Cause(err),
-					Scope: s.String(),
-					Time:  time.Since(start).Milliseconds(),
-				})
+			switch st := stmt.(type) {
+			case *syntax.DescribeStatement:
+				results, err := t.runDescribedTests(defs, st)
+				if len(results) > 0 {
+					cases = append(cases, results...)
+				}
 				if err != nil {
-					t.counter.Fail()
+					errChan <- errors.WithStack(err)
+					return
+				}
+			case *ast.SubroutineDeclaration:
+				// Some functions like "testing.table_set()" will take side-effect for another testing subroutine
+				// so we always initialize interpreter, inject testing functions for each subroutine
+				i := t.setupInterpreter(defs)
+
+				mockRequest := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+				if err := i.TestProcessInit(mockRequest); err != nil {
+					errChan <- errors.WithStack(err)
+					return
+				}
+				suite, scopes := t.findTestSuites(st)
+				for _, s := range scopes {
+					start := time.Now()
+					err := i.ProcessTestSubroutine(s, st)
+					cases = append(cases, &TestCase{
+						Name:  suite,
+						Error: errors.Cause(err),
+						Scope: s.String(),
+						Time:  time.Since(start).Milliseconds(),
+					})
+					if err != nil {
+						t.counter.Fail()
+					}
 				}
 			}
 		}
+
 		finishChan <- cases
 	}(vcl)
 
@@ -171,6 +175,65 @@ func (t *Tester) run(testFile string) (*TestResult, error) {
 			Lexer:    l,
 		}, nil
 	}
+}
+
+func (t *Tester) runDescribedTests(
+	defs *tf.Definiions,
+	d *syntax.DescribeStatement,
+) ([]*TestCase, error) {
+
+	var cases []*TestCase
+	mockRequest := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+
+	// describe should run as group testing, create interpreter once through tests
+	i := t.setupInterpreter(defs)
+
+	if err := i.TestProcessInit(mockRequest); err != nil {
+		return cases, err
+	}
+
+	for _, sub := range d.Subroutines {
+		suite, scopes := t.findTestSuites(sub)
+		for _, s := range scopes {
+			// Run before_xxx hook that corresponds to scope is exists
+			if hook, ok := d.Befores[strings.ToLower("before_"+s.String())]; ok {
+				i.SetScope(s)
+				if _, _, _, err := i.ProcessBlockStatement(
+					hook.Block.Statements,
+					interpreter.DebugPass,
+					false,
+				); err != nil {
+					return cases, err
+				}
+			}
+
+			start := time.Now()
+			err := i.ProcessTestSubroutine(s, sub)
+			cases = append(cases, &TestCase{
+				Name:  suite,
+				Error: errors.Cause(err),
+				Scope: s.String(),
+				Time:  time.Since(start).Milliseconds(),
+			})
+			if err != nil {
+				t.counter.Fail()
+			}
+
+			// Run after_xxx hook that corresponds to scope is exists
+			if hook, ok := d.Afters[strings.ToLower("after_"+s.String())]; ok {
+				i.SetScope(s)
+				if _, _, _, err := i.ProcessBlockStatement(
+					hook.Block.Statements,
+					interpreter.DebugPass,
+					false,
+				); err != nil {
+					return cases, err
+				}
+			}
+		}
+	}
+
+	return cases, nil
 }
 
 // Find test suite name and may multile scopes


### PR DESCRIPTION
Fixes: #301 

This PR implements special syntaxes for testing the same as Jest:

- `describe`
- `before_[scope]`
- `after_[scope]`

The above syntax aims to group tests through the request session for each subroutine like `vcl_recv`, `vcl_fetch`, etc.

Note that these syntaxes are enabled only for testing, not for typical VCL parsing.