### PR TITLE
fix(formatter): remove space between return and parenthesis

### DIFF
--- a/formatter/statement_format.go
+++ b/formatter/statement_format.go
@@ -535,7 +535,7 @@ func (f *Formatter) formatReturnStatement(stmt *ast.ReturnStatement) string {
 		// If ReturnStatementParenthesis is enabled and inside functional subroutine,
 		// the return argument must be surrounded by parenthesis
 		if f.conf.ReturnStatementParenthesis && !f.isFunctionalSubroutine {
-			prefix = " ("
+			prefix = "("
 			suffix = ")"
 		}
 		buf.WriteString(prefix)

--- a/formatter/statement_format_test.go
+++ b/formatter/statement_format_test.go
@@ -471,6 +471,21 @@ func TestFormatReturnStatement(t *testing.T) {
 		conf   *config.FormatConfig
 	}{
 		{
+			name: "simple case",
+			input: `sub vcl_recv {
+	return(pass);
+}
+`,
+			expect: `sub vcl_recv {
+  return(pass);
+}
+`,
+			conf: &config.FormatConfig{
+				IndentWidth:                2,
+				ReturnStatementParenthesis: true,
+			},
+		},
+		{
 			name: "basic formatting with comments",
 			input: `sub vcl_recv {
 	// return leading comment
@@ -486,11 +501,11 @@ func TestFormatReturnStatement(t *testing.T) {
 		{
 			name: "with parenthesis",
 			input: `sub vcl_recv {
-	return /* before_parenthesis */ (/* inside_parenthesis */ lookup /* inside_parenthesis */) /* after_parenthesis */;
+	return/* before_parenthesis */ (/* inside_parenthesis */ lookup /* inside_parenthesis */) /* after_parenthesis */;
 }
 `,
 			expect: `sub vcl_recv {
-  return /* before_parenthesis */ (/* inside_parenthesis */ lookup /* inside_parenthesis */) /* after_parenthesis */;
+  return /* before_parenthesis */(/* inside_parenthesis */ lookup /* inside_parenthesis */) /* after_parenthesis */;
 }
 `,
 			conf: &config.FormatConfig{
@@ -503,7 +518,7 @@ func TestFormatReturnStatement(t *testing.T) {
 		{
 			name: "without argument",
 			input: `sub vcl_recv {
-	return /* before_semicolon */ ; // trailing
+	return/* before_semicolon */ ; // trailing
 }
 `,
 			expect: `sub vcl_recv {


### PR DESCRIPTION
- Remove extra space before opening parenthesis in return statements
- Add simple test case
- Update test cases to reflect the new behaviour
- This matches the Fastly VCL style, e.g.:
   - https://www.fastly.com/documentation/reference/vcl/statements/return/ 
   - https://www.fastly.com/documentation/guides/vcl/using/#custom-vcl