### PR TITLE
strict macro linting

### DIFF
--- a/examples/linter/custom_linter.vcl
+++ b/examples/linter/custom_linter.vcl
@@ -28,7 +28,7 @@ backend F_httpbin_org {
 }
 
 sub vcl_recv {
-  #Fastly recv
+  #FASTLY recv
   set req.backend = F_httpbin_org;
   return (lookup);
 }

--- a/examples/linter/default01.vcl
+++ b/examples/linter/default01.vcl
@@ -33,7 +33,7 @@ sub custom_logger {
 
 sub vcl_recv {
 
-  #Fastly recv
+  #FASTLY recv
   set req.backend = httpbin_org;
   set req.http.Foo = {" foo bar baz "};
   call custom_logger;
@@ -42,7 +42,7 @@ sub vcl_recv {
 
 sub vcl_deliver {
 
-  #Fastly deliver
+  #FASTLY deliver
   set resp.http.X-Custom-Header = "Custom Header";
   call custom_logger;
   return (deliver);
@@ -50,7 +50,7 @@ sub vcl_deliver {
 
 sub vcl_fetch {
 
-  #Fastly fetch
+  #FASTLY fetch
   call custom_logger;
   return(deliver);
 }

--- a/examples/linter/default02.vcl
+++ b/examples/linter/default02.vcl
@@ -27,7 +27,7 @@ backend httpbin_org {
 
 sub vcl_recv {
 
-  #Fastly recv
+  #FASTLY recv
   set req.backend = httpbin_org;
 
   return (pass);
@@ -35,13 +35,13 @@ sub vcl_recv {
 
 sub vcl_deliver {
 
-  #Fastly deliver
+  #FASTLY deliver
   set resp.http.X-Custom-Header = "Custom Header";
   return (deliver);
 }
 
 sub vcl_fetch {
 
-  #Fastly fetch
+  #FASTLY fetch
   return(deliver);
 }

--- a/examples/linter/default03.vcl
+++ b/examples/linter/default03.vcl
@@ -27,7 +27,7 @@ backend httpbin_org {
 
 sub vcl_recv {
 
-  #Fastly recv
+  #FASTLY recv
   set req.backend = httpbin_org;
 
   if (req.http.Host !~ "(foo)\.example\.com") {
@@ -43,13 +43,13 @@ sub vcl_recv {
 
 sub vcl_deliver {
 
-  #Fastly deliver
+  #FASTLY deliver
   set resp.http.X-Custom-Header = "Custom Header";
   return (deliver);
 }
 
 sub vcl_fetch {
 
-  #Fastly fetch
+  #FASTLY fetch
   return(deliver);
 }

--- a/examples/linter/default04.vcl
+++ b/examples/linter/default04.vcl
@@ -27,7 +27,7 @@ backend httpbin_org {
 
 sub vcl_recv {
 
-  #Fastly recv
+  #FASTLY recv
   set req.backend = httpbin_org;
 
   return (pass);
@@ -35,7 +35,7 @@ sub vcl_recv {
 
 sub vcl_deliver {
 
-  #Fastly deliver
+  #FASTLY deliver
   set resp.http.X-Custom-Header = "Custom Header";
   return (deliver);
 }
@@ -44,13 +44,13 @@ sub vcl_fetch {
 
   error 755 "/login?s=error";
 
-  #Fastly fetch
+  #FASTLY fetch
   return(deliver);
 }
 
 sub vcl_error {
 
-  #Fastly error
+  #FASTLY error
   if (obj.status == 755) {
     set obj.http.Location = regsub(obj.response, "^([^;]*)(;.*)?$", "\1");
     set obj.response = "Found";

--- a/examples/linter/default05.vcl
+++ b/examples/linter/default05.vcl
@@ -29,7 +29,7 @@ include "default05_include01";
 
 sub vcl_recv {
 
-  #Fastly recv
+  #FASTLY recv
   set req.backend = httpbin_org;
 
   if (req.http.Some-Truthy-Header) {

--- a/linter/expression_linter_test.go
+++ b/linter/expression_linter_test.go
@@ -202,7 +202,7 @@ sub foo {
 	t.Run("pass: with argument", func(t *testing.T) {
 		input := `
 sub vcl_recv {
-	#Fastly recv
+	#FASTLY recv
 	return (pass);
 }`
 		assertNoError(t, input)
@@ -211,7 +211,7 @@ sub vcl_recv {
 	t.Run("pass: with reserved word", func(t *testing.T) {
 		input := `
 sub vcl_recv {
-	#Fastly recv
+	#FASTLY recv
 	return (restart);
 }`
 		assertNoError(t, input)
@@ -220,7 +220,7 @@ sub vcl_recv {
 	t.Run("sub: return correct type", func(t *testing.T) {
 		input := `
 sub custom_sub INTEGER {
-	#Fastly recv
+	#FASTLY recv
 	return 1;
 }`
 		assertNoError(t, input)
@@ -303,7 +303,7 @@ sub get_bool BOOL {
 func TestBlockSyntaxInsideBlockStatement(t *testing.T) {
 	input := `
 sub vcl_recv {
-	#Fastly recv
+	#FASTLY recv
 	{
 		log "vcl_recv";
 	}
@@ -314,7 +314,7 @@ sub vcl_recv {
 func TestBlockSyntaxInsideBlockStatementmultiply(t *testing.T) {
 	input := `
 sub vcl_recv {
-	#Fastly recv
+	#FASTLY recv
 	{
 		{
 			log "vcl_recv";
@@ -328,7 +328,7 @@ func TestRegexExpressionIsInvalid(t *testing.T) {
 	t.Run("pass", func(t *testing.T) {
 		input := `
 sub vcl_recv {
-	#Fastly recv
+	#FASTLY recv
 	if (req.url ~ "^/([^\?]*)?(\?.*)?$") {
 		restart;
 	}
@@ -339,7 +339,7 @@ sub vcl_recv {
 	t.Run("error: invalid regex", func(t *testing.T) {
 		input := `
 sub vcl_recv {
-	#Fastly recv
+	#FASTLY recv
 	if (req.url ~ "^/([^\?]*)?(\?.*?$") {
 		restart;
 	}

--- a/linter/helper.go
+++ b/linter/helper.go
@@ -438,10 +438,19 @@ func getFastlySubroutineScope(name string) string {
 	return ""
 }
 
-func hasFastlyBoilerPlateMacro(cs ast.Comments, phrase string) bool {
+// Fastly macro format Must be "#FASTLY [scope]"
+// - Comment sign must starts with single "#". "/" sign is not accepted
+// - Fixed "FASTLY" string must exactly present without whitespace after comment sign
+// - [scope] string is case-insensitive (recv/RECV can be accepcted, typically uppercase)
+// - Additional comment is also accepted like "#FASTLY RECV some extra comment"
+func hasFastlyBoilerPlateMacro(cs ast.Comments, scope string) bool {
 	for _, c := range cs {
-		line := strings.TrimLeft(c.String(), " */#")
-		if strings.HasPrefix(strings.ToUpper(line), phrase) {
+		// Uppercase scope
+		if strings.HasPrefix(c.String(), "#FASTLY "+strings.ToUpper(scope)) {
+			return true
+		}
+		// lowercase scope
+		if strings.HasPrefix(c.String(), "#FASTLY "+strings.ToLower(scope)) {
 			return true
 		}
 	}

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -549,8 +549,6 @@ func (l *Linter) factoryRootDeclarations(statements []ast.Statement, ctx *contex
 }
 
 func (l *Linter) lintFastlyBoilerPlateMacro(sub *ast.SubroutineDeclaration, ctx *context.Context, scope string) {
-	phrase := strings.ToUpper("FASTLY " + scope)
-
 	// prepare scoped snippets
 	scopedSnippets, ok := ctx.Snippets().ScopedSnippets[scope]
 	if !ok {
@@ -559,7 +557,7 @@ func (l *Linter) lintFastlyBoilerPlateMacro(sub *ast.SubroutineDeclaration, ctx 
 
 	var resolved []ast.Statement
 	// visit all statement comments and find "FASTLY [phase]" comment
-	if hasFastlyBoilerPlateMacro(sub.Block.Infix, phrase) {
+	if hasFastlyBoilerPlateMacro(sub.Block.Infix, scope) {
 		for _, s := range scopedSnippets {
 			resolved = append(resolved, l.loadSnippetVCL("snippet::"+s.Name, s.Data)...)
 		}
@@ -569,7 +567,7 @@ func (l *Linter) lintFastlyBoilerPlateMacro(sub *ast.SubroutineDeclaration, ctx 
 
 	var found bool
 	for _, stmt := range sub.Block.Statements {
-		if hasFastlyBoilerPlateMacro(stmt.GetMeta().Leading, phrase) && !found {
+		if hasFastlyBoilerPlateMacro(stmt.GetMeta().Leading, scope) && !found {
 			// Macro found but embedding snippets should do only once
 			for _, s := range scopedSnippets {
 				resolved = append(resolved, l.loadSnippetVCL("snippet::"+s.Name, s.Data)...)
@@ -590,7 +588,7 @@ func (l *Linter) lintFastlyBoilerPlateMacro(sub *ast.SubroutineDeclaration, ctx 
 		Severity: WARNING,
 		Token:    sub.GetMeta().Token,
 		Message: fmt.Sprintf(
-			`Subroutine "%s" is missing Fastly boilerplate comment "%s" inside definition`, sub.Name.Value, phrase,
+			`Subroutine "%s" is missing Fastly boilerplate comment "#FASTLY %s" inside definition`, sub.Name.Value, strings.ToUpper(scope),
 		),
 	}
 	l.Error(err.Match(SUBROUTINE_BOILERPLATE_MACRO))

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -128,14 +128,14 @@ func TestLintStuff(t *testing.T) {
 			}
 
 			sub vcl_log {
-				# FASTLY log
+				#FASTLY log
 				if (example()) {
 					log "foo";
 				}
 			}
 
 			sub vcl_deliver {
-			# FASTLY deliver
+			#FASTLY deliver
 				if (example()) {
 					log "foo";
 				}
@@ -398,7 +398,7 @@ func TestPassIssue39(t *testing.T) {
 	t.Run("pass", func(t *testing.T) {
 		input := `
 sub vcl_fetch {
-	### FASTLY fetch
+	#FASTLY fetch
     if (parse_time_delta(beresp.http.Edge-Control:cache-maxage) >= 0) {
       set beresp.ttl = parse_time_delta(beresp.http.Edge-Control:cache-maxage);
     }
@@ -413,7 +413,7 @@ func TestSubroutineHoisting(t *testing.T) {
 	t.Run("pass", func(t *testing.T) {
 		input := `
 sub vcl_recv {
-	### FASTLY recv
+	#FASTLY recv
 	call hoisted_subroutine;
 	return(lookup);
 }


### PR DESCRIPTION
Related to https://www.fastly.com/documentation/guides/vcl/using/#custom-vcl , we need more strict linting for Fastly boilerplate macro.

The macro format must be:

```vcl
#FASTLY RECV
```

1. Comment sign must be a single `#`
2. `FASTLY` string must be uppercase without leading whitespace
3. Scope name is case-insensitive
4. Additional comment can be accepted