### PR TITLE
support Fastly generated specific syntaxes

### DIFF
--- a/__generator__/builtin.yml
+++ b/__generator__/builtin.yml
@@ -1297,3 +1297,4 @@ fastly.try_select_shield:
   on: [RECV, HASH, HIT, MISS, PASS, FETCH, ERROR, DELIVER, LOG]
   arguments:
     - [BACKEND, BACKEND]
+  return: BACKEND

--- a/cmd/falco/runner_test.go
+++ b/cmd/falco/runner_test.go
@@ -51,6 +51,13 @@ func loadRepoExampleTestMetadata() []RepoExampleTestMetadata {
 			warnings: 0,
 			infos:    1,
 		},
+		{
+			name:     "Fastly Generated",
+			fileName: "../../examples/linter/fastly_generated.vcl",
+			errors:   0,
+			warnings: 12,
+			infos:    2,
+		},
 	}
 
 	// Run custom linter testing only in CI env
@@ -216,7 +223,8 @@ func TestRepositoryExamples(t *testing.T) {
 	tests := loadRepoExampleTestMetadata()
 	c := &config.Config{
 		Linter: &config.LinterConfig{
-			VerboseWarning: true,
+			VerboseWarning:    true,
+			IgnoreSubroutines: []string{"vcl_pipe"},
 		},
 	}
 	for _, tt := range tests {
@@ -254,7 +262,8 @@ func TestRepositoryExamplesJSONMode(t *testing.T) {
 	c := &config.Config{
 		Json: true,
 		Linter: &config.LinterConfig{
-			VerboseWarning: true,
+			VerboseWarning:    true,
+			IgnoreSubroutines: []string{"vcl_pipe"},
 		},
 	}
 
@@ -281,8 +290,12 @@ func TestRepositoryExamplesJSONMode(t *testing.T) {
 			if ret.Errors != tt.errors {
 				t.Errorf("Errors expects %d, got %d", tt.errors, ret.Errors)
 			}
-			if len(ret.LintErrors) != tt.infos+tt.warnings+tt.errors {
-				t.Errorf("Expected %d linting errors, got %d", tt.infos+tt.warnings+tt.errors, len(ret.LintErrors))
+			var c int
+			for _, v := range ret.LintErrors {
+				c += len(v)
+			}
+			if c != tt.infos+tt.warnings+tt.errors {
+				t.Errorf("Expected %d linting errors, got %d", tt.infos+tt.warnings+tt.errors, c)
 			}
 
 			countLintErrorsWithSeverity := func(sev linter.Severity) int {

--- a/config/config.go
+++ b/config/config.go
@@ -174,6 +174,10 @@ func New(args []string) (*Config, error) {
 	c.Simulator.IncludePaths = c.IncludePaths
 	c.Testing.IncludePaths = c.IncludePaths
 
+	// On Fastly generated VCL, "vcl_pipe" subroutine will present internally.
+	// The "vcl_pipe" subroutine looks fastly managed but undocumented, so we will ignore linting
+	c.Linter.IgnoreSubroutines = append(c.Linter.IgnoreSubroutines, "vcl_pipe")
+
 	return c, nil
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -49,9 +49,10 @@ func TestConfigFromCLI(t *testing.T) {
 		Json:     true,
 		Commands: Commands{"lint"},
 		Linter: &LinterConfig{
-			VerboseLevel:   "",
-			VerboseWarning: true,
-			VerboseInfo:    true,
+			VerboseLevel:      "",
+			VerboseWarning:    true,
+			VerboseInfo:       true,
+			IgnoreSubroutines: []string{"vcl_pipe"},
 		},
 		Simulator: &SimulatorConfig{
 			Port:            3124,

--- a/context/builtin.go
+++ b/context/builtin.go
@@ -603,6 +603,7 @@ func builtinFunctions() Functions {
 				"try_select_shield": &FunctionSpec{
 					Items: map[string]*FunctionSpec{},
 					Value: &BuiltinFunction{
+						Return: types.BackendType,
 						Arguments: [][]types.Type{
 							[]types.Type{types.BackendType, types.BackendType},
 						},

--- a/examples/linter/fastly_generated.vcl
+++ b/examples/linter/fastly_generated.vcl
@@ -1,0 +1,501 @@
+# Noticing changes to your VCL? The event log
+# (https://docs.fastly.com/en/guides/reviewing-service-activity-with-the-event-log)
+# in the web interface shows changes to your service's configurations and the
+# change log on developer.fastly.com (https://developer.fastly.com/reference/changes/vcl/)
+# provides info on changes to the Fastly-provided VCL itself.
+
+pragma optional_param geoip_opt_in true;
+pragma optional_param max_object_size 2147483648;
+pragma optional_param smiss_max_object_size 5368709120;
+pragma optional_param fetchless_purge_all 1;
+pragma optional_param chash_randomize_on_pass true;
+pragma optional_param default_ssl_check_cert 1;
+pragma optional_param max_backends 20;
+pragma optional_param customer_id "bwIxaoVzhiEJrt4SIaIvT";
+C!
+W!
+# Backends
+
+backend F_Host_1 {
+    .between_bytes_timeout = 10s;
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .first_byte_timeout = 15s;
+    .host = "example.com";
+    .max_connections = 200;
+    .port = "443";
+    .share_key = "qRK2E1vLIVkQ3BU0iVk9X7";
+
+    .ssl = true;
+    .ssl_cert_hostname = "example.com";
+    .ssl_check_cert = always;
+    .ssl_sni_hostname = "example.com";
+
+    .probe = {
+        .dummy = true;
+        .initial = 5;
+        .request = "HEAD / HTTP/1.1"  "Host: example.com" "Connection: close";
+        .threshold = 1;
+        .timeout = 2s;
+        .window = 5;
+      }
+}
+backend F_httpbin_org {
+    .between_bytes_timeout = 10s;
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .first_byte_timeout = 15s;
+    .host = "httpbin.org";
+    .max_connections = 200;
+    .port = "443";
+    .share_key = "qRK2E1vLIVkQ3BU0iVk9X7";
+
+    .ssl = true;
+    .ssl_cert_hostname = "httpbin.org";
+    .ssl_check_cert = always;
+    .ssl_sni_hostname = "httpbin.org";
+
+    .probe = {
+        .dummy = true;
+        .initial = 5;
+        .request = "HEAD / HTTP/1.1"  "Host: httpbin.org" "Connection: close";
+        .threshold = 1;
+        .timeout = 2s;
+        .window = 5;
+      }
+}
+
+
+
+
+
+director ssl_shield_hnd_tokyo_jp shield {
+   .shield = "hnd-tokyo-jp";
+   .is_ssl = true;
+}
+
+director ssl_shield_tyo_tokyo_jp shield {
+   .shield = "tyo-tokyo-jp";
+   .is_ssl = true;
+}
+
+
+
+table example {
+}
+
+table my_example_dictionary {
+    # REDACTED dictionary content
+    # digest: db817286bc0c2af867c866e134641cc25b8b518913e8826dc952b9fc42e660b5
+    # item_count: 1
+    # last_updated: 2023-04-27 14:24:34
+}
+
+
+
+
+
+
+
+
+
+
+backend httpbin_org {
+  .connect_timeout = 1s;
+  .dynamic = true;
+  .port = "443";
+  .host = "httpbin.org";
+  .first_byte_timeout = 20s;
+  .max_connections = 500;
+  .between_bytes_timeout = 20s;
+  .share_key = "xei5lohleex3Joh5ie5uy7du";
+  .ssl = true;
+  .ssl_sni_hostname = "httpbin.org";
+  .ssl_cert_hostname = "httpbin.org";
+  .ssl_check_cert = always;
+  .min_tls_version = "1.2";
+  .max_tls_version = "1.2";
+  //.bypass_local_route_table = false;
+  .probe = {
+    .request = "GET /status/200 HTTP/1.1" "Host: httpbin.org" "Connection: close";
+    .dummy = true;
+    .threshold = 1;
+    .window = 2;
+    .timeout = 5s;
+    .initial = 1;
+    .expected_response = 200;
+    .interval = 10s;
+  }
+}
+
+sub vcl_recv {
+#--FASTLY RECV BEGIN
+  if (req.restarts == 0) {
+    if (!req.http.X-Timer) {
+      set req.http.X-Timer = "S" time.start.sec "." time.start.usec_frac;
+    }
+    set req.http.X-Timer = req.http.X-Timer ",VS0";
+  }
+
+  if (req.http.Fastly-Orig-Accept-Encoding) {
+    if (req.http.Fastly-Orig-Accept-Encoding ~ "\bbr\b") {
+      set req.http.Accept-Encoding = "br";
+    }
+  }
+
+
+
+  declare local var.fastly_req_do_shield BOOL;
+  set var.fastly_req_do_shield = (req.restarts == 0);
+
+# Snippet example_recv : 100
+set req.http.Example-Recv = "1";
+
+# Snippet my_dynamic_snippet_name : 100
+if ( req.url ) { set req.http.my-snippet-test-header = "affirmative"; }
+
+  # default conditions
+  set req.backend = F_Host_1;
+
+  if (!req.http.Fastly-SSL) {
+     error 801 "Force SSL";
+  }
+
+
+
+
+    # end default conditions
+
+
+
+
+      #do shield here F_Host_1 > ssl_shield_tyo_tokyo_jp;
+
+
+
+
+  {
+    if (req.backend == F_Host_1 && var.fastly_req_do_shield) {
+      set req.backend = fastly.try_select_shield(ssl_shield_tyo_tokyo_jp, F_Host_1);
+    }
+  }
+        #do shield here F_httpbin_org > ssl_shield_hnd_tokyo_jp;
+
+
+
+
+  {
+    if (req.backend == F_httpbin_org && var.fastly_req_do_shield) {
+      set req.backend = fastly.try_select_shield(ssl_shield_hnd_tokyo_jp, F_httpbin_org);
+    }
+  }
+
+
+
+#--FASTLY RECV END
+  set req.http.Foo = "bar";
+}
+
+sub vcl_miss {
+#--FASTLY MISS BEGIN
+
+
+# this is not a hit after all, clean up these set in vcl_hit
+  unset req.http.Fastly-Tmp-Obj-TTL;
+  unset req.http.Fastly-Tmp-Obj-Grace;
+
+  {
+    if (req.http.Fastly-Check-SHA1) {
+       error 550 "Doesnt exist";
+    }
+
+#--FASTLY BEREQ BEGIN
+    {
+      {
+        if (req.http.Fastly-FF) {
+          set bereq.http.Fastly-Client = "1";
+        }
+      }
+      {
+        # do not send this to the backend
+        unset bereq.http.Fastly-Original-Cookie;
+        unset bereq.http.Fastly-Original-URL;
+        unset bereq.http.Fastly-Vary-String;
+        unset bereq.http.X-Varnish-Client;
+      }
+      if (req.http.Fastly-Temp-XFF) {
+         if (req.http.Fastly-Temp-XFF == "") {
+           unset bereq.http.X-Forwarded-For;
+         } else {
+           set bereq.http.X-Forwarded-For = req.http.Fastly-Temp-XFF;
+         }
+         # unset bereq.http.Fastly-Temp-XFF;
+      }
+    }
+#--FASTLY BEREQ END
+
+
+ #;
+
+    set req.http.Fastly-Cachetype = "MISS";
+
+  }
+
+#--FASTLY MISS END
+}
+
+sub vcl_hit {
+#--FASTLY HIT BEGIN
+
+# we cannot reach obj.ttl and obj.grace in deliver, save them when we can in vcl_hit
+  set req.http.Fastly-Tmp-Obj-TTL = obj.ttl;
+  set req.http.Fastly-Tmp-Obj-Grace = obj.grace;
+
+  {
+    set req.http.Fastly-Cachetype = "HIT";
+  }
+
+#--FASTLY HIT END
+}
+
+sub vcl_pass {
+#--FASTLY PASS BEGIN
+
+
+  {
+
+#--FASTLY BEREQ BEGIN
+    {
+      {
+        if (req.http.Fastly-FF) {
+          set bereq.http.Fastly-Client = "1";
+        }
+      }
+      {
+        # do not send this to the backend
+        unset bereq.http.Fastly-Original-Cookie;
+        unset bereq.http.Fastly-Original-URL;
+        unset bereq.http.Fastly-Vary-String;
+        unset bereq.http.X-Varnish-Client;
+      }
+      if (req.http.Fastly-Temp-XFF) {
+         if (req.http.Fastly-Temp-XFF == "") {
+           unset bereq.http.X-Forwarded-For;
+         } else {
+           set bereq.http.X-Forwarded-For = req.http.Fastly-Temp-XFF;
+         }
+         # unset bereq.http.Fastly-Temp-XFF;
+      }
+    }
+#--FASTLY BEREQ END
+
+
+ #;
+    set req.http.Fastly-Cachetype = "PASS";
+  }
+
+#--FASTLY PASS END
+}
+
+sub vcl_hash {
+
+#--FASTLY HASH BEGIN
+
+# support purge all
+set req.hash += req.vcl.generation;
+#--FASTLY HASH END
+}
+
+sub vcl_fetch {
+
+
+#--FASTLY FETCH BEGIN
+
+
+
+# record which cache ran vcl_fetch for this object and when
+  set beresp.http.Fastly-Debug-Path = "(F " server.identity " " now.sec ") " if(beresp.http.Fastly-Debug-Path, beresp.http.Fastly-Debug-Path, "");
+
+# generic mechanism to vary on something
+  if (req.http.Fastly-Vary-String) {
+    if (beresp.http.Vary) {
+      set beresp.http.Vary = "Fastly-Vary-String, "  beresp.http.Vary;
+    } else {
+      set beresp.http.Vary = "Fastly-Vary-String, ";
+    }
+  }
+
+
+
+#--FASTLY FETCH END
+
+}
+
+sub vcl_deliver {
+
+
+#--FASTLY DELIVER BEGIN
+
+# record the journey of the object, expose it only if req.http.Fastly-Debug.
+  if (req.http.Fastly-Debug || req.http.Fastly-FF) {
+    set resp.http.Fastly-Debug-Path = "(D " server.identity " " now.sec ") "
+       if(resp.http.Fastly-Debug-Path, resp.http.Fastly-Debug-Path, "");
+
+    set resp.http.Fastly-Debug-TTL = if(obj.hits > 0, "(H ", "(M ")
+       server.identity
+       if(req.http.Fastly-Tmp-Obj-TTL && req.http.Fastly-Tmp-Obj-Grace, " " req.http.Fastly-Tmp-Obj-TTL " " req.http.Fastly-Tmp-Obj-Grace " ", " - - ")
+       if(resp.http.Age, resp.http.Age, "-")
+       ") "
+       if(resp.http.Fastly-Debug-TTL, resp.http.Fastly-Debug-TTL, "");
+
+    set resp.http.Fastly-Debug-Digest = digest.hash_sha256(req.digest);
+  } else {
+    unset resp.http.Fastly-Debug-Path;
+    unset resp.http.Fastly-Debug-TTL;
+    unset resp.http.Fastly-Debug-Digest;
+  }
+
+  # add or append X-Served-By/X-Cache(-Hits)
+  {
+
+    if(!resp.http.X-Served-By) {
+      set resp.http.X-Served-By  = server.identity;
+    } else {
+      set resp.http.X-Served-By = resp.http.X-Served-By ", " server.identity;
+    }
+
+    set resp.http.X-Cache = if(resp.http.X-Cache, resp.http.X-Cache ", ","") if(fastly_info.state ~ "HIT(?:-|\z)", "HIT", "MISS");
+
+    if(!resp.http.X-Cache-Hits) {
+      set resp.http.X-Cache-Hits = obj.hits;
+    } else {
+      set resp.http.X-Cache-Hits = resp.http.X-Cache-Hits ", " obj.hits;
+    }
+
+  }
+
+  if (req.http.X-Timer) {
+    set resp.http.X-Timer = req.http.X-Timer ",VE" time.elapsed.msec;
+  }
+
+  # VARY FIXUP
+  {
+    # remove before sending to client
+    set resp.http.Vary = regsub(resp.http.Vary, "Fastly-Vary-String, ", "");
+    if (resp.http.Vary ~ "^\s*$") {
+      unset resp.http.Vary;
+    }
+  }
+  unset resp.http.X-Varnish;
+
+
+  # Pop the surrogate headers into the request object so we can reference them later
+  set req.http.Surrogate-Key = resp.http.Surrogate-Key;
+  set req.http.Surrogate-Control = resp.http.Surrogate-Control;
+
+  # If we are not forwarding or debugging unset the surrogate headers so they are not present in the response
+  if (!req.http.Fastly-FF && !req.http.Fastly-Debug) {
+    unset resp.http.Surrogate-Key;
+    unset resp.http.Surrogate-Control;
+  }
+
+  if(resp.status == 550) {
+    return(deliver);
+  }
+  #default response conditions
+
+
+# Header rewrite Generated by force TLS and enable HSTS : 100
+
+
+      set resp.http.Strict-Transport-Security = "max-age=300";
+
+
+
+
+
+
+
+#--FASTLY DELIVER END
+}
+
+sub vcl_error {
+#--FASTLY ERROR BEGIN
+
+
+  if (obj.status == 801) {
+     set obj.status = 301;
+     set obj.response = "Moved Permanently";
+     set obj.http.Location = "https://" req.http.host req.url;
+     synthetic {""};
+     return (deliver);
+  }
+
+
+
+
+  if (req.http.Fastly-Restart-On-Error) {
+    if (obj.status == 503 && req.restarts == 0) {
+      restart;
+    }
+  }
+
+  {
+    if (obj.status == 550) {
+      return(deliver);
+    }
+  }
+#--FASTLY ERROR END
+
+
+}
+
+sub vcl_log {
+#--FASTLY LOG BEGIN
+
+  # default response conditions
+
+
+
+#--FASTLY LOG END
+}
+
+sub vcl_pipe {
+#--FASTLY PIPE BEGIN
+  {
+
+
+#--FASTLY BEREQ BEGIN
+    {
+      {
+        if (req.http.Fastly-FF) {
+          set bereq.http.Fastly-Client = "1";
+        }
+      }
+      {
+        # do not send this to the backend
+        unset bereq.http.Fastly-Original-Cookie;
+        unset bereq.http.Fastly-Original-URL;
+        unset bereq.http.Fastly-Vary-String;
+        unset bereq.http.X-Varnish-Client;
+      }
+      if (req.http.Fastly-Temp-XFF) {
+         if (req.http.Fastly-Temp-XFF == "") {
+           unset bereq.http.X-Forwarded-For;
+         } else {
+           set bereq.http.X-Forwarded-For = req.http.Fastly-Temp-XFF;
+         }
+         # unset bereq.http.Fastly-Temp-XFF;
+      }
+    }
+#--FASTLY BEREQ END
+
+
+    #;
+    set req.http.Fastly-Cachetype = "PIPE";
+    set bereq.http.connection = "close";
+  }
+#--FASTLY PIPE END
+
+}
+

--- a/interpreter/function/builtin_functions.go
+++ b/interpreter/function/builtin_functions.go
@@ -514,7 +514,7 @@ var builtinFunctions = map[string]*Function{
 		Call: func(ctx *context.Context, args ...value.Value) (value.Value, error) {
 			return builtin.Fastly_try_select_shield(ctx, args...)
 		},
-		CanStatementCall: true,
+		CanStatementCall: false,
 		IsIdentArgument: func(i int) bool {
 			return false
 		},

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -301,6 +301,17 @@ func (l *Lexer) NextToken() token.Token {
 	case 0x0A: // '\n'
 		t = newToken(token.LF, l.char, line, index)
 	default:
+		// Fastly control syntaxes
+		if l.char == 0x43 || l.char == 0x57 { // "C" or "W"
+			c := l.char
+			if l.peekChar() == '!' { // "C!" or "W!"
+				l.readChar()
+				t = newToken(token.FASTLY_CONTROL, l.char, line, index)
+				t.Literal = string(c) + "!"
+				break
+			}
+		}
+
 		switch {
 		case l.isLetter(l.char):
 			literal := l.readIdentifier()

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -698,3 +698,57 @@ func TestCustomToken(t *testing.T) {
 		}
 	}
 }
+
+func TestFastlyControlSyntaxes(t *testing.T) {
+	t.Run("pragma syntax", func(t *testing.T) {
+		input := "pragma optional_param geoip_opt_in true;"
+		l := NewFromString(input)
+		expects := []token.Token{
+			{Type: token.PRAGMA, Literal: "pragma", Line: 1, Position: 1},
+			{Type: token.IDENT, Literal: "optional_param", Line: 1, Position: 8},
+			{Type: token.IDENT, Literal: "geoip_opt_in", Line: 1, Position: 23},
+			{Type: token.TRUE, Literal: "true", Line: 1, Position: 36},
+			{Type: token.SEMICOLON, Literal: ";", Line: 1, Position: 40},
+			{Type: token.EOF, Literal: "", Line: 1, Position: 41},
+		}
+		for i, tt := range expects {
+			tok := l.NextToken()
+
+			if diff := cmp.Diff(tt, tok, cmpopts.IgnoreFields(token.Token{}, "Offset")); diff != "" {
+				t.Errorf(`Tests[%d] failed, diff= %s`, i, diff)
+			}
+		}
+	})
+
+	t.Run("other control syntax of C!", func(t *testing.T) {
+		input := "C!"
+		l := NewFromString(input)
+		expects := []token.Token{
+			{Type: token.FASTLY_CONTROL, Literal: "C!", Line: 1, Position: 1},
+			{Type: token.EOF, Literal: "", Line: 1, Position: 3},
+		}
+		for i, tt := range expects {
+			tok := l.NextToken()
+
+			if diff := cmp.Diff(tt, tok, cmpopts.IgnoreFields(token.Token{}, "Offset")); diff != "" {
+				t.Errorf(`Tests[%d] failed, diff= %s`, i, diff)
+			}
+		}
+	})
+
+	t.Run("other control syntax of W!", func(t *testing.T) {
+		input := "W!"
+		l := NewFromString(input)
+		expects := []token.Token{
+			{Type: token.FASTLY_CONTROL, Literal: "W!", Line: 1, Position: 1},
+			{Type: token.EOF, Literal: "", Line: 1, Position: 3},
+		}
+		for i, tt := range expects {
+			tok := l.NextToken()
+
+			if diff := cmp.Diff(tt, tok, cmpopts.IgnoreFields(token.Token{}, "Offset")); diff != "" {
+				t.Errorf(`Tests[%d] failed, diff= %s`, i, diff)
+			}
+		}
+	})
+}

--- a/linter/helper.go
+++ b/linter/helper.go
@@ -105,6 +105,7 @@ var DirectorPropertyTypes = map[string]DirectorProps{
 		// We should do linting loughly because this type is only provided via Faslty Origin-Shielding
 		Props: map[string]types.Type{
 			"shield": types.StringType,
+			"is_ssl": types.BoolType,
 		},
 		Requires: []string{"shield"},
 	},

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -126,6 +126,10 @@ func (l *Linter) lintUnusedSubroutines(ctx *context.Context) {
 		if context.IsFastlySubroutine(s.Decl.Name.Value) {
 			continue
 		}
+		// Or, subroutine is ignored to lint, skip it
+		if isIgnoredSubroutineInConfig(l.conf.IgnoreSubroutines, s.Decl.Name.Value) {
+			continue
+		}
 		l.Error(UnusedDeclaration(s.Decl.GetMeta(), s.Decl.Name.Value, "subroutine").Match(UNUSED_DECLARATION))
 	}
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -124,6 +124,18 @@ func (p *Parser) ReadPeek() {
 			p.level++
 		case token.RIGHT_BRACE:
 			p.level--
+		case token.FASTLY_CONTROL:
+			// Skip Fastly control syntaxes
+			continue
+		case token.PRAGMA:
+			// Skip Fastly pgrama embedded data
+			for {
+				t = p.l.NextToken()
+				if t.Type == token.SEMICOLON {
+					break
+				}
+			}
+			continue
 		}
 		meta := ast.New(t, p.level, leading)
 		meta.PreviousEmptyLines = previousEmptyLines

--- a/token/token.go
+++ b/token/token.go
@@ -130,6 +130,12 @@ const (
 	// This keyword is special usecase for extensible language definition.
 	// Token is processed via custom lexer/parser definition by literal
 	CUSTOM = "CUSTOM"
+
+	// Fastly Generated control syntaxes
+	// Fastly automatically generates some control syntaxes like "pragma".
+	// falco should lex them
+	PRAGMA         = "PRAGMA"
+	FASTLY_CONTROL = "CONTROL" // Presents as "C!" or "W!" character
 )
 
 var keywords = map[string]TokenType{
@@ -167,6 +173,7 @@ var keywords = map[string]TokenType{
 	"default":          DEFAULT,
 	"break":            BREAK,
 	"fallthrough":      FALLTHROUGH,
+	"pragma":           PRAGMA,
 }
 
 func LookupIdent(ident string) TokenType {


### PR DESCRIPTION
Fixes #337 

This PR supports Fastly generated VCL with the following features.

- enable to lex/parse Fastly specific syntax `pragma`, `C!`, `W!` but ignore on linting
- default ignore linting `vcl_pipe` subroutine because we don't know what scope should be (undocumented)

And improve some linting logics.

- add `is_ssl` field to shield director
- support more string concatenation for `req.hash`