### PR TITLE
Feature/arbitrary process flow marking

### DIFF
--- a/examples/simulator/simulator.vcl
+++ b/examples/simulator/simulator.vcl
@@ -37,6 +37,7 @@ sub vcl_recv {
   // @debugger
   set req.backend = example_com;
   set req.http.Foo = {" foo bar baz "};
+  // @process inject dict
   set req.http.Item = table.lookup(injectable_dict, "virtual");
   call custom_logger;
   return (pass);

--- a/interpreter/helper.go
+++ b/interpreter/helper.go
@@ -1,0 +1,18 @@
+package interpreter
+
+import (
+	"strings"
+
+	"github.com/ysugimoto/falco/ast"
+)
+
+func findProcessMark(comments ast.Comments) (string, bool) {
+	for i := range comments {
+		l := strings.TrimLeft(comments[i].Value, " */#")
+		if strings.HasPrefix(l, "@process") {
+			return strings.TrimSpace(strings.TrimPrefix(l, "@process")), true
+		}
+	}
+
+	return "", false
+}

--- a/interpreter/process/flow.go
+++ b/interpreter/process/flow.go
@@ -3,7 +3,6 @@ package process
 import (
 	"context"
 
-	"github.com/ysugimoto/falco/ast"
 	icontext "github.com/ysugimoto/falco/interpreter/context"
 )
 
@@ -11,7 +10,9 @@ type Flow struct {
 	File            string    `json:"file"`
 	Line            int       `json:"line"`
 	Position        int       `json:"position"`
-	Subroutine      string    `json:"subroutine"`
+	Subroutine      string    `json:"subroutine,omitempty"`
+	Name            string    `json:"name,omitempty"`
+	Scope           string    `json:"scope"`
 	Request         *HttpFlow `json:"req,omitempty"`
 	BackendRequest  *HttpFlow `json:"bereq,omitempty"`
 	BackendResponse *HttpFlow `json:"beresp,omitempty"`
@@ -19,15 +20,14 @@ type Flow struct {
 	Object          *HttpFlow `json:"object,omitempty"`
 }
 
-func NewFlow(ctx *icontext.Context, sub *ast.SubroutineDeclaration) *Flow {
+func NewFlow(ctx *icontext.Context, opts ...Option) *Flow {
 	c := context.Background()
 
-	token := sub.GetMeta().Token
 	f := &Flow{
-		File:       token.File,
-		Line:       token.Line,
-		Position:   token.Position,
-		Subroutine: sub.Name.Value,
+		Scope: ctx.Scope.String(),
+	}
+	for i := range opts {
+		opts[i](f)
 	}
 	if ctx.Request != nil {
 		f.Request = newFlowRequest(ctx.Request.Clone(c))

--- a/interpreter/process/option.go
+++ b/interpreter/process/option.go
@@ -1,0 +1,32 @@
+package process
+
+import (
+	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/token"
+)
+
+type Option func(f *Flow)
+
+func WithSubroutine(sub *ast.SubroutineDeclaration) Option {
+	return func(f *Flow) {
+		tok := sub.GetMeta().Token
+		f.Subroutine = sub.Name.Value
+		f.File = tok.File
+		f.Line = tok.Line
+		f.Position = tok.Position
+	}
+}
+
+func WithName(name string) Option {
+	return func(f *Flow) {
+		f.Name = name
+	}
+}
+
+func WithToken(tok token.Token) Option {
+	return func(f *Flow) {
+		f.File = tok.File
+		f.Line = tok.Line
+		f.Position = tok.Position
+	}
+}

--- a/interpreter/statement.go
+++ b/interpreter/statement.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/k0kubun/pp"
 	"github.com/pkg/errors"
 	"github.com/ysugimoto/falco/ast"
 	"github.com/ysugimoto/falco/interpreter/assign"
@@ -33,6 +34,17 @@ func (i *Interpreter) ProcessBlockStatement(
 		// Call debugger
 		if debugState != DebugStepOut {
 			debugState = i.Debugger.Run(stmt)
+		}
+
+		// Find process marker and add flow if found
+		if stmt.GetMeta() == nil {
+			pp.Println(stmt)
+		}
+		if name, found := findProcessMark(stmt.GetMeta().Leading); found {
+			i.process.Flows = append(
+				i.process.Flows,
+				process.NewFlow(i.ctx, process.WithName(name), process.WithToken(stmt.GetMeta().Token)),
+			)
 		}
 
 		switch t := stmt.(type) {

--- a/interpreter/statement_test.go
+++ b/interpreter/statement_test.go
@@ -154,6 +154,7 @@ func TestSetStatement(t *testing.T) {
 			name:  "set local variable",
 			scope: context.RecvScope,
 			stmt: &ast.SetStatement{
+				Meta:     &ast.Meta{},
 				Ident:    &ast.Ident{Value: "var.foo"},
 				Operator: &ast.Operator{Operator: "="},
 				Value:    &ast.Integer{Value: 100},
@@ -163,6 +164,7 @@ func TestSetStatement(t *testing.T) {
 			name:  "set client.geo.ip_override in vcl_recv",
 			scope: context.RecvScope,
 			stmt: &ast.SetStatement{
+				Meta:     &ast.Meta{},
 				Ident:    &ast.Ident{Value: "client.geo.ip_override"},
 				Operator: &ast.Operator{Operator: "="},
 				Value:    &ast.String{Value: "127.0.0.1"},
@@ -172,6 +174,7 @@ func TestSetStatement(t *testing.T) {
 			name:  "set bereq.http.Foo in vcl_miss",
 			scope: context.MissScope,
 			stmt: &ast.SetStatement{
+				Meta:     &ast.Meta{},
 				Ident:    &ast.Ident{Value: "bereq.http.Foo"},
 				Operator: &ast.Operator{Operator: "="},
 				Value:    &ast.String{Value: "test"},
@@ -181,6 +184,7 @@ func TestSetStatement(t *testing.T) {
 			name:  "set bereq.http.Foo in vcl_pass",
 			scope: context.PassScope,
 			stmt: &ast.SetStatement{
+				Meta:     &ast.Meta{},
 				Ident:    &ast.Ident{Value: "bereq.http.Foo"},
 				Operator: &ast.Operator{Operator: "="},
 				Value:    &ast.String{Value: "test"},
@@ -218,7 +222,9 @@ func TestBlockStatement(t *testing.T) {
 			name:  "block statement with bare return",
 			scope: context.RecvScope,
 			stmts: []ast.Statement{
-				&ast.ReturnStatement{},
+				&ast.ReturnStatement{
+					Meta: &ast.Meta{},
+				},
 			},
 			expected_state: BARE_RETURN,
 		},
@@ -227,8 +233,10 @@ func TestBlockStatement(t *testing.T) {
 			scope: context.RecvScope,
 			stmts: []ast.Statement{
 				&ast.BlockStatement{
+					Meta: &ast.Meta{},
 					Statements: []ast.Statement{
 						&ast.ReturnStatement{
+							Meta: &ast.Meta{},
 							ReturnExpression: &ast.Ident{
 								Value: "pass",
 								Meta:  &ast.Meta{},
@@ -236,7 +244,9 @@ func TestBlockStatement(t *testing.T) {
 						},
 					},
 				},
-				&ast.ReturnStatement{},
+				&ast.ReturnStatement{
+					Meta: &ast.Meta{},
+				},
 			},
 			expected_state: PASS,
 		},
@@ -245,14 +255,19 @@ func TestBlockStatement(t *testing.T) {
 			scope: context.RecvScope,
 			stmts: []ast.Statement{
 				&ast.IfStatement{
+					Meta:      &ast.Meta{},
 					Condition: &ast.Boolean{Value: true},
 					Consequence: &ast.BlockStatement{
+						Meta: &ast.Meta{},
 						Statements: []ast.Statement{
-							&ast.ReturnStatement{},
+							&ast.ReturnStatement{
+								Meta: &ast.Meta{},
+							},
 						},
 					},
 				},
 				&ast.ReturnStatement{
+					Meta: &ast.Meta{},
 					ReturnExpression: &ast.Ident{
 						Value: "pass",
 						Meta:  &ast.Meta{},
@@ -295,6 +310,7 @@ func TestBlockStatementWithReturnValue(t *testing.T) {
 			scope: context.RecvScope,
 			stmts: []ast.Statement{
 				&ast.ReturnStatement{
+					Meta: &ast.Meta{},
 					ReturnExpression: &ast.Integer{
 						Value: 1,
 						Meta:  &ast.Meta{},
@@ -307,8 +323,10 @@ func TestBlockStatementWithReturnValue(t *testing.T) {
 			scope: context.RecvScope,
 			stmts: []ast.Statement{
 				&ast.BlockStatement{
+					Meta: &ast.Meta{},
 					Statements: []ast.Statement{
 						&ast.ReturnStatement{
+							Meta: &ast.Meta{},
 							ReturnExpression: &ast.Integer{
 								Value: 1,
 								Meta:  &ast.Meta{},
@@ -317,6 +335,7 @@ func TestBlockStatementWithReturnValue(t *testing.T) {
 					},
 				},
 				&ast.ReturnStatement{
+					Meta: &ast.Meta{},
 					ReturnExpression: &ast.String{
 						Value: "invalid",
 						Meta:  &ast.Meta{},
@@ -329,10 +348,12 @@ func TestBlockStatementWithReturnValue(t *testing.T) {
 			scope: context.RecvScope,
 			stmts: []ast.Statement{
 				&ast.IfStatement{
+					Meta:      &ast.Meta{},
 					Condition: &ast.Boolean{Value: true},
 					Consequence: &ast.BlockStatement{
 						Statements: []ast.Statement{
 							&ast.ReturnStatement{
+								Meta: &ast.Meta{},
 								ReturnExpression: &ast.Integer{
 									Value: 1,
 									Meta:  &ast.Meta{},
@@ -342,6 +363,7 @@ func TestBlockStatementWithReturnValue(t *testing.T) {
 					},
 				},
 				&ast.ReturnStatement{
+					Meta: &ast.Meta{},
 					ReturnExpression: &ast.String{
 						Value: "invalid",
 						Meta:  &ast.Meta{},


### PR DESCRIPTION
This PR provided feature that the user add arbitrary flow log on simulator.

## Usage

Put `@process [name]` annotation comment on your subroutine and the simulator add flow log the snapshop status (scope, req, beresp, etc...) , and enable to see on a simulator response.

Example:

```vcl
sub vcl_recv {
   ...
   // @process some_status
   set req.http.Foo = "bar";
}
```
