### PR TITLE
Add feature to disable only specific lint rules with `ignore` comment

### DIFF
--- a/docs/linter.md
+++ b/docs/linter.md
@@ -135,6 +135,10 @@ sub vcl_recv {
 
   // falco-ignore-next-line
   set req.http.Example = some.undefined.variable;
+
+  // You can disable specific rules only
+  // falco-ignore-next-line function/arguments, function/argument-type
+  set req.http.foo = std.itoa(req.http.bar) + std.itoa(0, 1, 2);
 }
 ```
 
@@ -147,6 +151,9 @@ sub vcl_recv {
   # FASTLY RECV
 
   set req.http.Example = some.undefined.variable; // falco-ignore
+
+  // You can disable specific rules only
+  set req.http.foo = std.itoa(req.http.bar) + std.itoa(0, 1, 2); // falco-ignore function/arguments, function/argument-type
 }
 ```
 
@@ -162,6 +169,18 @@ sub vcl_recv {
   set req.http.Example = some.undefined.variable;
   // falco-igore-end
 
+  // You can disable specific rules only
+  // falco-ignore-start function/arguments, function/argument-type
+  set req.http.foo = std.itoa(req.http.bar) + std.itoa(0, 1, 2);
+  // falco-ignore-end function/arguments, function/argument-type
+
+  // Note that falco-ignore-end without rule names specified re-enables all rules
+  // falco-ignore-start function/arguments
+  set req.http.foo = std.itoa(0, 1, 2);
+  // falco-ignore-start function/argument-type
+  set req.http.foo = std.itoa(req.http.bar);
+  // falco-ignore-end
+  // Now both function/arguments and function/argument-type are enabled again.
 }
 ```
 

--- a/linter/ignore.go
+++ b/linter/ignore.go
@@ -76,7 +76,7 @@ func parseIgnoreComment(comment string) (string, []Rule) {
 	var rules []Rule
 	for _, r := range strings.Split(body, ",") {
 		trimmed := strings.TrimSpace(r)
-		if len(trimmed) != 0 {
+		if trimmed != "" {
 			rules = append(rules, Rule(trimmed))
 		}
 	}
@@ -107,8 +107,8 @@ func (i *ignore) SetupStatement(meta *ast.Meta) {
 
 	// Find ignore signature in trailing comments
 	for _, c := range meta.Trailing {
-		switch ignoreType, rules := parseIgnoreComment(c.String()); ignoreType {
-		case falcoIgnoreThisLine:
+		ignoreType, rules := parseIgnoreComment(c.String())
+		if ignoreType == falcoIgnoreThisLine {
 			ignoreRules(&i.ignoreThisLine, rules)
 		}
 	}
@@ -117,15 +117,15 @@ func (i *ignore) SetupStatement(meta *ast.Meta) {
 // Clean up common statements, declarations
 func (i *ignore) TeardownStatement(meta *ast.Meta) {
 	for _, c := range meta.Leading {
-		switch ignoreType, rules := parseIgnoreComment(c.String()); ignoreType {
-		case falcoIgnoreNextLine:
+		ignoreType, rules := parseIgnoreComment(c.String())
+		if ignoreType == falcoIgnoreNextLine {
 			unignoreRules(&i.ignoreNextLine, rules)
 		}
 	}
 
 	for _, c := range meta.Trailing {
-		switch ignoreType, rules := parseIgnoreComment(c.String()); ignoreType {
-		case falcoIgnoreThisLine:
+		ignoreType, rules := parseIgnoreComment(c.String())
+		if ignoreType == falcoIgnoreThisLine {
 			unignoreRules(&i.ignoreThisLine, rules)
 		}
 	}
@@ -156,8 +156,8 @@ func (i *ignore) SetupBlockStatement(meta *ast.Meta) {
 }
 func (i *ignore) TeardownBlockStatement(meta *ast.Meta) {
 	for _, c := range meta.Leading {
-		switch ignoreType, rules := parseIgnoreComment(c.String()); ignoreType {
-		case falcoIgnoreNextLine:
+		ignoreType, rules := parseIgnoreComment(c.String())
+		if ignoreType == falcoIgnoreNextLine {
 			unignoreRules(&i.ignoreNextLine, rules)
 		}
 	}
@@ -173,5 +173,10 @@ func (i *ignore) TeardownBlockStatement(meta *ast.Meta) {
 }
 
 func (i *ignore) IsEnable(rule Rule) bool {
-	return i.ignoreNextLine.all || i.ignoreThisLine.all || i.ignoreRange.all || i.ignoreNextLine.rules[rule] || i.ignoreThisLine.rules[rule] || i.ignoreRange.rules[rule]
+	return i.ignoreNextLine.all ||
+		i.ignoreThisLine.all ||
+		i.ignoreRange.all ||
+		i.ignoreNextLine.rules[rule] ||
+		i.ignoreThisLine.rules[rule] ||
+		i.ignoreRange.rules[rule]
 }

--- a/linter/ignore.go
+++ b/linter/ignore.go
@@ -1,6 +1,7 @@
 package linter
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/ysugimoto/falco/ast"
@@ -15,9 +16,66 @@ const (
 )
 
 type ignore struct {
-	ignoreNextLine bool
-	ignoreThisLine bool
-	ignoreRange    bool
+	ignoreNextLine ignoredRules
+	ignoreThisLine ignoredRules
+	ignoreRange    ignoredRules
+}
+
+type ignoredRules struct {
+	all   bool
+	rules map[Rule]bool
+}
+
+func ignoreRules(ignoredRules *ignoredRules, rules []Rule) {
+	ignoreAllRules := len(rules) == 0
+
+	if ignoreAllRules {
+		ignoredRules.all = true
+		ignoredRules.rules = make(map[Rule]bool)
+		return
+	}
+
+	ignoredRules.all = false
+	if ignoredRules.rules == nil {
+		ignoredRules.rules = make(map[Rule]bool)
+	}
+	for _, r := range rules {
+		ignoredRules.rules[r] = true
+	}
+}
+
+func unignoreRules(ignoredRules *ignoredRules, rules []Rule) {
+	unignoreAllRules := len(rules) == 0
+
+	if unignoreAllRules {
+		ignoredRules.all = false
+		ignoredRules.rules = make(map[Rule]bool)
+		return
+	}
+
+	ignoredRules.all = false
+	for _, r := range rules {
+		delete(ignoredRules.rules, r)
+	}
+}
+
+func parseIgnoreComment(comment string) (string, []Rule) {
+	body := strings.TrimLeft(comment, "#@*/ ")
+	ignoreType, body, _ := strings.Cut(body, " ")
+
+	if ignoreType != falcoIgnoreNextLine && ignoreType != falcoIgnoreThisLine && ignoreType != falcoIgnoreStart && ignoreType != falcoIgnoreEnd {
+		return "", []Rule{}
+	}
+
+	var rules []Rule
+	for _, r := range regexp.MustCompile(`\s*,\s*`).Split(body, -1) {
+		trimmed := strings.TrimSpace(r)
+		if len(trimmed) != 0 {
+			rules = append(rules, Rule(trimmed))
+		}
+	}
+
+	return ignoreType, rules
 }
 
 // Setup ignores for common statements, declarations.
@@ -31,30 +89,40 @@ type ignore struct {
 func (i *ignore) SetupStatement(meta *ast.Meta) {
 	// Find ignore signature in leading comments
 	for _, c := range meta.Leading {
-		line := strings.TrimLeft(c.String(), "#@*/ ")
-		switch {
-		case strings.HasPrefix(line, falcoIgnoreNextLine):
-			i.ignoreNextLine = true
-		case strings.HasPrefix(line, falcoIgnoreStart):
-			i.ignoreRange = true
-		case strings.HasPrefix(line, falcoIgnoreEnd):
-			i.ignoreRange = false
+		switch ignoreType, rules := parseIgnoreComment(c.String()); ignoreType {
+		case falcoIgnoreNextLine:
+			ignoreRules(&i.ignoreNextLine, rules)
+		case falcoIgnoreStart:
+			ignoreRules(&i.ignoreRange, rules)
+		case falcoIgnoreEnd:
+			unignoreRules(&i.ignoreRange, rules)
 		}
 	}
 
 	// Find ignore signature in trailing comments
 	for _, c := range meta.Trailing {
-		line := strings.TrimLeft(c.String(), "#@*/ ")
-		if strings.HasPrefix(line, falcoIgnoreThisLine) {
-			i.ignoreThisLine = true
+		switch ignoreType, rules := parseIgnoreComment(c.String()); ignoreType {
+		case falcoIgnoreThisLine:
+			ignoreRules(&i.ignoreThisLine, rules)
 		}
 	}
 }
 
 // Clean up common statements, declarations
-func (i *ignore) TeardownStatement() {
-	i.ignoreNextLine = false
-	i.ignoreThisLine = false
+func (i *ignore) TeardownStatement(meta *ast.Meta) {
+	for _, c := range meta.Leading {
+		switch ignoreType, rules := parseIgnoreComment(c.String()); ignoreType {
+		case falcoIgnoreNextLine:
+			unignoreRules(&i.ignoreNextLine, rules)
+		}
+	}
+
+	for _, c := range meta.Trailing {
+		switch ignoreType, rules := parseIgnoreComment(c.String()); ignoreType {
+		case falcoIgnoreThisLine:
+			unignoreRules(&i.ignoreThisLine, rules)
+		}
+	}
 }
 
 // Block statement is special, the comment placing is following:
@@ -70,29 +138,34 @@ func (i *ignore) TeardownStatement() {
 // So we need to divide parsing leading and trailing comment by setup and teardown
 func (i *ignore) SetupBlockStatement(meta *ast.Meta) {
 	for _, c := range meta.Leading {
-		line := strings.TrimLeft(c.String(), "#@*/ ")
-		switch {
-		case strings.HasPrefix(line, falcoIgnoreNextLine):
-			i.ignoreNextLine = true
-		case strings.HasPrefix(line, falcoIgnoreStart):
-			i.ignoreRange = true
-		case strings.HasPrefix(line, falcoIgnoreEnd):
-			i.ignoreRange = false
+		switch ignoreType, rules := parseIgnoreComment(c.String()); ignoreType {
+		case falcoIgnoreNextLine:
+			ignoreRules(&i.ignoreNextLine, rules)
+		case falcoIgnoreStart:
+			ignoreRules(&i.ignoreRange, rules)
+		case falcoIgnoreEnd:
+			unignoreRules(&i.ignoreRange, rules)
 		}
 	}
 }
 func (i *ignore) TeardownBlockStatement(meta *ast.Meta) {
-	i.ignoreNextLine = false
-	i.ignoreThisLine = false
+	for _, c := range meta.Leading {
+		switch ignoreType, rules := parseIgnoreComment(c.String()); ignoreType {
+		case falcoIgnoreNextLine:
+			unignoreRules(&i.ignoreNextLine, rules)
+		}
+	}
 
 	for _, c := range meta.Trailing {
-		line := strings.TrimLeft(c.String(), "#@*/ ")
-		if strings.HasPrefix(line, falcoIgnoreEnd) {
-			i.ignoreRange = false
+		switch ignoreType, rules := parseIgnoreComment(c.String()); ignoreType {
+		case falcoIgnoreThisLine:
+			unignoreRules(&i.ignoreThisLine, rules)
+		case falcoIgnoreEnd:
+			unignoreRules(&i.ignoreRange, rules)
 		}
 	}
 }
 
-func (i *ignore) IsEnable() bool {
-	return i.ignoreNextLine || i.ignoreThisLine || i.ignoreRange
+func (i *ignore) IsEnable(rule Rule) bool {
+	return i.ignoreNextLine.all || i.ignoreThisLine.all || i.ignoreRange.all || i.ignoreNextLine.rules[rule] || i.ignoreThisLine.rules[rule] || i.ignoreRange.rules[rule]
 }

--- a/linter/ignore.go
+++ b/linter/ignore.go
@@ -1,7 +1,6 @@
 package linter
 
 import (
-	"regexp"
 	"strings"
 
 	"github.com/ysugimoto/falco/ast"
@@ -75,7 +74,7 @@ func parseIgnoreComment(comment string) (string, []Rule) {
 	}
 
 	var rules []Rule
-	for _, r := range regexp.MustCompile(`\s*,\s*`).Split(body, -1) {
+	for _, r := range strings.Split(body, ",") {
 		trimmed := strings.TrimSpace(r)
 		if len(trimmed) != 0 {
 			rules = append(rules, Rule(trimmed))

--- a/linter/ignore.go
+++ b/linter/ignore.go
@@ -15,10 +15,10 @@ const (
 )
 
 var supportedIgnoreTypes = map[string]bool{
-  falcoIgnoreNextLine: true,
-  falcoIgnoreThisLine: true,
-  falcoIgnoreStart:    true,
-  falcoIgnoreEnd:      true,
+	falcoIgnoreNextLine: true,
+	falcoIgnoreThisLine: true,
+	falcoIgnoreStart:    true,
+	falcoIgnoreEnd:      true,
 }
 
 type ignore struct {

--- a/linter/ignore.go
+++ b/linter/ignore.go
@@ -15,6 +15,13 @@ const (
 	falcoIgnoreEnd      = "falco-ignore-end"
 )
 
+var supportedIgnoreTypes = map[string]bool{
+  falcoIgnoreNextLine: true,
+  falcoIgnoreThisLine: true,
+  falcoIgnoreStart:    true,
+  falcoIgnoreEnd:      true,
+}
+
 type ignore struct {
 	ignoreNextLine ignoredRules
 	ignoreThisLine ignoredRules
@@ -63,7 +70,7 @@ func parseIgnoreComment(comment string) (string, []Rule) {
 	body := strings.TrimLeft(comment, "#@*/ ")
 	ignoreType, body, _ := strings.Cut(body, " ")
 
-	if ignoreType != falcoIgnoreNextLine && ignoreType != falcoIgnoreThisLine && ignoreType != falcoIgnoreStart && ignoreType != falcoIgnoreEnd {
+	if supported, ok := supportedIgnoreTypes[ignoreType]; !ok || !supported {
 		return "", []Rule{}
 	}
 

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -41,7 +41,7 @@ func (l *Linter) Lexers() map[string]*lexer.Lexer {
 
 func (l *Linter) Error(err error) {
 	if le, ok := err.(*LintError); ok {
-		if !l.ignore.IsEnable() {
+		if !l.ignore.IsEnable(le.Rule) {
 			l.Errors = append(l.Errors, le)
 		}
 	} else {
@@ -300,7 +300,7 @@ func (l *Linter) lintVCL(vcl *ast.VCL, ctx *context.Context) types.Type {
 func (l *Linter) lintStatement(s ast.Statement, ctx *context.Context) {
 	// Any statements may have ignoring comments so we do setup and teardown
 	l.ignore.SetupStatement(s.GetMeta())
-	defer l.ignore.TeardownStatement()
+	defer l.ignore.TeardownStatement(s.GetMeta())
 	l.lint(s, ctx)
 }
 

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -704,6 +704,27 @@ sub vcl_recv {
 	assertNoError(t, input)
 }
 
+func TestIgnoreErrorNextLineWithRuleSpecified(t *testing.T) {
+	input := `
+sub vcl_recv {
+   #FASTLY RECV
+   # function/arguments is ignored, but there is also a function/argument-type error
+   # falco-ignore-next-line function/arguments
+   set req.http.foo = std.itoa(req.http.bar) + std.itoa(0, 1, 2);
+}`
+	assertError(t, input)
+}
+
+func TestIgnoreErrorNextLineWithMultipleRulesSpecified(t *testing.T) {
+	input := `
+sub vcl_recv {
+   #FASTLY RECV
+   # falco-ignore-next-line function/arguments, function/argument-type
+   set req.http.foo = std.itoa(req.http.bar) + std.itoa(0, 1, 2);
+}`
+	assertNoError(t, input)
+}
+
 func TestIgnoreErrorNextLineOnly(t *testing.T) {
 	input := `
 sub vcl_recv {
@@ -724,6 +745,25 @@ sub vcl_recv {
 	assertNoError(t, input)
 }
 
+func TestIgnoreErrorThisLineWithRuleSpecified(t *testing.T) {
+	input := `
+sub vcl_recv {
+   #FASTLY RECV
+   # function/arguments is ignored, but there is also a function/argument-type error
+   set req.http.foo = std.itoa(req.http.bar) + std.itoa(0, 1, 2); # falco-ignore function/arguments
+}`
+	assertError(t, input)
+}
+
+func TestIgnoreErrorThisLineWithMultipleRulesSpecified(t *testing.T) {
+	input := `
+sub vcl_recv {
+   #FASTLY RECV
+   set req.http.foo = std.itoa(req.http.bar) + std.itoa(0, 1, 2); # falco-ignore function/arguments, function/argument-type
+}`
+	assertNoError(t, input)
+}
+
 func TestIgnoreErrorStartEnd(t *testing.T) {
 	input := `
 sub vcl_recv {
@@ -736,6 +776,29 @@ sub vcl_recv {
 	assertNoError(t, input)
 }
 
+func TestIgnoreErrorStartEndWithRuleSpecified(t *testing.T) {
+	input := `
+sub vcl_recv {
+   # falco-ignore-start function/arguments
+   #FASTLY RECV
+   # function/arguments is ignored, but there is also a function/argument-type error
+   set req.http.foo = std.itoa(req.http.bar) + std.itoa(0, 1, 2);
+   # falco-ignore-end function/arguments
+}`
+	assertError(t, input)
+}
+
+func TestIgnoreErrorStartEndWithMultipleRulesSpecified(t *testing.T) {
+	input := `
+sub vcl_recv {
+   # falco-ignore-start function/arguments, function/argument-type
+   #FASTLY RECV
+   set req.http.foo = std.itoa(req.http.bar) + std.itoa(0, 1, 2);
+   # falco-ignore-end function/arguments, function/argument-type
+}`
+	assertNoError(t, input)
+}
+
 func TestIgnoreErrorStartEndRangeOnly(t *testing.T) {
 	input := `
 sub vcl_recv {
@@ -744,6 +807,32 @@ sub vcl_recv {
    set req.http.H2-Fingerprint = fastly_info.h2.undefined;
 	// falco-ignore-end
    set req.http.H2-Fingerprint = fastly_info.h2.undefined;
+}`
+	assertError(t, input)
+}
+
+func TestIgnoreErrorStartEndRangeOnlyWithRuleSpecified(t *testing.T) {
+	input := `
+sub vcl_recv {
+   # falco-ignore-start function/arguments, function/argument-type
+   #FASTLY RECV
+   set req.http.foo = std.itoa(req.http.bar) + std.itoa(0, 1, 2);
+   # falco-ignore-end function/arguments
+   set req.http.foo = std.itoa(req.http.bar);
+}`
+	assertNoError(t, input)
+}
+
+func TestIgnoreErrorStartEndRangeOnly_EndWithNoRulesSpecifiedUnignoresAllRules(t *testing.T) {
+	input := `
+sub vcl_recv {
+   # falco-ignore-start function/arguments
+   #FASTLY RECV
+   set req.http.foo = std.itoa(0, 1, 2);
+   # falco-ignore-start function/argument-type
+   set req.http.foo = std.itoa(req.http.bar) + std.itoa(0, 1, 2);
+   # falco-ignore-end
+   set req.http.foo = std.itoa(0, 1, 2);
 }`
 	assertError(t, input)
 }

--- a/linter/statement_linter.go
+++ b/linter/statement_linter.go
@@ -71,7 +71,7 @@ func (l *Linter) lintBlockStatement(block *ast.BlockStatement, ctx *context.Cont
 	for _, stmt := range statements {
 		func(v ast.Statement, c *context.Context) {
 			l.ignore.SetupStatement(v.GetMeta())
-			defer l.ignore.TeardownStatement()
+			defer l.ignore.TeardownStatement(v.GetMeta())
 			l.lint(v, c)
 		}(stmt, ctx)
 	}


### PR DESCRIPTION
The current linter can be configured to disable arbitrary rules for an entire project using [its config `linter.rules`](https://github.com/ysugimoto/falco/blob/main/docs/configuration.md), but not for a specific line, range, or file only.

Sometimes you want to do so, for example when your VCL is split into several moduled VCLs you might get `unused/declaration` errors because some declarations in a module are only used by main VCL and not used from its own module. In this situation, it's better to disable `unused/declaration` in module VCLs only, rather than disabling `unused/declaration` or excluding modules from linting completely.

This PR extends the syntax of `ignore` comments of linter so that you can disable only specific lint rules.

```
// falco-ignore-next-line [rule-name [, rule-name [, ...]]]
// falco-ignore [rule-name [, rule-name [, ...]]]
// falco-start [rule-name [, rule-name [, ...]]]
// falco-end [rule-name [, rule-name [, ...]]]
```