### PR TITLE
reduce memory allocation using pool

### DIFF
--- a/examples/formatter/formatter.vcl
+++ b/examples/formatter/formatter.vcl
@@ -1,0 +1,114 @@
+backend example_com {
+  .connect_timeout = 1s;
+  .dynamic = true;
+  .port = "443";
+  .host = "example.com";
+  .first_byte_timeout = 20s;
+  .max_connections = 500;
+  .between_bytes_timeout = 20s;
+  .share_key = "xei5lohleex3Joh5ie5uy7du";
+  .ssl = true;
+  .ssl_sni_hostname = "example.com";
+  .ssl_cert_hostname = "example.com";
+  .ssl_check_cert = always;
+  .min_tls_version = "1.2";
+  .max_tls_version = "1.2";
+  .bypass_local_route_table = false;
+  .probe = {
+    .request = "GET / HTTP/1.1" "Host: example.com" "Connection: close";
+    .dummy = true;
+    .threshold = 1;
+    .window = 2;
+    .timeout = 5s;
+    .initial = 1;
+    .expected_response = 200;
+    .interval = 10s;
+  }
+}
+
+backend httpbin_org {
+  .connect_timeout = 1s;
+  .dynamic = true;
+  .port = "443";
+  .host = "httpbin.org";
+  .first_byte_timeout = 20s;
+  .max_connections = 500;
+  .between_bytes_timeout = 20s;
+  .share_key = "xei5lohleex3Joh5ie5uy7du";
+  .ssl = true;
+  .ssl_sni_hostname = "httpbin.org";
+  .ssl_cert_hostname = "httpbin.org";
+  .ssl_check_cert = always;
+  .min_tls_version = "1.2";
+  .max_tls_version = "1.2";
+  .bypass_local_route_table = false;
+  .probe = {
+    .request = "GET / HTTP/1.1" "Host: httpbin.org" "Connection: close";
+    .dummy = true;
+    .threshold = 1;
+    .window = 2;
+    .timeout = 5s;
+    .initial = 1;
+    .expected_response = 200;
+    .interval = 10s;
+  }
+}
+
+director example_director random {
+  .retries = 3;
+  { .backend = example_com; .weight = 1; }
+  { .backend = httpbin_org; .weight = 1; }
+}
+
+table example_table STRING {
+  "lorem": "ipsum",
+  "dolor": "sit",
+}
+
+sub vcl_recv {
+
+  #Fastly recv
+  set req.http.Foo = {" foo bar baz "};
+
+  if (!req.http.Host) {
+    set req.backend = example_director;
+    set req.http.Host = "example.com";
+  } else if (req.http.Host == "example.com") {
+    set req.backend = httpbin_org;
+    set req.http.Host = "httpbin.org";
+  } else {
+    set req.backend = example_com;
+    set req.http.Host = "example.com";
+  }
+  return (pass);
+}
+
+sub vcl_deliver {
+
+  #Fastly deliver
+  if (req.http.Header1 == "1" && req.http.Header2 == "2" && req.http.Header3 == "3" && req.http.Header4 == "4") {
+    set resp.http.Matched = "yes";
+  }
+
+  set resp.http.X-Custom-Header = "Custom Header";
+  return (deliver);
+}
+
+sub vcl_fetch {
+
+  #Fastly fetch
+  return(deliver);
+}
+
+sub vcl_error {
+
+  #Fastly error
+  synthetic {"Synthetic error response."};
+}
+
+
+sub vcl_log {
+
+  #Fastly log
+  log {"lorem ipsum "} req.http.Host client.os.name {" dolor sit amet."};
+}

