### PR TITLE
feat(formatter): prevent indentation of #FASTLY macros

### DIFF
--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -154,7 +154,10 @@ func (f *Formatter) formatComment(comments ast.Comments, sep string, level int) 
 		if comments[i].PreviousEmptyLines > 0 {
 			buf.WriteString("\n")
 		}
-		buf.WriteString(f.indent(level))
+		// #FASTLY macros are not indented
+		if !strings.HasPrefix(comments[i].String(), "#FASTLY") {
+			buf.WriteString(f.indent(level))
+		}
 		switch f.conf.CommentStyle {
 		case config.CommentStyleSharp, config.CommentStyleSlash:
 			r := '#' // default as sharp style comment

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -62,3 +62,77 @@ func BenchmarkFormatter(b *testing.B) {
 		New(c).Format(vcl)
 	}
 }
+
+func TestFormatComment(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		conf   *config.FormatConfig
+		expect string
+	}{
+		{
+			name: "Regular comment",
+			input: `sub recv {
+// This is a single comment
+return(pass);
+}`,
+			expect: `sub recv {
+  // This is a single comment
+  return(pass);
+}
+`,
+			conf: &config.FormatConfig{
+				CommentStyle:               "slash",
+				IndentWidth:                2,
+				IndentStyle:                "space",
+				ReturnStatementParenthesis: true,
+			},
+		},
+		{
+			name: "Comment starting with #FASTLY",
+			input: `sub recv {
+#FASTLY recv
+return(pass);
+}`,
+			expect: `sub recv {
+#FASTLY recv
+  return(pass);
+}
+`,
+			conf: &config.FormatConfig{
+				CommentStyle:               "sharp",
+				IndentWidth:                2,
+				IndentStyle:                "space",
+				ReturnStatementParenthesis: true,
+			},
+		},
+		{
+			name: "Multiple comments",
+			input: `sub recv {
+# Regular comment 1
+#FASTLY recv
+  # Regular comment 2
+return(pass);
+}`,
+			expect: `sub recv {
+  # Regular comment 1
+#FASTLY recv
+  # Regular comment 2
+  return(pass);
+}
+`,
+			conf: &config.FormatConfig{
+				CommentStyle:               "sharp",
+				IndentWidth:                2,
+				IndentStyle:                "space",
+				ReturnStatementParenthesis: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert(t, tt.input, tt.expect, tt.conf)
+		})
+	}
+}


### PR DESCRIPTION
- Modified the `formatComment()` function to skip indentation for comments starting with `#FASTLY`
- Added unit tests to verify the new behaviour for regular comments, #FASTLY macros, and mixed comment scenarios
- This change ensures that #FASTLY macros remain at the start of the line, adhering to Fastly's VCL formatting conventions, e.g.:
  - https://www.fastly.com/documentation/guides/vcl/using/#custom-vcl