### PR TITLE
fix: update timezone in test

### DIFF
--- a/examples/testing/default_values.test.vcl
+++ b/examples/testing/default_values.test.vcl
@@ -75,7 +75,7 @@ sub test_default_local_var_recv {
   assert.false(var.bool);
   assert.equal(var.integer, 0);
   assert.equal(var.float, 0.000);
-  assert.equal(var.time, std.time("Thu, 01 Jan 1970 00:00:00 GMT", now));
+  assert.equal(var.time, std.time("Thu, 01 Jan 1970 00:00:00 UTC", now));
   assert.equal(var.rtime, 0s);
 
   if (!var.string) {


### PR DESCRIPTION
The default time value assertion in the `test_default_local_var_recv()` function uses the "GMT" time zone, but `local.go` when creating a default `TIME` value uses a "UTC" time standard. This causes tests to fail when run in the UK (BST):

```
--- FAIL: TestTester (0.00s)
    --- FAIL: TestTester/empty_and_notset_value_test (0.00s)
        runner_test.go:386: Test case "default value check" raises error:
        Assertion Error: Assertion error:
        expect=Thu, 01 Jan 1970 01:00:00 GMT,
        actual=Thu, 01 Jan 1970 00:00:00 GMT
FAIL
```

To resolve this, update the test to use "UTC".