### PR TITLE
Feature/https server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ request.json
 
 .falco.yml
 .falco.yaml
+*.pem

--- a/cmd/falco/help.go
+++ b/cmd/falco/help.go
@@ -107,6 +107,8 @@ Flags:
     -debug             : Enable debug mode
     --max_backends     : Override max backends limitation
     --max_acls         : Override max acls limitation
+    --key              : Specify TLS server key file
+    --cert             : Specify TLS cert file
 
 Local simulator example:
     falco simulate -I . /path/to/vcl/main.vcl

--- a/cmd/falco/runner.go
+++ b/cmd/falco/runner.go
@@ -444,23 +444,20 @@ func (r *Runner) Simulate(rslv resolver.Resolver) error {
 
 	i := interpreter.New(options...)
 
-	// Both key and cert file are provided, server should listen TLK
-	isTLS := sc.KeyFile != "" && sc.CertFile != ""
-
-	// If debugger flag is on, run debugger mode
 	if sc.IsDebug {
-		return debugger.New(interpreter.New(options...)).Run(sc.Port, isTLS)
+		// If debugger flag is on, run debugger mode
+		return debugger.New(i).Run(sc)
 	}
 
 	// Otherwise, simply start simulator server
 	mux := http.NewServeMux()
 	mux.Handle("/", i)
-
 	s := &http.Server{
 		Handler: mux,
 		Addr:    fmt.Sprintf(":%d", sc.Port),
 	}
-	if isTLS {
+
+	if sc.KeyFile != "" && sc.CertFile != "" {
 		writeln(green, "Simulator server starts on 0.0.0.0:%d with TLS", sc.Port)
 		return s.ListenAndServeTLS(sc.CertFile, sc.KeyFile)
 	}

--- a/cmd/falco/runner.go
+++ b/cmd/falco/runner.go
@@ -457,12 +457,18 @@ func (r *Runner) Simulate(rslv resolver.Resolver) error {
 		Addr:    fmt.Sprintf(":%d", sc.Port),
 	}
 
+	var err error
 	if sc.KeyFile != "" && sc.CertFile != "" {
 		writeln(green, "Simulator server starts on 0.0.0.0:%d with TLS", sc.Port)
-		return s.ListenAndServeTLS(sc.CertFile, sc.KeyFile)
+		err = s.ListenAndServeTLS(sc.CertFile, sc.KeyFile)
+	} else {
+		writeln(green, "Simulator server starts on 0.0.0.0:%d", sc.Port)
+		err = s.ListenAndServe()
 	}
-	writeln(green, "Simulator server starts on 0.0.0.0:%d", sc.Port)
-	return s.ListenAndServe()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
 }
 
 func (r *Runner) Test(rslv resolver.Resolver) (*tester.TestFactory, error) {

--- a/cmd/falco/runner.go
+++ b/cmd/falco/runner.go
@@ -444,9 +444,12 @@ func (r *Runner) Simulate(rslv resolver.Resolver) error {
 
 	i := interpreter.New(options...)
 
+	// Both key and cert file are provided, server should listen TLK
+	isTLS := sc.KeyFile != "" && sc.CertFile != ""
+
 	// If debugger flag is on, run debugger mode
 	if sc.IsDebug {
-		return debugger.New(interpreter.New(options...)).Run(sc.Port)
+		return debugger.New(interpreter.New(options...)).Run(sc.Port, isTLS)
 	}
 
 	// Otherwise, simply start simulator server
@@ -456,6 +459,10 @@ func (r *Runner) Simulate(rslv resolver.Resolver) error {
 	s := &http.Server{
 		Handler: mux,
 		Addr:    fmt.Sprintf(":%d", sc.Port),
+	}
+	if isTLS {
+		writeln(green, "Simulator server starts on 0.0.0.0:%d with TLS", sc.Port)
+		return s.ListenAndServeTLS(sc.CertFile, sc.KeyFile)
 	}
 	writeln(green, "Simulator server starts on 0.0.0.0:%d", sc.Port)
 	return s.ListenAndServe()

--- a/config/config.go
+++ b/config/config.go
@@ -43,6 +43,10 @@ type SimulatorConfig struct {
 	IsDebug      bool     `cli:"debug"` // Enable only in CLI option
 	IncludePaths []string // Copy from root field
 
+	// HTTPS related configuration. If both fields are spcified, simulator will serve with HTTPS
+	KeyFile  string `cli:"key" yaml:"key_file"`
+	CertFile string `cli:"cert" yaml:"cert_file"`
+
 	// Override Request configuration
 	OverrideRequest *RequestConfig
 }

--- a/debugger/console.go
+++ b/debugger/console.go
@@ -114,11 +114,17 @@ func (c *Console) keyEventHandler(evt *tcell.EventKey) *tcell.EventKey {
 	return evt
 }
 
-func (c *Console) Run(port int) error {
+func (c *Console) Run(port int, isTLS bool) error {
+	protocol := "http"
+	if isTLS {
+		protocol = "https"
+	}
+
 	c.app.SetInputCapture(c.keyEventHandler)
 	c.message.Append(
 		messageview.Debugger,
-		"Waiting Request on http://localhost:%d...",
+		"Waiting Request on %s://localhost:%d...",
+		protocol,
 		port,
 	)
 	go c.startDebugServer(port)

--- a/debugger/console.go
+++ b/debugger/console.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
+	"github.com/ysugimoto/falco/config"
 	"github.com/ysugimoto/falco/debugger/codeview"
 	"github.com/ysugimoto/falco/debugger/colors"
 	"github.com/ysugimoto/falco/debugger/helpview"
@@ -114,7 +115,21 @@ func (c *Console) keyEventHandler(evt *tcell.EventKey) *tcell.EventKey {
 	return evt
 }
 
-func (c *Console) Run(port int, isTLS bool) error {
+func (c *Console) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if c.isDebugging.Load() {
+		http.Error(w, "Other debugging process is running.", http.StatusLocked)
+		return
+	}
+
+	c.activate()
+	defer c.deactivate()
+
+	c.interpreter.ServeHTTP(w, r)
+}
+
+func (c *Console) Run(sc *config.SimulatorConfig) error {
+	isTLS := sc.KeyFile != "" && sc.CertFile != ""
+
 	protocol := "http"
 	if isTLS {
 		protocol = "https"
@@ -125,10 +140,25 @@ func (c *Console) Run(port int, isTLS bool) error {
 		messageview.Debugger,
 		"Waiting Request on %s://localhost:%d...",
 		protocol,
-		port,
+		sc.Port,
 	)
-	go c.startDebugServer(port)
+
+	go func() {
+		mux := http.NewServeMux()
+		mux.Handle("/", c)
+		s := &http.Server{
+			Handler: mux,
+			Addr:    fmt.Sprintf(":%d", sc.Port),
+		}
+
+		if isTLS {
+			s.ListenAndServeTLS(sc.CertFile, sc.KeyFile)
+		}
+		s.ListenAndServe()
+	}()
+
 	return c.app.Run()
+
 }
 
 func (c *Console) activate() {
@@ -143,25 +173,4 @@ func (c *Console) deactivate() {
 	c.shell.IsActivated = false
 	c.message.Append(messageview.Debugger, "Debugger session has finished.")
 	c.app.Draw()
-}
-
-func (c *Console) startDebugServer(port int) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		if c.isDebugging.Load() {
-			http.Error(w, "Other debugging process is running.", http.StatusLocked)
-			return
-		}
-
-		c.activate()
-		defer c.deactivate()
-
-		c.interpreter.ServeHTTP(w, r)
-	})
-
-	s := &http.Server{
-		Handler: mux,
-		Addr:    fmt.Sprintf(":%d", port),
-	}
-	s.ListenAndServe() // nolint:errcheck
 }

--- a/debugger/debugger.go
+++ b/debugger/debugger.go
@@ -15,7 +15,7 @@ import (
 )
 
 const debuggerMark = "@debugger"
-const highlightDeplay = 120
+const highlightDelay = 120
 
 type Debugger struct {
 	app     *tview.Application
@@ -55,7 +55,7 @@ func (d *Debugger) breakPoint(t token.Token) interpreter.DebugState {
 	// Wait for keyboard input
 	d.mode = <-d.input
 
-	time.AfterFunc(time.Duration(highlightDeplay)*time.Millisecond, func() {
+	time.AfterFunc(time.Duration(highlightDelay)*time.Millisecond, func() {
 		d.help.Highlight(helpview.Default)
 		d.app.Draw()
 	})

--- a/debugger/debugger.go
+++ b/debugger/debugger.go
@@ -37,7 +37,7 @@ func (d *Debugger) Run(node ast.Node) interpreter.DebugState {
 		return d.breakPoint(node.GetMeta().Token)
 	default:
 		meta := node.GetMeta()
-		if !hasDebufferMark(meta.Leading) {
+		if !hasDebuggerMark(meta.Leading) {
 			return interpreter.DebugPass
 		}
 		return d.breakPoint(meta.Token)
@@ -76,6 +76,6 @@ func (d *Debugger) breakPoint(t token.Token) interpreter.DebugState {
 	return interpreter.DebugPass
 }
 
-func hasDebufferMark(cs ast.Comments) bool {
+func hasDebuggerMark(cs ast.Comments) bool {
 	return strings.Contains(cs.String(), debuggerMark)
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,8 @@ simulator:
   port: 3124
   max_backends: 100
   max_acls: 100
+  key_file: /path/to/key_file.pem
+  cert_file: /path/to/cert_file.pem
 
 ## Testing configuration
 testing:

--- a/docs/simulator.md
+++ b/docs/simulator.md
@@ -25,6 +25,8 @@ Flags:
     -debug             : Enable debug mode
     --max_backends     : Override max backends limitation
     --max_acls         : Override max acls limitation
+    --key              : Specify TLS server key file
+    --cert             : Specify TLS cert file
 
 Local simulator example:
     falco simulate -I . /path/to/vcl/main.vcl
@@ -62,6 +64,20 @@ Particularly VCL subroutine flow is useful for debugging.
 **falco's interpreter is just a `simulator`, so we could not be depicted Fastly's actual behavior.
 There are many limitations which are described below.**
 
+## TLS server
+
+Typically Fastly runs with TLS environment so your VCL may has HTTPS-related logic.
+falco supports to run as HTTPS server with your key/cert files. We recommend to use [mkcert](https://github.com/FiloSottile/mkcert) to generate key/cert file on your local machine.
+
+```shell
+# Generate certificates for localhost
+mkcert localhost
+
+# Run as HTTP server
+falco simulate /path/to/your/default.vcl --key /path/to/localhost-key.pem --cert /path/to/localhost.pem
+```
+
+Then falco serve with https://localhost:3124.
 
 ## Debug mode
 


### PR DESCRIPTION
Fixes #317 

This PR implements the simulator to serve with TLS.

## Synopsis

Added `--key` and `--cert` arguments in `simulator` subcommand and then the user can provide both arguments to serve the simulator with TLS.

```shell
falco simulator /path/to/default.vcl --key /path/to/keyfile --cert /path/to/certfile
```

Of course, the debugger also can use HTTPS server:

```shell
falco simulator --debug /path/to/default.vcl --key /path/to/keyfile --cert /path/to/certfile
```

The server starts with `https://localhost:3124`.


<img width="1251" alt="CleanShot 2024-05-31 at 12 18 22@2x" src="https://github.com/ysugimoto/falco/assets/1000401/2eca48c3-8735-42d4-9d86-da1b333d5e2c">