### PR TITLE
Fix broken result message of tester and use exactly the same format for both passed and failed tests

### DIFF
--- a/cmd/falco/main.go
+++ b/cmd/falco/main.go
@@ -339,9 +339,9 @@ func runTest(runner *Runner, rslv resolver.Resolver) error {
 
 		for _, c := range r.Cases {
 			totalCount++
-      var prefix string
-				if c.Group != "" {
-					prefix = c.Group + " › "
+			var prefix string
+			if c.Group != "" {
+				prefix = c.Group + " › "
 			}
 			if c.Error != nil {
 				writeln(redBold, "%s● [%s] %s%s\n", indent(1), c.Scope, prefix, c.Name)

--- a/cmd/falco/main.go
+++ b/cmd/falco/main.go
@@ -339,11 +339,11 @@ func runTest(runner *Runner, rslv resolver.Resolver) error {
 
 		for _, c := range r.Cases {
 			totalCount++
-			if c.Error != nil {
-				var prefix string
+      var prefix string
 				if c.Group != "" {
 					prefix = c.Group + " › "
-				}
+			}
+			if c.Error != nil {
 				writeln(redBold, "%s● [%s] %s%s\n", indent(1), c.Scope, prefix, c.Name)
 				writeln(red, "%s%s", indent(2), c.Error.Error())
 				switch e := c.Error.(type) {
@@ -358,7 +358,7 @@ func runTest(runner *Runner, rslv resolver.Resolver) error {
 				writeln(white, "")
 				failedCount++
 			} else {
-				writeln(green, "%s✓ [%s] %s", indent(1), c.Scope, c.Name)
+				writeln(green, "%s✓ [%s] %s%s", indent(1), c.Scope, prefix, c.Name)
 				passedCount++
 			}
 		}

--- a/cmd/falco/main.go
+++ b/cmd/falco/main.go
@@ -344,7 +344,7 @@ func runTest(runner *Runner, rslv resolver.Resolver) error {
 				if c.Group != "" {
 					prefix = c.Group + " › "
 				}
-				writeln(redBold, "%s●  [%s] %s%s\n", indent(1), prefix, c.Scope, c.Name)
+				writeln(redBold, "%s● [%s] %s%s\n", indent(1), c.Scope, prefix, c.Name)
 				writeln(red, "%s%s", indent(2), c.Error.Error())
 				switch e := c.Error.(type) {
 				case *ife.AssertionError:

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -223,6 +223,7 @@ func (t *Tester) runDescribedTests(
 			err := i.ProcessTestSubroutine(s, sub)
 			cases = append(cases, &TestCase{
 				Name:  suite,
+        Group: d.Name.String(),
 				Error: errors.Cause(err),
 				Scope: s.String(),
 				Time:  time.Since(start).Milliseconds(),

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -223,7 +223,7 @@ func (t *Tester) runDescribedTests(
 			err := i.ProcessTestSubroutine(s, sub)
 			cases = append(cases, &TestCase{
 				Name:  suite,
-        Group: d.Name.String(),
+				Group: d.Name.String(),
 				Error: errors.Cause(err),
 				Scope: s.String(),
 				Time:  time.Since(start).Milliseconds(),


### PR DESCRIPTION
Hi, thank you very much for creating a great tool to help us work with VCL!

I've noticed that in result messages of tester,

1. `scope` is not placed in brackets `[]` of a failed test, which differs from passed one
2. `group` is not shown at all, while there is code to try to output it when a test fails

<img width="653" alt="Screenshot 2024-07-13 at 10 12 40 AM" src="https://github.com/user-attachments/assets/489d944f-ba8a-402b-ae01-6260b7e056a6">

This PR fixes the above issues and lets `falco` report group name of tests even when a test passes for consistency.

<img width="661" alt="Screenshot 2024-07-13 at 10 11 30 AM" src="https://github.com/user-attachments/assets/75ee10e6-10eb-4435-acc1-011445c87291">

