### PR TITLE
Feature/inject edge dictionary

### DIFF
--- a/cmd/falco/runner.go
+++ b/cmd/falco/runner.go
@@ -441,6 +441,10 @@ func (r *Runner) Simulate(rslv resolver.Resolver) error {
 	if r.config.OverrideBackends != nil {
 		options = append(options, icontext.WithOverrideBackends(r.config.OverrideBackends))
 	}
+	// If simulator configuration has edge dictionaries, inject them
+	if sc.OverrideEdgeDictionaries != nil {
+		options = append(options, icontext.WithInjectEdgeDictionaries(sc.OverrideEdgeDictionaries))
+	}
 
 	i := interpreter.New(options...)
 

--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,8 @@ type OverrideBackend struct {
 	Unhealthy bool   `yaml:"unhealthy" default:"false"`
 }
 
+type EdgeDictionary map[string]string
+
 // Linter configuration
 type LinterConfig struct {
 	VerboseLevel            string              `yaml:"verbose"`
@@ -46,6 +48,9 @@ type SimulatorConfig struct {
 	// HTTPS related configuration. If both fields are spcified, simulator will serve with HTTPS
 	KeyFile  string `cli:"key" yaml:"key_file"`
 	CertFile string `cli:"cert" yaml:"cert_file"`
+
+	// Inject Edge Dictionary items
+	OverrideEdgeDictionaries map[string]EdgeDictionary `yaml:"edge_dictionary"`
 
 	// Override Request configuration
 	OverrideRequest *RequestConfig

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,6 +29,10 @@ simulator:
   max_acls: 100
   key_file: /path/to/key_file.pem
   cert_file: /path/to/cert_file.pem
+  edge_dictionary:
+    dict_name:
+      key1: value1
+      key2: value2
 
 ## Testing configuration
 testing:
@@ -55,6 +59,10 @@ All configurations of configuration files and CLI arguments are described follow
 | max_acls                           | Integer       | 1000    | --max_acls         | Override Fastly's acl amount limitation                                                                                               |
 | simulator                          | Object        | null    | -                  | Simulator configuration object                                                                                                        |
 | simulator.port                     | Integer       | 3124    | -p, --port         | Simulator server listen port                                                                                                          |
+| simulator.key_file                 | String        | -       | --key              | TLS server key file path                                                                                                              |
+| simulator.cert_file                | String        | -       | --cert             | TLS server cert file path                                                                                                             |
+| simulator.edge_dictionary          | Object        | null    | -                  | Local edge dictionary item definitions                                                                                                |
+| simulator.edge_dictionary.[name]   | Object        | -       | -                  | Local edge dictionary name                                                                                                            |
 | testing                            | Object        | null    | -                  | Testing configuration object                                                                                                          |
 | testing.timeout                    | Integer       | 10      | -t, --timeout      | Set timeout to stop testing                                                                                                           |
 | linter                             | Object        | null    | -                  | Override linter rules                                                                                                                 |

--- a/docs/simulator.md
+++ b/docs/simulator.md
@@ -79,6 +79,13 @@ falco simulate /path/to/your/default.vcl --key /path/to/localhost-key.pem --cert
 
 Then falco serve with https://localhost:3124.
 
+## Override Edge Dictionary Items
+
+Edge Dictionary values are managed in Fastly cloud but often we have some logics that relates to its value (e.g flag true/false), and write-only dictionary items could access via remote API.
+To simulate its behavior with specific value, falco supports overriding edge dictionary item locally from configuration.
+
+See `simulator.edge_dictionary` field in [configuration.md](./configuration.md).
+
 ## Debug mode
 
 `falco` also includes TUI debugger so that you can debug VCL with step execution.

--- a/examples/simulator/simulator.vcl
+++ b/examples/simulator/simulator.vcl
@@ -28,12 +28,16 @@ backend example_com {
   }
 }
 
+table injectable_dict STRING {
+}
+
 sub vcl_recv {
 
   #Fastly recv
   // @debugger
   set req.backend = example_com;
   set req.http.Foo = {" foo bar baz "};
+  set req.http.Item = table.lookup(injectable_dict, "virtual");
   call custom_logger;
   return (pass);
 }

--- a/interpreter/context/context.go
+++ b/interpreter/context/context.go
@@ -56,10 +56,11 @@ type Context struct {
 	SubroutineFunctions map[string]*ast.SubroutineDeclaration
 	OriginalHost        string
 
-	OverrideMaxBackends int
-	OverrideMaxAcls     int
-	OverrideRequest     *config.RequestConfig
-	OverrideBackends    map[string]*config.OverrideBackend
+	OverrideMaxBackends    int
+	OverrideMaxAcls        int
+	OverrideRequest        *config.RequestConfig
+	OverrideBackends       map[string]*config.OverrideBackend
+	InjectEdgeDictionaries map[string]config.EdgeDictionary
 
 	Request          *http.Request
 	BackendRequest   *http.Request
@@ -162,15 +163,16 @@ type Context struct {
 
 func New(options ...Option) *Context {
 	ctx := &Context{
-		Acls:                make(map[string]*value.Acl),
-		Backends:            make(map[string]*value.Backend),
-		Tables:              make(map[string]*ast.TableDeclaration),
-		Subroutines:         make(map[string]*ast.SubroutineDeclaration),
-		Penaltyboxes:        make(map[string]*ast.PenaltyboxDeclaration),
-		Ratecounters:        make(map[string]*ast.RatecounterDeclaration),
-		Gotos:               make(map[string]*ast.GotoStatement),
-		SubroutineFunctions: make(map[string]*ast.SubroutineDeclaration),
-		OverrideBackends:    make(map[string]*config.OverrideBackend),
+		Acls:                   make(map[string]*value.Acl),
+		Backends:               make(map[string]*value.Backend),
+		Tables:                 make(map[string]*ast.TableDeclaration),
+		Subroutines:            make(map[string]*ast.SubroutineDeclaration),
+		Penaltyboxes:           make(map[string]*ast.PenaltyboxDeclaration),
+		Ratecounters:           make(map[string]*ast.RatecounterDeclaration),
+		Gotos:                  make(map[string]*ast.GotoStatement),
+		SubroutineFunctions:    make(map[string]*ast.SubroutineDeclaration),
+		OverrideBackends:       make(map[string]*config.OverrideBackend),
+		InjectEdgeDictionaries: make(map[string]config.EdgeDictionary),
 
 		CacheHitItem:                    nil,
 		RequestStartTime:                time.Now(),

--- a/interpreter/context/option.go
+++ b/interpreter/context/option.go
@@ -49,3 +49,9 @@ func WithOverrideHost(host string) Option {
 		c.OriginalHost = host
 	}
 }
+
+func WithInjectEdgeDictionaries(ed map[string]config.EdgeDictionary) Option {
+	return func(c *Context) {
+		c.InjectEdgeDictionaries = ed
+	}
+}

--- a/interpreter/edge_dictionary.go
+++ b/interpreter/edge_dictionary.go
@@ -1,0 +1,70 @@
+package interpreter
+
+import (
+	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/config"
+	"github.com/ysugimoto/falco/token"
+)
+
+// Inject edge dictionary item from configuration.
+// Edge dictionary value is managed in Fastly could so typically items are readonly.
+// However we need to set some items in local simulator, particularly write-only edge dictionary
+// So the interpreter can inject virtual value from falco coniguration.
+func (i *Interpreter) InjectEdgeDictionaryItem(table *ast.TableDeclaration, dict config.EdgeDictionary) error {
+	for key, val := range dict {
+		idx := -1
+		// Find existing key index
+		for i, prop := range table.Properties {
+			if prop.Key.Value == key {
+				idx = i
+				break
+			}
+		}
+
+		inject := createInjectTableProperty(key, val)
+		if idx == -1 {
+			// If key not found, simply append inject value
+			table.Properties = append(table.Properties, inject)
+		} else {
+			// Otherwise, replace its value
+			table.Properties[idx] = inject
+		}
+	}
+	return nil
+}
+
+// Create virtual ast.TableProperty node with injected value
+func createInjectTableProperty(key, value string) *ast.TableProperty {
+	return &ast.TableProperty{
+		Meta: ast.New(token.Token{
+			Type:     token.STRING,
+			Literal:  value,
+			Line:     0,
+			Position: 0,
+			Offset:   0,
+			File:     "EdgeDictionary.Injected",
+		}, 0),
+		Key: &ast.String{
+			Meta: ast.New(token.Token{
+				Type:     token.STRING,
+				Literal:  key,
+				Line:     0,
+				Position: 0,
+				Offset:   0,
+				File:     "EdgeDictionary.Injected",
+			}, 0),
+			Value: key,
+		},
+		Value: &ast.String{
+			Meta: ast.New(token.Token{
+				Type:     token.STRING,
+				Literal:  value,
+				Line:     0,
+				Position: 0,
+				Offset:   0,
+				File:     "EdgeDictionary.Injected",
+			}, 0),
+			Value: value,
+		},
+	}
+}

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -181,6 +181,17 @@ func (i *Interpreter) ProcessDeclarations(statements []ast.Statement) error {
 				return exception.Runtime(&t.Token, "Table %s is duplicated", t.Name.Value)
 			}
 			i.ctx.Tables[t.Name.Value] = t
+
+			// Set items if injected edge dictionaries exists
+			if inject, ok := i.ctx.InjectEdgeDictionaries[t.Name.Value]; ok {
+				// Edge Dictionary value type must be STRING
+				if t.ValueType.Value != "STRING" {
+					return exception.System("EdgeDictionary injection error: %s value type is not STRING", t.Name.Value)
+				}
+				if err := i.InjectEdgeDictionaryItem(t, inject); err != nil {
+					return errors.WithStack(err)
+				}
+			}
 		case *ast.SubroutineDeclaration:
 			i.Debugger.Run(stmt)
 			if t.ReturnType != nil {

--- a/snippets/template.go
+++ b/snippets/template.go
@@ -1,7 +1,7 @@
 package snippets
 
 var tableTemplate = `
-table {{ .Name }} {
+table {{ .Name }} STRING {
 	{{- range .Items }}
 	"{{ .Key }}": "{{ .Value }}",
 	{{- end }}


### PR DESCRIPTION
Fixes #315 

This PR implements a feature for setting virtual edge dictionary items on the simulator.

## Use Case

On the local simulation, VCL has a logic that depends on the edge dictionary item value.
However, edge dictionary item is managed on the Fastly cloud - especially write-only dictionaries - so we need to set the virtual items on the local simulation.

We decide to inject these items via configuration. You can set virtual items at the `simulator` section in  the `.falco.yaml`. 

```yaml
...
simulator:
  edge_dictionary:
    inject_dict:
      key1: value1
      key2: value2
      ...
```

Then falco inject/override edge dictionary item for `inject_dict` which is defined on the Fastly service.
Note that the edge dictionary item value must be a `STRING` so we always set it as a string even if you specify numeric or boolean values like `1.0e`, `true`.
