### PR TITLE
fix(config): adjust default TrailingCommentWidth to 1

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -85,7 +85,7 @@ type FormatConfig struct {
 
 	// Formatter options
 	IndentWidth                int    `yaml:"indent_width" default:"2"`
-	TrailingCommentWidth       int    `yaml:"trailing_comment_width" default:"2"`
+	TrailingCommentWidth       int    `yaml:"trailing_comment_width" default:"1"`
 	IndentStyle                string `yaml:"indent_style" default:"space"`
 	LineWidth                  int    `yaml:"line_width" default:"120"`
 	ExplicitStringConat        bool   `yaml:"explicit_string_concat" default:"false"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -70,7 +70,7 @@ func TestConfigFromCLI(t *testing.T) {
 		},
 		Format: &FormatConfig{
 			IndentWidth:                2,
-			TrailingCommentWidth:       2,
+			TrailingCommentWidth:       1,
 			LineWidth:                  120,
 			IndentStyle:                "space",
 			ExplicitStringConat:        false,


### PR DESCRIPTION
Change the default value of `TrailingCommentWidth` from 2 to 1 in the `FormatConfig` struct and its corresponding test.

This matches Fastly's style. Fastly has standardized on one space for a trailing comment, like `gofmt`, Prettier for JavaScript, `rustfmt`, and others:

https://www.fastly.com/documentation/guides/vcl/best-practices/#organize-and-comment-your-code https://www.fastly.com/documentation/guides/vcl/using/#custom-vcl