### PR TITLE
implement subroutine mocking feature

### DIFF
--- a/cmd/falco/runner_test.go
+++ b/cmd/falco/runner_test.go
@@ -363,6 +363,12 @@ func TestTester(t *testing.T) {
 			filter: "*group.test.vcl",
 			passes: 3,
 		},
+		{
+			name:   "mockging test",
+			main:   "../../examples/testing/mock_subroutine.vcl",
+			filter: "*mock_subroutine.test.vcl",
+			passes: 6,
+		},
 	}
 
 	for _, tt := range tests {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,6 +29,10 @@ simulator:
   max_acls: 100
   key_file: /path/to/key_file.pem
   cert_file: /path/to/cert_file.pem
+  edge_dictionary:
+    dict_name:
+      key1: value1
+      key2: value2
 
 ## Testing configuration
 testing:
@@ -55,6 +59,10 @@ All configurations of configuration files and CLI arguments are described follow
 | max_acls                           | Integer       | 1000    | --max_acls         | Override Fastly's acl amount limitation                                                                                               |
 | simulator                          | Object        | null    | -                  | Simulator configuration object                                                                                                        |
 | simulator.port                     | Integer       | 3124    | -p, --port         | Simulator server listen port                                                                                                          |
+| simulator.key_file                 | String        | -       | --key              | TLS server key file path                                                                                                              |
+| simulator.cert_file                | String        | -       | --cert             | TLS server cert file path                                                                                                             |
+| simulator.edge_dictionary          | Object        | null    | -                  | Local edge dictionary item definitions                                                                                                |
+| simulator.edge_dictionary.[name]   | Object        | -       | -                  | Local edge dictionary name                                                                                                            |
 | testing                            | Object        | null    | -                  | Testing configuration object                                                                                                          |
 | testing.timeout                    | Integer       | 10      | -t, --timeout      | Set timeout to stop testing                                                                                                           |
 | linter                             | Object        | null    | -                  | Override linter rules                                                                                                                 |

--- a/docs/simulator.md
+++ b/docs/simulator.md
@@ -79,6 +79,13 @@ falco simulate /path/to/your/default.vcl --key /path/to/localhost-key.pem --cert
 
 Then falco serve with https://localhost:3124.
 
+## Override Edge Dictionary Items
+
+Edge Dictionary values are managed in Fastly cloud but often we have some logics that relates to its value (e.g flag true/false), and write-only dictionary items could access via remote API.
+To simulate its behavior with specific value, falco supports overriding edge dictionary item locally from configuration.
+
+See `simulator.edge_dictionary` field in [configuration.md](./configuration.md).
+
 ## Debug mode
 
 `falco` also includes TUI debugger so that you can debug VCL with step execution.

--- a/examples/testing/mock_subroutine.test.vcl
+++ b/examples/testing/mock_subroutine.test.vcl
@@ -1,0 +1,37 @@
+sub mocked {
+  set req.http.Mocked = "1";
+}
+
+sub mocked_func STRING {
+  return "Mocked";
+}
+
+describe group {
+
+  before_recv {
+    testing.mock("original", "mocked");
+    testing.mock("original_func", "mocked_func");
+  }
+
+  after_recv {
+    testing.restore_all_mocks();
+    unset req.http.Mocked;
+  }
+
+  // @scope: recv
+  sub test_recv {
+    testing.call_subroutine("vcl_recv");
+    assert.equal(req.http.Mocked, "1");
+    assert.is_notset(req.http.Original);
+    assert.equal(req.http.FuncValue, "Mocked");
+  }
+
+  // @scope: fetch
+  sub test_fetch {
+    testing.call_subroutine("vcl_fetch");
+    assert.equal(req.http.Original, "1");
+    assert.is_notset(req.http.Mocked);
+    assert.equal(req.http.FuncValue, "Original");
+  }
+
+}

--- a/examples/testing/mock_subroutine.vcl
+++ b/examples/testing/mock_subroutine.vcl
@@ -1,0 +1,21 @@
+// @scope: recv,fetch
+sub original {
+  set req.http.Original = "1";
+}
+
+// @scope: recv,fetch
+sub original_func STRING {
+  return "Original";
+}
+
+sub vcl_recv {
+  #FASTLY RECV
+  call original;
+  set req.http.FuncValue = original_func();
+}
+
+sub vcl_fetch {
+  #FASTLY FETCH
+  call original;
+  set req.http.FuncValue = original_func();
+}

--- a/interpreter/context/context.go
+++ b/interpreter/context/context.go
@@ -61,6 +61,10 @@ type Context struct {
 	OverrideRequest     *config.RequestConfig
 	OverrideBackends    map[string]*config.OverrideBackend
 
+	// Mocking subroutines map
+	MockedSubroutines            map[string]*ast.SubroutineDeclaration
+	MockedFunctioncalSubroutines map[string]*ast.SubroutineDeclaration
+
 	Request          *http.Request
 	BackendRequest   *http.Request
 	BackendResponse  *http.Response
@@ -171,6 +175,9 @@ func New(options ...Option) *Context {
 		Gotos:               make(map[string]*ast.GotoStatement),
 		SubroutineFunctions: make(map[string]*ast.SubroutineDeclaration),
 		OverrideBackends:    make(map[string]*config.OverrideBackend),
+
+		MockedSubroutines:            make(map[string]*ast.SubroutineDeclaration),
+		MockedFunctioncalSubroutines: make(map[string]*ast.SubroutineDeclaration),
 
 		CacheHitItem:                    nil,
 		RequestStartTime:                time.Now(),

--- a/interpreter/expression.go
+++ b/interpreter/expression.go
@@ -234,6 +234,10 @@ func (i *Interpreter) ProcessFunctionCallExpression(exp *ast.FunctionCallExpress
 				exp.Function.Value,
 			)
 		}
+		// If mocked functional subroutine found, use it
+		if mocked, ok := i.ctx.MockedFunctioncalSubroutines[exp.Function.Value]; ok {
+			sub = mocked
+		}
 		if _, ok := types.ValueTypeMap[sub.ReturnType.Value]; !ok {
 			return value.Null, exception.Runtime(
 				&sub.GetMeta().Token,

--- a/interpreter/statement.go
+++ b/interpreter/statement.go
@@ -282,12 +282,22 @@ func (i *Interpreter) ProcessCallStatement(stmt *ast.CallStatement, ds DebugStat
 	var state State
 	var err error
 	name := stmt.Subroutine.Value
+
 	if sub, ok := i.ctx.SubroutineFunctions[name]; ok {
+		// If mocked functional subroutine exists, use it
+		if mocked, ok := i.ctx.MockedFunctioncalSubroutines[name]; ok {
+			sub = mocked
+		}
+
 		_, state, err = i.ProcessFunctionSubroutine(sub, ds)
 		if err != nil {
 			return NONE, errors.WithStack(err)
 		}
 	} else if sub, ok = i.ctx.Subroutines[name]; ok {
+		// If mocked subroutine exists, use it
+		if mocked, ok := i.ctx.MockedSubroutines[name]; ok {
+			sub = mocked
+		}
 		state, err = i.ProcessSubroutine(sub, ds)
 		if err != nil {
 			return NONE, errors.WithStack(err)

--- a/linter/rules.go
+++ b/linter/rules.go
@@ -32,7 +32,7 @@ const (
 	SUBROUTINE_BOILERPLATE_MACRO         = "subroutine/boilerplate-macro"
 	SUBROUTINE_DUPLICATED                = "subroutine/duplicated"
 	SUBROUTINE_INVALID_RETURN_TYPE       = "subroutine/invalid-return-type"
-	UNRECOGNIZE_CALL_SCOPE               = "sburoutine/unrecognize-call-scope"
+	UNRECOGNIZE_CALL_SCOPE               = "subroutine/unrecognize-call-scope"
 	PENALTYBOX_SYNTAX                    = "penaltybox/syntax"
 	PENALTYBOX_DUPLICATED                = "penaltybox/duplicated"
 	PENALTYBOX_NONEMPTY_BLOCK            = "penaltybox/nonempty-block"

--- a/tester/function/testing_call_subroutine.go
+++ b/tester/function/testing_call_subroutine.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Testing_call_subroutine_Name = "assert"
+const Testing_call_subroutine_Name = "testing.call_subroutine"
 
 var Testing_call_subroutine_ArgumentTypes = []value.Type{value.StringType}
 

--- a/tester/function/testing_functions.go
+++ b/tester/function/testing_functions.go
@@ -17,9 +17,10 @@ type Counter interface {
 }
 
 type Definiions struct {
-	Tables   map[string]*ast.TableDeclaration
-	Backends map[string]*value.Backend
-	Acls     map[string]*value.Acl
+	Tables      map[string]*ast.TableDeclaration
+	Backends    map[string]*value.Backend
+	Acls        map[string]*value.Acl
+	Subroutines map[string]*ast.SubroutineDeclaration
 }
 
 type Functions map[string]*ifn.Function
@@ -106,6 +107,34 @@ func testingFunctions(i *interpreter.Interpreter, defs *Definiions) Functions {
 			Scope: allScope,
 			Call: func(ctx *context.Context, args ...value.Value) (value.Value, error) {
 				return Testing_table_merge(ctx, defs, args...)
+			},
+			CanStatementCall: true,
+			IsIdentArgument: func(i int) bool {
+				return false
+			},
+		},
+		"testing.mock": {
+			Scope: allScope,
+			Call: func(ctx *context.Context, args ...value.Value) (value.Value, error) {
+				return Testing_mock(ctx, defs, args...)
+			},
+			CanStatementCall: true,
+			IsIdentArgument: func(i int) bool {
+				return false
+			},
+		},
+		"testing.restore_mock": {
+			Scope:            allScope,
+			Call:             Testing_restore_mock,
+			CanStatementCall: true,
+			IsIdentArgument: func(i int) bool {
+				return false
+			},
+		},
+		"testing.restore_all_mocks": {
+			Scope: allScope,
+			Call: func(ctx *context.Context, args ...value.Value) (value.Value, error) {
+				return Testing_restore_all_mocks(ctx)
 			},
 			CanStatementCall: true,
 			IsIdentArgument: func(i int) bool {

--- a/tester/function/testing_mock.go
+++ b/tester/function/testing_mock.go
@@ -1,0 +1,99 @@
+package function
+
+import (
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/function/errors"
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+const Testing_mock_Name = "testing.mock"
+
+var Testing_mock_ArgumentTypes = []value.Type{value.StringType, value.StringType}
+
+func Testing_mock_Validate(args []value.Value) error {
+	if len(args) != 2 {
+		return errors.ArgumentNotEnough(Testing_mock_Name, 2, args)
+	}
+
+	for i := range Testing_mock_ArgumentTypes {
+		if args[i].Type() != Testing_mock_ArgumentTypes[i] {
+			return errors.TypeMismatch(
+				Testing_mock_Name, i+1, Testing_mock_ArgumentTypes[i], args[i].Type(),
+			)
+		}
+	}
+	return nil
+}
+
+func Testing_mock(
+	ctx *context.Context,
+	defs *Definiions,
+	args ...value.Value,
+) (value.Value, error) {
+
+	if err := Testing_mock_Validate(args); err != nil {
+		return nil, errors.NewTestingError(err.Error())
+	}
+
+	from := value.Unwrap[*value.String](args[0]).Value
+	to := value.Unwrap[*value.String](args[1]).Value
+
+	if _, ok := Testing_mock_Fastly_reserved[from]; ok {
+		return value.Null, errors.NewTestingError("Cannot mock Fastly reserved subroutine %s", from)
+	}
+
+	// Check subroutine existence
+	mockFrom, ok := ctx.Subroutines[from]
+	if !ok {
+		if mockFrom, ok = ctx.SubroutineFunctions[from]; !ok {
+			return value.Null, errors.NewTestingError("subroutine %s is not declared in VCL", from)
+		}
+	}
+
+	mockTo, ok := defs.Subroutines[to]
+	if !ok {
+		return value.Null, errors.NewTestingError("mock subroutine %s is not declared in testing VCL", to)
+	}
+
+	// Check functional subroutine
+	if mockFrom.ReturnType != nil {
+		if mockTo.ReturnType == nil {
+			return value.Null, errors.NewTestingError(
+				"%s is functional subroutine but mock target %s is not functional", from, to,
+			)
+		}
+
+		// Return type must match between original and mock target
+		if mockFrom.ReturnType.Value != mockTo.ReturnType.Value {
+			return value.Null, errors.NewTestingError(
+				"mocking subroutine return type mismatch, original is %s, mock target is %s",
+				mockFrom.ReturnType.Value,
+				mockTo.ReturnType.Value,
+			)
+		}
+
+		ctx.MockedFunctioncalSubroutines[from] = mockTo
+		return value.Null, nil
+	}
+
+	if mockTo.ReturnType != nil {
+		return value.Null, errors.NewTestingError(
+			"%s is subroutine but mock target %s is functional subroutine", from, to,
+		)
+	}
+
+	ctx.MockedSubroutines[from] = mockTo
+	return value.Null, nil
+}
+
+var Testing_mock_Fastly_reserved = map[string]struct{}{
+	"vcl_recv":    {},
+	"vcl_hash":    {},
+	"vcl_hit":     {},
+	"vcl_miss":    {},
+	"vcl_pass":    {},
+	"vcl_fetch":   {},
+	"vcl_error":   {},
+	"vcl_deliver": {},
+	"vcl_log":     {},
+}

--- a/tester/function/testing_mock_test.go
+++ b/tester/function/testing_mock_test.go
@@ -1,0 +1,278 @@
+package function
+
+import (
+	"testing"
+
+	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/value"
+	"github.com/ysugimoto/falco/lexer"
+	"github.com/ysugimoto/falco/parser"
+)
+
+func Test_mock(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		mock    string
+		isError bool
+	}{
+		{
+			name: "mock subroutine",
+			input: `sub original {
+					set req.http.Original = "1";
+				}`,
+			mock: `sub mocked {
+					set req.http.Mocked = "1";
+				}`,
+		},
+		{
+			name: "name mismatch",
+			input: `sub undefined {
+					set req.http.Original = "1";
+				}`,
+			mock: `sub mocked {
+					set req.http.Mocked = "1";
+				}`,
+			isError: true,
+		},
+		{
+			name: "cannot mock functional subroutine",
+			input: `sub undefined STRING {
+					set req.http.Original = "1";
+					return "FOO";
+				}`,
+			mock: `sub mocked {
+					set req.http.Mocked = "1";
+				}`,
+			isError: true,
+		},
+		{
+			name: "cannot mock target functional subroutine",
+			input: `sub original {
+					set req.http.Original = "1";
+				}`,
+			mock: `sub mocked STRING {
+					set req.http.Mocked = "1";
+					return "FOO";
+				}`,
+			isError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			from, err := parser.New(lexer.NewFromString(tt.input)).ParseVCL()
+			if err != nil {
+				t.Errorf("Unexpected input parse error: %s", err)
+				return
+			}
+			fromSubroutine := from.Statements[0].(*ast.SubroutineDeclaration)
+			mock, err := parser.New(lexer.NewFromString(tt.mock)).ParseVCL()
+			if err != nil {
+				t.Errorf("Unexpected mock parse error: %s", err)
+				return
+			}
+			mockSubroutine := mock.Statements[0].(*ast.SubroutineDeclaration)
+
+			c := &context.Context{
+				Subroutines: map[string]*ast.SubroutineDeclaration{
+					fromSubroutine.Name.Value: fromSubroutine,
+				},
+				MockedSubroutines: map[string]*ast.SubroutineDeclaration{},
+			}
+			defs := &Definiions{
+				Subroutines: map[string]*ast.SubroutineDeclaration{
+					mockSubroutine.Name.Value: mockSubroutine,
+				},
+			}
+			_, err = Testing_mock(
+				c,
+				defs,
+				&value.String{Value: "original"},
+				&value.String{Value: "mocked"},
+			)
+			if tt.isError {
+				if err == nil {
+					t.Errorf("Expected error but nil")
+				}
+				return
+			}
+			v, ok := c.MockedSubroutines["original"]
+			if !ok {
+				t.Errorf("Expected mocked subroutine exists but not found")
+				return
+			}
+			if v.Name.Value != "mocked" {
+				t.Errorf("Expected mocked subroutine exists but name is mismatch")
+			}
+		})
+	}
+}
+
+func Test_mock_functional_subroutine(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		input   string
+		mock    string
+		isError bool
+	}{
+		{
+			name: "mock functional subroutine",
+			input: `sub original STRING {
+					set req.http.Original = "1";
+					return "FOO";
+				}`,
+			mock: `sub mocked STRING {
+					set req.http.Mocked = "1";
+					return "BAR";
+				}`,
+		},
+		{
+			name: "name mismatch",
+			input: `sub undefined STRING {
+					set req.http.Original = "1";
+					return "FOO";
+				}`,
+			mock: `sub mocked STRING {
+					set req.http.Mocked = "1";
+					return "BAR";
+				}`,
+			isError: true,
+		},
+		{
+			name: "cannot mock stateful subroutine",
+			input: `sub undefined STRING {
+					set req.http.Original = "1";
+					return "FOO";
+				}`,
+			mock: `sub mocked {
+					set req.http.Mocked = "1";
+				}`,
+			isError: true,
+		},
+		{
+			name: "mock type mismatch",
+			input: `sub original INTEGER {
+					set req.http.Original = "1";
+					return 1;
+				}`,
+			mock: `sub mocked STRING {
+					set req.http.Mocked = "1";
+					return "FOO";
+				}`,
+			isError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			from, err := parser.New(lexer.NewFromString(tt.input)).ParseVCL()
+			if err != nil {
+				t.Errorf("Unexpected input parse error: %s", err)
+				return
+			}
+			fromSubroutine := from.Statements[0].(*ast.SubroutineDeclaration)
+			mock, err := parser.New(lexer.NewFromString(tt.mock)).ParseVCL()
+			if err != nil {
+				t.Errorf("Unexpected mock parse error: %s", err)
+				return
+			}
+			mockSubroutine := mock.Statements[0].(*ast.SubroutineDeclaration)
+
+			c := &context.Context{
+				SubroutineFunctions: map[string]*ast.SubroutineDeclaration{
+					fromSubroutine.Name.Value: fromSubroutine,
+				},
+				MockedFunctioncalSubroutines: map[string]*ast.SubroutineDeclaration{},
+			}
+			defs := &Definiions{
+				Subroutines: map[string]*ast.SubroutineDeclaration{
+					mockSubroutine.Name.Value: mockSubroutine,
+				},
+			}
+			_, err = Testing_mock(
+				c,
+				defs,
+				&value.String{Value: "original"},
+				&value.String{Value: "mocked"},
+			)
+			if tt.isError {
+				if err == nil {
+					t.Errorf("Expected error but nil")
+				}
+				return
+			}
+			v, ok := c.MockedFunctioncalSubroutines["original"]
+			if !ok {
+				t.Errorf("Expected mocked subroutine exists but not found")
+				return
+			}
+			if v.Name.Value != "mocked" {
+				t.Errorf("Expected mocked subroutine exists but name is mismatch")
+			}
+		})
+	}
+}
+
+func Test_mock_fastly_reserved_subroutine(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		input   string
+		mock    string
+		isError bool
+	}{
+		{
+			name: "cannot mock fastly reserved subroutine",
+			input: `sub vcl_recv {
+					set req.http.Original = "1";
+				}`,
+			mock: `sub mocked {
+					set req.http.Mocked = "1";
+				}`,
+			isError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			from, err := parser.New(lexer.NewFromString(tt.input)).ParseVCL()
+			if err != nil {
+				t.Errorf("Unexpected input parse error: %s", err)
+				return
+			}
+			fromSubroutine := from.Statements[0].(*ast.SubroutineDeclaration)
+			mock, err := parser.New(lexer.NewFromString(tt.mock)).ParseVCL()
+			if err != nil {
+				t.Errorf("Unexpected mock parse error: %s", err)
+				return
+			}
+			mockSubroutine := mock.Statements[0].(*ast.SubroutineDeclaration)
+
+			c := &context.Context{
+				Subroutines: map[string]*ast.SubroutineDeclaration{
+					fromSubroutine.Name.Value: fromSubroutine,
+				},
+			}
+			defs := &Definiions{
+				Subroutines: map[string]*ast.SubroutineDeclaration{
+					mockSubroutine.Name.Value: mockSubroutine,
+				},
+			}
+			_, err = Testing_mock(
+				c,
+				defs,
+				&value.String{Value: "vcl_recv"},
+				&value.String{Value: "mocked"},
+			)
+			if tt.isError {
+				if err == nil {
+					t.Errorf("Expected error but nil")
+				}
+				return
+			}
+		})
+	}
+}

--- a/tester/function/testing_restore_all_mocks.go
+++ b/tester/function/testing_restore_all_mocks.go
@@ -1,0 +1,33 @@
+package function
+
+import (
+	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/function/errors"
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+const Testing_restore_all_mocks_Name = "testing.restore_all_mocks"
+
+func Testing_restore_all_mocks_Validate(args []value.Value) error {
+	if len(args) > 0 {
+		return errors.ArgumentMustEmpty(Testing_restore_all_mocks_Name, args)
+	}
+	return nil
+}
+
+func Testing_restore_all_mocks(
+	ctx *context.Context,
+	args ...value.Value,
+) (value.Value, error) {
+
+	if err := Testing_restore_all_mocks_Validate(args); err != nil {
+		return nil, errors.NewTestingError(err.Error())
+	}
+
+	// clear all mocked subroutines
+	ctx.MockedSubroutines = map[string]*ast.SubroutineDeclaration{}
+	ctx.MockedFunctioncalSubroutines = map[string]*ast.SubroutineDeclaration{}
+
+	return value.Null, nil
+}

--- a/tester/function/testing_restore_all_mocks_test.go
+++ b/tester/function/testing_restore_all_mocks_test.go
@@ -1,0 +1,96 @@
+package function
+
+import (
+	"testing"
+
+	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/lexer"
+	"github.com/ysugimoto/falco/parser"
+)
+
+func Test_restore_all_mocks(t *testing.T) {
+
+	tests := []struct {
+		name string
+		mock string
+	}{
+		{
+			name: "restore mocked subroutine",
+			mock: `sub mocked {
+					set req.http.Mocked = "1";
+				}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock, err := parser.New(lexer.NewFromString(tt.mock)).ParseVCL()
+			if err != nil {
+				t.Errorf("Unexpected mock parse error: %s", err)
+				return
+			}
+			mockSubroutine := mock.Statements[0].(*ast.SubroutineDeclaration)
+
+			c := &context.Context{
+				MockedSubroutines: map[string]*ast.SubroutineDeclaration{
+					"original": mockSubroutine,
+				},
+			}
+			_, err = Testing_restore_all_mocks(c)
+			if err != nil {
+				t.Errorf("Expected no error but returned: %s", err)
+			}
+			if len(c.MockedSubroutines) > 0 {
+				t.Errorf("mocked subroutines must be empty")
+			}
+			if len(c.MockedFunctioncalSubroutines) > 0 {
+				t.Errorf("mocked functional subroutines must be empty")
+			}
+		})
+	}
+}
+
+func Test_restore_all_functional_mock(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		mock    string
+		isError bool
+	}{
+		{
+			name: "restore mocked functional subroutine",
+			mock: `sub mocked STRING {
+					set req.http.Mocked = "1";
+					return "BAR";
+				}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock, err := parser.New(lexer.NewFromString(tt.mock)).ParseVCL()
+			if err != nil {
+				t.Errorf("Unexpected mock parse error: %s", err)
+				return
+			}
+			mockSubroutine := mock.Statements[0].(*ast.SubroutineDeclaration)
+
+			c := &context.Context{
+				MockedFunctioncalSubroutines: map[string]*ast.SubroutineDeclaration{
+					"original": mockSubroutine,
+				},
+			}
+			_, err = Testing_restore_all_mocks(c)
+			if err != nil {
+				t.Errorf("Expected no error but returned: %s", err)
+			}
+			if len(c.MockedSubroutines) > 0 {
+				t.Errorf("mocked subroutines must be empty")
+			}
+			if len(c.MockedFunctioncalSubroutines) > 0 {
+				t.Errorf("mocked functional subroutines must be empty")
+			}
+		})
+	}
+}

--- a/tester/function/testing_restore_mock.go
+++ b/tester/function/testing_restore_mock.go
@@ -1,0 +1,49 @@
+package function
+
+import (
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/function/errors"
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+const Testing_restore_mock_Name = "testing.restore_mock"
+
+func Testing_restore_mock_Validate(args []value.Value) error {
+	if len(args) == 0 {
+		return errors.ArgumentAtLeast(Testing_restore_mock_Name, 1)
+	}
+
+	for i := range args {
+		if args[i].Type() != value.StringType {
+			return errors.TypeMismatch(
+				Testing_restore_mock_Name, i+1, value.StringType, args[i].Type(),
+			)
+		}
+	}
+
+	return nil
+}
+
+func Testing_restore_mock(
+	ctx *context.Context,
+	args ...value.Value,
+) (value.Value, error) {
+
+	if err := Testing_restore_mock_Validate(args); err != nil {
+		return nil, errors.NewTestingError(err.Error())
+	}
+
+	for i := range args {
+		name := value.Unwrap[*value.String](args[i]).Value
+		if _, ok := ctx.MockedSubroutines[name]; ok {
+			delete(ctx.MockedSubroutines, name)
+			continue
+		}
+		if _, ok := ctx.MockedFunctioncalSubroutines[name]; ok {
+			delete(ctx.MockedFunctioncalSubroutines, name)
+			continue
+		}
+		return value.Null, errors.NewTestingError("subroutine %s is not mocked", name)
+	}
+	return value.Null, nil
+}

--- a/tester/function/testing_restore_mock_test.go
+++ b/tester/function/testing_restore_mock_test.go
@@ -1,0 +1,128 @@
+package function
+
+import (
+	"testing"
+
+	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/value"
+	"github.com/ysugimoto/falco/lexer"
+	"github.com/ysugimoto/falco/parser"
+)
+
+func Test_restore_mock(t *testing.T) {
+	tests := []struct {
+		name     string
+		mockName string
+		mock     string
+		isError  bool
+	}{
+		{
+			name:     "restore mocked subroutine",
+			mockName: "original",
+			mock: `sub mocked {
+					set req.http.Mocked = "1";
+				}`,
+		},
+		{
+			name:     "error if mocked subroutine not found",
+			mockName: "undefined",
+			mock: `sub mocked {
+					set req.http.Mocked = "1";
+				}`,
+			isError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock, err := parser.New(lexer.NewFromString(tt.mock)).ParseVCL()
+			if err != nil {
+				t.Errorf("Unexpected mock parse error: %s", err)
+				return
+			}
+			mockSubroutine := mock.Statements[0].(*ast.SubroutineDeclaration)
+
+			c := &context.Context{
+				MockedSubroutines: map[string]*ast.SubroutineDeclaration{
+					tt.mockName: mockSubroutine,
+				},
+			}
+			_, err = Testing_restore_mock(
+				c,
+				&value.String{Value: "original"},
+			)
+			if tt.isError {
+				if err == nil {
+					t.Errorf("Expected error but nil")
+				}
+				return
+			}
+			_, ok := c.MockedSubroutines["original"]
+			if ok {
+				t.Errorf("Expected mocked subroutine does not exist but exists")
+				return
+			}
+		})
+	}
+}
+
+func Test_restore_functional_mock(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		mockName string
+		mock     string
+		isError  bool
+	}{
+		{
+			name:     "mock functional subroutine",
+			mockName: "original",
+			mock: `sub mocked STRING {
+					set req.http.Mocked = "1";
+					return "BAR";
+				}`,
+		},
+		{
+			name:     "error if mocked functional subroutine not found",
+			mockName: "undefined",
+			mock: `sub mocked STRING {
+					set req.http.Mocked = "1";
+					return "BAR";
+				}`,
+			isError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock, err := parser.New(lexer.NewFromString(tt.mock)).ParseVCL()
+			if err != nil {
+				t.Errorf("Unexpected mock parse error: %s", err)
+				return
+			}
+			mockSubroutine := mock.Statements[0].(*ast.SubroutineDeclaration)
+
+			c := &context.Context{
+				MockedFunctioncalSubroutines: map[string]*ast.SubroutineDeclaration{
+					tt.mockName: mockSubroutine,
+				},
+			}
+			_, err = Testing_restore_mock(
+				c,
+				&value.String{Value: "original"},
+			)
+			if tt.isError {
+				if err == nil {
+					t.Errorf("Expected error but nil")
+				}
+				return
+			}
+			_, ok := c.MockedSubroutines["original"]
+			if ok {
+				t.Errorf("Expected mocked subroutine does not exist but exists")
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #316 

This PR implements a subroutine mocking feature in testing VCL. Now we add three functions:

- `testing.mock`
- `testing.resotre_mock`
- `testing.restore_all_mocks`

This mechanism is very similar to Jest-like mocking system but it is a tiny note that both mocking subroutine names must be specified as STRING - it's some reason from our subroutine detecting logic.