### PR TITLE
Add extra format check for backend.share_key

### DIFF
--- a/linter/declaration_linter.go
+++ b/linter/declaration_linter.go
@@ -97,6 +97,14 @@ func (l *Linter) lintBackendProperty(prop *ast.BackendProperty, ctx *context.Con
 		if kt != vt {
 			l.Error(InvalidType(prop.Value.GetMeta(), prop.Key.Value, kt, vt).Match(BACKEND_SYNTAX))
 		}
+
+    // share_key must consist of alphanumeric or ASCII characters
+    if prop.Key.Value == "share_key" {
+      v := prop.Value.(*ast.String).Value
+      if !isValidBackendShareKey(v) {
+        l.Error(InvalidValue(prop.Value.GetMeta(), "share_key", v).Match(BACKEND_SYNTAX))
+      }
+    }
 	}
 }
 

--- a/linter/declaration_linter.go
+++ b/linter/declaration_linter.go
@@ -98,13 +98,13 @@ func (l *Linter) lintBackendProperty(prop *ast.BackendProperty, ctx *context.Con
 			l.Error(InvalidType(prop.Value.GetMeta(), prop.Key.Value, kt, vt).Match(BACKEND_SYNTAX))
 		}
 
-    // share_key must consist of alphanumeric or ASCII characters
-    if prop.Key.Value == "share_key" {
-      v := prop.Value.(*ast.String).Value
-      if !isValidBackendShareKey(v) {
-        l.Error(InvalidValue(prop.Value.GetMeta(), "share_key", v).Match(BACKEND_SYNTAX))
-      }
-    }
+		// share_key must consist of alphanumeric or ASCII characters
+		if prop.Key.Value == "share_key" {
+			v := prop.Value.(*ast.String).Value
+			if !isValidBackendShareKey(v) {
+				l.Error(InvalidValue(prop.Value.GetMeta(), "share_key", v).Match(BACKEND_SYNTAX))
+			}
+		}
 	}
 }
 

--- a/linter/declaration_linter_test.go
+++ b/linter/declaration_linter_test.go
@@ -76,7 +76,7 @@ backend foo-bar {
 
 	t.Run("invalid type", func(t *testing.T) {
 		input := `
-backend foo-bar {
+backend foo {
   .host = 1s;
 }`
 		assertError(t, input)

--- a/linter/declaration_linter_test.go
+++ b/linter/declaration_linter_test.go
@@ -82,7 +82,7 @@ backend foo {
 		assertError(t, input)
 	})
 
-  t.Run("invalid share_key", func(t *testing.T) {
+	t.Run("invalid share_key", func(t *testing.T) {
 		input := `
 backend foo {
   .share_key = "example.com";

--- a/linter/declaration_linter_test.go
+++ b/linter/declaration_linter_test.go
@@ -60,7 +60,7 @@ backend foo {
     .request = "GET / HTTP/1.1";
     .threshold = 1;
     .timeout = 2s;
-    .window = 4; 
+    .window = 4;
   }
 }`
 		assertNoError(t, input)
@@ -78,6 +78,14 @@ backend foo-bar {
 		input := `
 backend foo {
   .host = 1s;
+}`
+		assertError(t, input)
+	})
+
+  t.Run("invalid share_key", func(t *testing.T) {
+		input := `
+backend foo {
+  .share_key = "example.com";
 }`
 		assertError(t, input)
 	})

--- a/linter/helper.go
+++ b/linter/helper.go
@@ -111,13 +111,13 @@ var DirectorPropertyTypes = map[string]DirectorProps{
 }
 
 func isAlphaNumeric(r rune) bool {
-	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_'
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
 }
 
 // isValidName validates ident name has only [0-9a-zA-Z_]+
 func isValidName(name string) bool {
 	for _, r := range name {
-		if isAlphaNumeric(r) {
+		if isAlphaNumeric(r) || r == '_'{
 			continue
 		}
 		return false
@@ -128,7 +128,7 @@ func isValidName(name string) bool {
 // isValidVariableName validates ident name has only [0-9a-zA-Z_\.-:]+
 func isValidVariableName(name string) bool {
 	for _, r := range name {
-		if isAlphaNumeric(r) || r == '.' || r == '-' || r == ':' {
+		if isAlphaNumeric(r) || r == '_' || r == '.' || r == '-' || r == ':' {
 			continue
 		}
 		return false
@@ -446,6 +446,17 @@ func hasFastlyBoilerPlateMacro(cs ast.Comments, phrase string) bool {
 		}
 	}
 	return false
+}
+
+// According to fastly share_key must be alphanumeric and ASCII only
+func isValidBackendShareKey(shareKey string) bool {
+  for _, c := range shareKey {
+    if isAlphaNumeric(c) {
+      continue
+    }
+    return false
+  }
+  return true
 }
 
 // According to fastly if a prober is configured with initial < threshold

--- a/linter/helper.go
+++ b/linter/helper.go
@@ -117,7 +117,7 @@ func isAlphaNumeric(r rune) bool {
 // isValidName validates ident name has only [0-9a-zA-Z_]+
 func isValidName(name string) bool {
 	for _, r := range name {
-		if isAlphaNumeric(r) || r == '_'{
+		if isAlphaNumeric(r) || r == '_' {
 			continue
 		}
 		return false
@@ -450,13 +450,13 @@ func hasFastlyBoilerPlateMacro(cs ast.Comments, phrase string) bool {
 
 // According to fastly share_key must be alphanumeric and ASCII only
 func isValidBackendShareKey(shareKey string) bool {
-  for _, c := range shareKey {
-    if isAlphaNumeric(c) {
-      continue
-    }
-    return false
-  }
-  return true
+	for _, c := range shareKey {
+		if isAlphaNumeric(c) {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 // According to fastly if a prober is configured with initial < threshold


### PR DESCRIPTION
According to fastly, `backend.share_key` must be alphanumeric and ASCII only as in an error message shown below returned from their server.

```
Syntax error: `.share_key` must be alphanumeric and ASCII only
at: (input Line 48 Pos 16)
  .share_key = "nodaguti-test.storage.googleapis.com";
---------------######################################-
```

Thus this PR introduces new check to linter so that `backend.share_key` will not contain any invalid characters.