### PR TITLE
Set exit code to 1 when there are one or more lint errors

### DIFF
--- a/cmd/falco/main.go
+++ b/cmd/falco/main.go
@@ -204,25 +204,25 @@ func runLint(runner *Runner, rslv resolver.Resolver) error {
 	write(yellow, ":exclamation:%d warnings, ", result.Warnings)
 	writeln(cyan, ":speaker:%d recommendations.", result.Infos)
 
-  if result.Errors > 0 {
-    return ErrExit
-  }
+	if result.Errors > 0 {
+		return ErrExit
+	}
 
 	// Display message corresponds to runner result
-  switch {
-  case result.Warnings > 0:
-    writeln(white, "VCL lint warnings encountered, but things should run OK :thumbsup:")
-    if runner.level < LevelWarning {
-      writeln(white, "Run command with the -v option to output warnings.")
-    }
-  case result.Infos > 0:
-    writeln(green, "VCL looks good :sparkles: Some recommendations are available :thumbsup:")
-    if runner.level < LevelInfo {
-      writeln(white, "Run command with the -vv option to output recommendations.")
-    }
-  default:
-    writeln(green, "VCL looks great :sparkles:")
-  }
+	switch {
+	case result.Warnings > 0:
+		writeln(white, "VCL lint warnings encountered, but things should run OK :thumbsup:")
+		if runner.level < LevelWarning {
+			writeln(white, "Run command with the -v option to output warnings.")
+		}
+	case result.Infos > 0:
+		writeln(green, "VCL looks good :sparkles: Some recommendations are available :thumbsup:")
+		if runner.level < LevelInfo {
+			writeln(white, "Run command with the -vv option to output recommendations.")
+		}
+	default:
+		writeln(green, "VCL looks great :sparkles:")
+	}
 
 	return nil
 }

--- a/cmd/falco/main.go
+++ b/cmd/falco/main.go
@@ -204,23 +204,25 @@ func runLint(runner *Runner, rslv resolver.Resolver) error {
 	write(yellow, ":exclamation:%d warnings, ", result.Warnings)
 	writeln(cyan, ":speaker:%d recommendations.", result.Infos)
 
+  if result.Errors > 0 {
+    return ErrExit
+  }
+
 	// Display message corresponds to runner result
-	if result.Errors == 0 {
-		switch {
-		case result.Warnings > 0:
-			writeln(white, "VCL lint warnings encountered, but things should run OK :thumbsup:")
-			if runner.level < LevelWarning {
-				writeln(white, "Run command with the -v option to output warnings.")
-			}
-		case result.Infos > 0:
-			writeln(green, "VCL looks good :sparkles: Some recommendations are available :thumbsup:")
-			if runner.level < LevelInfo {
-				writeln(white, "Run command with the -vv option to output recommendations.")
-			}
-		default:
-			writeln(green, "VCL looks great :sparkles:")
-		}
-	}
+  switch {
+  case result.Warnings > 0:
+    writeln(white, "VCL lint warnings encountered, but things should run OK :thumbsup:")
+    if runner.level < LevelWarning {
+      writeln(white, "Run command with the -v option to output warnings.")
+    }
+  case result.Infos > 0:
+    writeln(green, "VCL looks good :sparkles: Some recommendations are available :thumbsup:")
+    if runner.level < LevelInfo {
+      writeln(white, "Run command with the -vv option to output recommendations.")
+    }
+  default:
+    writeln(green, "VCL looks great :sparkles:")
+  }
 
 	return nil
 }


### PR DESCRIPTION
The current linter quits with exit code `0` even when there are some errors. This behaviour is not very useful especially when you are using `falco lint` in your CI because without special cares of `[ERROR]` messages a lint job will pass regardless of number of errors reported.

This PR changes the exit code to `1` when the linter reports one or more errors.

There might be another discussion whether the exit code should also reflect number of warnings and recommendations. In my opinion, providing similar options to [ESLint's `--max-warnings`](https://eslint.org/docs/latest/use/command-line-interface#--max-warnings) would be nice, i.e., adding `--max-warnings` and `--max-infos` to set warning and recommendation thresholds respectively. (I will work on this if you agree with this idea.)