--- a/formatter/chunk_buffer.go
+++ b/formatter/chunk_buffer.go
@@ -98,8 +98,10 @@ func (c *ChunkBuffer) Write(s string, t ChunkType) {
 
 // Get "No" chunked string
 func (c *ChunkBuffer) String() string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	for i := range c.chunks {
 		buf.WriteString(c.chunks[i].buffer)
 		if c.chunks[i].isLineComment() {
@@ -146,8 +148,10 @@ func (c *ChunkBuffer) ChunkedString(level, offset int) string {
 		count:     offset + level*c.conf.IndentWidth,
 	}
 
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	for {
 		chunk := c.nextChunk()
 		if chunk == nil {
@@ -253,11 +257,13 @@ func (c *ChunkBuffer) nextLine(state *ChunkState) string {
 
 // chunkLineComment() returns chunk string of line comment
 func (c *ChunkBuffer) chunkLineComment(state *ChunkState, chunk *Chunk) string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
 	// if !state.isHead() {
 	// 	buf.WriteString(c.nextLine(state))
 	// }
+	buf.Reset()
 	buf.WriteString(" " + chunk.buffer)
 	buf.WriteString(c.nextLine(state))
 	state.reset()
@@ -290,9 +296,11 @@ func (c *ChunkBuffer) chunkGroupOperator(state *ChunkState, chunk *Chunk) string
 
 // chunkString() returns chunked string
 func (c *ChunkBuffer) chunkString(state *ChunkState, expr string) string {
-	var buf bytes.Buffer
 	var prefix string
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	if !state.isHead() {
 		prefix = " "
 	}

--- a/formatter/declaration_format.go
+++ b/formatter/declaration_format.go
@@ -18,8 +18,10 @@ func (f *Formatter) formatAclDeclaration(decl *ast.AclDeclaration) *Declaration 
 			group.Lines = append(group.Lines, lines)
 			lines = DelclarationPropertyLines{}
 		}
-		var buf bytes.Buffer
+		buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+		buf.Reset()
 		buf.WriteString(f.indent(1))
+
 		if cidr.Inverse != nil && cidr.Inverse.Value {
 			buf.WriteString("!")
 		}
@@ -39,6 +41,7 @@ func (f *Formatter) formatAclDeclaration(decl *ast.AclDeclaration) *Declaration 
 			Key:          buf.String(),
 			EndCharacter: ";",
 		})
+		bufferPool.Put(buf)
 	}
 
 	// Append remaining lines
@@ -50,7 +53,10 @@ func (f *Formatter) formatAclDeclaration(decl *ast.AclDeclaration) *Declaration 
 		group.Align()
 	}
 
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
+
+	buf.Reset()
 	buf.WriteString("acl " + decl.Name.String() + " {\n")
 	buf.WriteString(group.String())
 	if len(decl.Infix) > 0 {
@@ -68,8 +74,10 @@ func (f *Formatter) formatAclDeclaration(decl *ast.AclDeclaration) *Declaration 
 
 // Format backend declaration
 func (f *Formatter) formatBackendDeclaration(decl *ast.BackendDeclaration) *Declaration {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	buf.WriteString("backend " + decl.Name.String() + " {\n")
 	buf.WriteString(f.formatBackendProperties(decl.Properties, 1))
 	if len(decl.Infix) > 0 {
@@ -205,7 +213,10 @@ func (f *Formatter) formatDirectorDeclaration(decl *ast.DirectorDeclaration) *De
 		group.Align()
 	}
 
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
+
+	buf.Reset()
 	buf.WriteString("director " + decl.Name.String() + " " + decl.DirectorType.String() + " {\n")
 	buf.WriteString(group.String())
 	if len(decl.Infix) > 0 {
@@ -223,8 +234,10 @@ func (f *Formatter) formatDirectorDeclaration(decl *ast.DirectorDeclaration) *De
 
 // Format table declaration
 func (f *Formatter) formatTableDeclaration(decl *ast.TableDeclaration) *Declaration {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	buf.WriteString("table " + decl.Name.String())
 	if decl.ValueType != nil {
 		buf.WriteString(" " + decl.ValueType.String())
@@ -291,8 +304,10 @@ func (f *Formatter) formatTableProperties(props []*ast.TableProperty) string {
 
 // Format penaltybox delclaration
 func (f *Formatter) formatPenaltyboxDeclaration(decl *ast.PenaltyboxDeclaration) *Declaration {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	buf.WriteString("penaltybox " + decl.Name.String())
 	buf.WriteString(" {")
 	// penaltybox does not have properties
@@ -312,8 +327,10 @@ func (f *Formatter) formatPenaltyboxDeclaration(decl *ast.PenaltyboxDeclaration)
 
 // Format ratecounter delclaration
 func (f *Formatter) formatRatecounterDeclaration(decl *ast.RatecounterDeclaration) *Declaration {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	buf.WriteString("ratecounter " + decl.Name.String())
 	buf.WriteString(" {")
 	// ratecounter does not have properties
@@ -333,8 +350,10 @@ func (f *Formatter) formatRatecounterDeclaration(decl *ast.RatecounterDeclaratio
 
 // Format subroutine declaration
 func (f *Formatter) formatSubroutineDeclaration(decl *ast.SubroutineDeclaration) *Declaration {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	buf.WriteString("sub " + decl.Name.String() + " ")
 	// Functional Subroutine
 	if decl.ReturnType != nil {

--- a/formatter/expression_format.go
+++ b/formatter/expression_format.go
@@ -129,8 +129,10 @@ func (f *Formatter) formatInfixExpression(expr *ast.InfixExpression) *ChunkBuffe
 
 // Format prefix expression like `if(req.http.Foo, "foo", "bar")`
 func (f *Formatter) formatIfExpression(expr *ast.IfExpression) string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	buf.WriteString("if(")
 	buf.WriteString(f.formatExpression(expr.Condition).String())
 	buf.WriteString(", ")
@@ -155,8 +157,10 @@ func (f *Formatter) formatGroupedExpression(expr *ast.GroupedExpression) *ChunkB
 
 // Format function call expression like `regsuball(req.http.Foo, ".*", "$1")`
 func (f *Formatter) formatFunctionCallExpression(expr *ast.FunctionCallExpression) string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	buf.WriteString(expr.Function.Value + "(")
 	for i, arg := range expr.Arguments {
 		buf.WriteString(f.formatExpression(arg).String())

--- a/formatter/helper.go
+++ b/formatter/helper.go
@@ -64,7 +64,7 @@ func isInlineComment(comments ast.Comments) bool {
 }
 
 // Get latest line offset (character length) from current buffer
-func getLineOffset(b bytes.Buffer) int {
+func getLineOffset(b *bytes.Buffer) int {
 	s := b.String()
 	if p := strings.LastIndex(s, "\n"); p >= 0 {
 		return len(s[p:])
@@ -74,8 +74,10 @@ func getLineOffset(b bytes.Buffer) int {
 
 // Format multiple line chunk string with specified indent
 func formatChunkedString(chunk, indent string) string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	for _, line := range strings.Split(chunk, "\n") {
 		buf.WriteString(indent + strings.TrimSpace(line) + "\n")
 	}

--- a/formatter/lines.go
+++ b/formatter/lines.go
@@ -21,8 +21,10 @@ type Line struct {
 
 // Get Line string
 func (l Line) String() string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	buf.WriteString(l.Leading)
 	buf.WriteString(l.Buffer)
 	buf.WriteString(l.Trailing)
@@ -53,8 +55,10 @@ func (l Lines) Align() {
 
 // Implements Alignable interface
 func (l Lines) String() string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	for i := range l {
 		buf.WriteString(l[i].String())
 		buf.WriteString("\n")
@@ -63,7 +67,7 @@ func (l Lines) String() string {
 	return buf.String()
 }
 
-// Check satisfieng Alignable interface
+// Check satisfying Alignable interface
 var _ Alignable = (*Lines)(nil)
 
 // DelclarationPropertyLine represents a single line of declaration properties.
@@ -140,8 +144,10 @@ func (l DelclarationPropertyLines) Align() {
 
 // Implement Alignable interface
 func (l DelclarationPropertyLines) String() string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	for i := range l {
 		buf.WriteString(l[i].Leading)
 		v := l[i].Key
@@ -161,7 +167,7 @@ func (l DelclarationPropertyLines) String() string {
 	return buf.String()
 }
 
-// Check satisfieng Alignable interface
+// Check satisfying Alignable interface
 var _ Alignable = (*DelclarationPropertyLines)(nil)
 
 // GroupedLines represents grouped lines
@@ -188,8 +194,10 @@ func (g *GroupedLines) Align() {
 
 // GroupedLines also satisfies Alignable interface
 func (g *GroupedLines) String() string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	for i := range g.Lines {
 		buf.WriteString(g.Lines[i].String())
 		if i != len(g.Lines)-1 {

--- a/formatter/statement_format.go
+++ b/formatter/statement_format.go
@@ -95,8 +95,10 @@ func (f *Formatter) formatStatement(stmt ast.Statement) *Line {
 
 // Format import statement
 func (f *Formatter) formatImportStatement(stmt *ast.ImportStatement) string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	buf.WriteString("import ")
 	buf.WriteString(stmt.Name.String())
 	buf.WriteString(";")
@@ -106,8 +108,10 @@ func (f *Formatter) formatImportStatement(stmt *ast.ImportStatement) string {
 
 // Format include statement
 func (f *Formatter) formatIncludeStatement(stmt *ast.IncludeStatement) string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	buf.WriteString("include ")
 	buf.WriteString(stmt.Module.String())
 	buf.WriteString(";")
@@ -136,7 +140,10 @@ func (f *Formatter) formatBlockStatement(stmt *ast.BlockStatement) string {
 		group.Align()
 	}
 
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
+
+	buf.Reset()
 	buf.WriteString("{\n")
 	buf.WriteString(group.String())
 	if len(stmt.Infix) > 0 {
@@ -151,8 +158,10 @@ func (f *Formatter) formatBlockStatement(stmt *ast.BlockStatement) string {
 
 // Format delclare local varialbe statement
 func (f *Formatter) formatDeclareStatement(stmt *ast.DeclareStatement) string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	buf.WriteString("declare ")
 	if v := f.formatComment(stmt.Infix, " ", 0); v != "" {
 		buf.WriteString(v)
@@ -166,8 +175,10 @@ func (f *Formatter) formatDeclareStatement(stmt *ast.DeclareStatement) string {
 
 // Format set statement
 func (f *Formatter) formatSetStatement(stmt *ast.SetStatement) string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	buf.WriteString("set " + stmt.Ident.String())
 	buf.WriteString(" " + stmt.Operator.Operator + " ")
 	buf.WriteString(f.formatExpression(stmt.Value).ChunkedString(stmt.Nest, buf.Len()))
@@ -178,8 +189,10 @@ func (f *Formatter) formatSetStatement(stmt *ast.SetStatement) string {
 
 // Format unset statement
 func (f *Formatter) formatUnsetStatement(stmt *ast.UnsetStatement) string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	buf.WriteString("unset " + stmt.Ident.String())
 	buf.WriteString(";")
 
@@ -188,7 +201,10 @@ func (f *Formatter) formatUnsetStatement(stmt *ast.UnsetStatement) string {
 
 // Format remove statement.
 func (f *Formatter) formatRemoveStatement(stmt *ast.RemoveStatement) string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
+
+	buf.Reset()
 
 	// The "remove" statement is alias of "unset" statement,
 	// so it could replaced to unset by configuration
@@ -204,8 +220,10 @@ func (f *Formatter) formatRemoveStatement(stmt *ast.RemoveStatement) string {
 
 // Format if statement
 func (f *Formatter) formatIfStatement(stmt *ast.IfStatement) string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	buf.WriteString(stmt.Keyword)
 	if v := f.formatComment(stmt.Infix, "", 0); v != "" {
 		buf.WriteString(" " + v)
@@ -309,8 +327,10 @@ func (f *Formatter) formatIfStatement(stmt *ast.IfStatement) string {
 
 // Format switch statement
 func (f *Formatter) formatSwitchStatement(stmt *ast.SwitchStatement) string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	buf.WriteString("switch ")
 	buf.WriteString(strings.TrimSpace(stmt.Control.String()))
 	buf.WriteString(" {\n")
@@ -370,15 +390,6 @@ func (f *Formatter) formatCaseSectionStatements(cs *ast.CaseStatement) string {
 		// need to plus 1 to  nested indent because parser won't increase nest level
 		stmt.GetMeta().Nest++
 		line := f.formatStatement(stmt)
-		// line := &Line{
-		// 	Leading:  f.formatComment(stmt.GetMeta().Leading, "\n", meta.Nest+1),
-		// 	Trailing: f.formatComment(stmt.GetMeta().Trailing, "\n", meta.Nest+1),
-		// }
-		// if _, ok := stmt.(*ast.BreakStatement); ok {
-		// 	line.Buffer = f.indent(meta.Nest+1) + "break;"
-		// } else {
-		// 	line.Buffer = f.formatStatement(stmt).String()
-		// }
 		lines = append(lines, line)
 	}
 
@@ -390,20 +401,15 @@ func (f *Formatter) formatCaseSectionStatements(cs *ast.CaseStatement) string {
 		group.Align()
 	}
 
-	var buf bytes.Buffer
-	buf.WriteString(group.String())
-	// if cs.Fallthrough {
-	// 	buf.WriteString(f.indent(cs.Meta.Nest + 1))
-	// 	buf.WriteString("fallthrough;")
-	// }
-
-	return trimMutipleLineFeeds(buf.String())
+	return trimMutipleLineFeeds(group.String())
 }
 
 // Format break statement
 func (f *Formatter) formatBreakStatement(stmt *ast.BreakStatement) string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	buf.WriteString("break")
 	if v := f.formatComment(stmt.Infix, "", 0); v != "" {
 		buf.WriteString(" " + v)
@@ -415,8 +421,10 @@ func (f *Formatter) formatBreakStatement(stmt *ast.BreakStatement) string {
 
 // Format fallthrough statement
 func (f *Formatter) formatFallthroughStatement(stmt *ast.FallthroughStatement) string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	buf.WriteString("fallthrough")
 	if v := f.formatComment(stmt.Infix, "", 0); v != "" {
 		buf.WriteString(" " + v)
@@ -428,8 +436,10 @@ func (f *Formatter) formatFallthroughStatement(stmt *ast.FallthroughStatement) s
 
 // Format restart statement
 func (f *Formatter) formatRestartStatement(stmt *ast.RestartStatement) string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	buf.WriteString("restart")
 	if v := f.formatComment(stmt.Infix, "", 0); v != "" {
 		buf.WriteString(" " + v)
@@ -441,8 +451,10 @@ func (f *Formatter) formatRestartStatement(stmt *ast.RestartStatement) string {
 
 // Format esi statement
 func (f *Formatter) formatEsiStatement(stmt *ast.EsiStatement) string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	buf.WriteString("esi")
 	if v := f.formatComment(stmt.Infix, "", 0); v != "" {
 		buf.WriteString(" " + v)
@@ -454,8 +466,10 @@ func (f *Formatter) formatEsiStatement(stmt *ast.EsiStatement) string {
 
 // Format add statement
 func (f *Formatter) formatAddStatement(stmt *ast.AddStatement) string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	buf.WriteString("add " + stmt.Ident.String())
 	buf.WriteString(" " + stmt.Operator.Operator + " ")
 	buf.WriteString(f.formatExpression(stmt.Value).ChunkedString(stmt.Nest, buf.Len()))
@@ -466,8 +480,10 @@ func (f *Formatter) formatAddStatement(stmt *ast.AddStatement) string {
 
 // Format call statement
 func (f *Formatter) formatCallStatement(stmt *ast.CallStatement) string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	buf.WriteString("call " + stmt.Subroutine.String())
 	buf.WriteString(";")
 
@@ -476,8 +492,10 @@ func (f *Formatter) formatCallStatement(stmt *ast.CallStatement) string {
 
 // Fromat error statement
 func (f *Formatter) formatErrorStatement(stmt *ast.ErrorStatement) string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	buf.WriteString("error " + stmt.Code.String())
 	// argument is arbitrary
 	if stmt.Argument != nil {
@@ -490,8 +508,10 @@ func (f *Formatter) formatErrorStatement(stmt *ast.ErrorStatement) string {
 
 // Format log statement
 func (f *Formatter) formatLogStatement(stmt *ast.LogStatement) string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	buf.WriteString("log ")
 	buf.WriteString(f.formatExpression(stmt.Value).ChunkedString(stmt.Nest, buf.Len()))
 	buf.WriteString(";")
@@ -501,8 +521,10 @@ func (f *Formatter) formatLogStatement(stmt *ast.LogStatement) string {
 
 // Format return statement
 func (f *Formatter) formatReturnStatement(stmt *ast.ReturnStatement) string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	buf.WriteString("return")
 	if stmt.ReturnExpression != nil {
 		if v := f.formatComment(stmt.ParenthesisLeadingComments, "", 0); v != "" {
@@ -535,8 +557,10 @@ func (f *Formatter) formatReturnStatement(stmt *ast.ReturnStatement) string {
 
 // Format synthetic statement
 func (f *Formatter) formatSyntheticStatement(stmt *ast.SyntheticStatement) string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	buf.WriteString("synthetic ")
 	buf.WriteString(f.formatExpression(stmt.Value).ChunkedString(stmt.Nest, buf.Len()))
 	buf.WriteString(";")
@@ -546,8 +570,10 @@ func (f *Formatter) formatSyntheticStatement(stmt *ast.SyntheticStatement) strin
 
 // Format synthetic.base64 statement
 func (f *Formatter) formatSyntheticBase64Statement(stmt *ast.SyntheticBase64Statement) string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	buf.WriteString("synthetic.base64 ")
 	buf.WriteString(f.formatExpression(stmt.Value).ChunkedString(stmt.Nest, buf.Len()))
 	buf.WriteString(";")
@@ -557,8 +583,10 @@ func (f *Formatter) formatSyntheticBase64Statement(stmt *ast.SyntheticBase64Stat
 
 // Format goto statement
 func (f *Formatter) formatGotoStatement(stmt *ast.GotoStatement) string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	buf.WriteString("goto " + stmt.Destination.String())
 	buf.WriteString(";")
 
@@ -567,8 +595,10 @@ func (f *Formatter) formatGotoStatement(stmt *ast.GotoStatement) string {
 
 // Format goto destination statement
 func (f *Formatter) formatGotoDestinationStatement(stmt *ast.GotoDestinationStatement) string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	buf.WriteString(stmt.Name.Value)
 
 	return buf.String()
@@ -576,8 +606,10 @@ func (f *Formatter) formatGotoDestinationStatement(stmt *ast.GotoDestinationStat
 
 // Format function calling statement
 func (f *Formatter) formatFunctionCallStatement(stmt *ast.FunctionCallStatement) string {
-	var buf bytes.Buffer
+	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
+	defer bufferPool.Put(buf)
 
+	buf.Reset()
 	buf.WriteString(stmt.Function.Value + "(")
 	length := buf.Len()
 	for i, a := range stmt.Arguments {


### PR DESCRIPTION
This PR improves formatter performance by using `sync.Pool`.

### Before

<img width="995" alt="CleanShot 2024-06-13 at 02 02 13@2x" src="https://github.com/ysugimoto/falco/assets/1000401/d8cb5efd-4b53-4921-9b62-4d22a5f2a013">

### After
<img width="1009" alt="CleanShot 2024-06-13 at 02 02 46@2x" src="https://github.com/ysugimoto/falco/assets/1000401/2a6c7126-c48d-4ede-93c9-2bb7ecdedc3b">
