### PR TITLE
feat: add --genearted option and add vcl_pipe related linter rule

### DIFF
--- a/cmd/falco/help.go
+++ b/cmd/falco/help.go
@@ -167,6 +167,7 @@ Flags:
     -v                 : Output lint warnings (verbose)
     -vv                : Output all lint results (very verbose)
     -json              : Output results as JSON (very verbose)
+	--generated        : Lint for Fastly generated VCL
 
 Simple linting with very verbose example:
     falco lint -I . -vv /path/to/vcl/main.vcl

--- a/cmd/falco/help.go
+++ b/cmd/falco/help.go
@@ -167,7 +167,7 @@ Flags:
     -v                 : Output lint warnings (verbose)
     -vv                : Output all lint results (very verbose)
     -json              : Output results as JSON (very verbose)
-	--generated        : Lint for Fastly generated VCL
+    --generated        : Lint for Fastly generated VCL
 
 Simple linting with very verbose example:
     falco lint -I . -vv /path/to/vcl/main.vcl

--- a/cmd/falco/runner_test.go
+++ b/cmd/falco/runner_test.go
@@ -51,13 +51,6 @@ func loadRepoExampleTestMetadata() []RepoExampleTestMetadata {
 			warnings: 0,
 			infos:    1,
 		},
-		{
-			name:     "Fastly Generated",
-			fileName: "../../examples/linter/fastly_generated.vcl",
-			errors:   0,
-			warnings: 12,
-			infos:    2,
-		},
 	}
 
 	// Run custom linter testing only in CI env
@@ -404,5 +397,33 @@ func TestTester(t *testing.T) {
 				return
 			}
 		})
+	}
+}
+
+func TestFastlyGeneratedVCLLinting(t *testing.T) {
+	c, err := config.New([]string{"--generated"})
+	if err != nil {
+		t.Errorf("Unexpected config pointer generation error: %s", err)
+		return
+	}
+
+	resolvers, err := resolver.NewFileResolvers("../../examples/linter/fastly_generated.vcl", c.IncludePaths)
+	if err != nil {
+		t.Errorf("Unexpected runner creation error: %s", err)
+		return
+	}
+	ret, err := NewRunner(c, nil).Run(resolvers[0])
+	if err != nil {
+		t.Errorf("Unexpected linting error: %s", err)
+		return
+	}
+	if ret.Infos != 2 {
+		t.Errorf("Infos expects 2, got %d", ret.Infos)
+	}
+	if ret.Warnings != 3 {
+		t.Errorf("Warning expects 3, got %d", ret.Warnings)
+	}
+	if ret.Errors > 0 {
+		t.Errorf("Errors expects 0, got %d", ret.Errors)
 	}
 }

--- a/config/command.go
+++ b/config/command.go
@@ -20,6 +20,7 @@ var needValueOptions = map[string]struct{}{
 	"--transformer":  {},
 	"-f":             {},
 	"--filter":       {},
+	"--generated":    {},
 }
 
 func parseCommands(args []string) Commands {

--- a/config/config.go
+++ b/config/config.go
@@ -37,6 +37,7 @@ type LinterConfig struct {
 	Rules                   map[string]string   `yaml:"rules"`
 	EnforceSubroutineScopes map[string][]string `yaml:"enforce_subroutine_scopes"`
 	IgnoreSubroutines       []string            `yaml:"ignore_subroutines"`
+	IsGenerated             bool                `cli:"generated"`
 }
 
 // Simulator configuration
@@ -177,6 +178,14 @@ func New(args []string) (*Config, error) {
 	// On Fastly generated VCL, "vcl_pipe" subroutine will present internally.
 	// The "vcl_pipe" subroutine looks fastly managed but undocumented, so we will ignore linting
 	c.Linter.IgnoreSubroutines = append(c.Linter.IgnoreSubroutines, "vcl_pipe")
+	// If generated option provided for linter, modify default rules
+	if c.Linter.IsGenerated {
+		if c.Linter.Rules == nil {
+			c.Linter.Rules = make(map[string]string)
+		}
+		// Fastly generated VCL no longer has boiler-plate marco due to extracted so ignore it
+		c.Linter.Rules["subroutine/boilerplate-macro"] = "IGNORE" // TODO: use linter rule constants instead of string hard-coded
+	}
 
 	return c, nil
 }

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -869,3 +869,10 @@ sub ignored_subroutine {
 		assertNoError(t, input)
 	})
 }
+
+func TestForbidVclPipeSubroutine(t *testing.T) {
+	input := `
+sub vcl_pipe {}
+`
+	assertError(t, input)
+}

--- a/linter/rules.go
+++ b/linter/rules.go
@@ -33,6 +33,7 @@ const (
 	SUBROUTINE_DUPLICATED                = "subroutine/duplicated"
 	SUBROUTINE_INVALID_RETURN_TYPE       = "subroutine/invalid-return-type"
 	UNRECOGNIZE_CALL_SCOPE               = "subroutine/unrecognize-call-scope"
+	FORBID_VCL_PIPE                      = "subroutine/forbid-vcl-pipe"
 	PENALTYBOX_SYNTAX                    = "penaltybox/syntax"
 	PENALTYBOX_DUPLICATED                = "penaltybox/duplicated"
 	PENALTYBOX_NONEMPTY_BLOCK            = "penaltybox/nonempty-block"


### PR DESCRIPTION
This PR includes a couple of features:

1. add `--generated` cli option that indicates linting for Fastly generated VCL
2. Forbid `vcl_pipe` subroutine declaration in custom VCL