### PR TITLE
Feat/exact custom token

### DIFF
--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -681,10 +681,12 @@ func TestPeekToken(t *testing.T) {
 
 func TestCustomToken(t *testing.T) {
 	input := `describe foo {}`
-	l := NewFromString(input, WithCustomTokens("describe"))
+	l := NewFromString(input, WithCustomTokens(map[string]token.TokenType{
+		"describe": token.Custom("DESCRIBE"),
+	}))
 
 	expects := []token.Token{
-		{Type: token.CUSTOM, Literal: "describe", Line: 1, Position: 1},
+		{Type: token.TokenType("DESCRIBE"), Literal: "describe", Line: 1, Position: 1},
 		{Type: token.IDENT, Literal: "foo", Line: 1, Position: 10},
 		{Type: token.LEFT_BRACE, Literal: "{", Line: 1, Position: 14},
 		{Type: token.RIGHT_BRACE, Literal: "}", Line: 1, Position: 15},

--- a/lexer/option.go
+++ b/lexer/option.go
@@ -1,10 +1,12 @@
 package lexer
 
+import "github.com/ysugimoto/falco/token"
+
 type OptionFunc func(o *Option)
 
 type Option struct {
 	Filename string
-	Customs  map[string]struct{}
+	Customs  map[string]token.TokenType
 	// more field if exists
 }
 
@@ -14,10 +16,10 @@ func WithFile(filename string) OptionFunc {
 	}
 }
 
-func WithCustomTokens(idents ...string) OptionFunc {
+func WithCustomTokens(tokenMap map[string]token.TokenType) OptionFunc {
 	return func(o *Option) {
-		for i := range idents {
-			o.Customs[idents[i]] = struct{}{}
+		for k, v := range tokenMap {
+			o.Customs[k] = v
 		}
 	}
 }
@@ -25,7 +27,7 @@ func WithCustomTokens(idents ...string) OptionFunc {
 func collect(opts []OptionFunc) *Option {
 	o := &Option{
 		Filename: "",
-		Customs:  make(map[string]struct{}),
+		Customs:  make(map[string]token.TokenType),
 	}
 
 	for i := range opts {

--- a/parser/custom_parser.go
+++ b/parser/custom_parser.go
@@ -2,15 +2,17 @@ package parser
 
 import (
 	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/token"
 )
 
 type CustomParser interface {
-	Literal() string
+	Ident() string
+	Token() token.TokenType
 	Parse(*Parser) (ast.CustomStatement, error)
 }
 
 func (p *Parser) ParseCustomToken() (ast.CustomStatement, error) {
-	v, ok := p.customParsers[p.curToken.Token.Literal]
+	v, ok := p.customParsers[p.curToken.Token.Type]
 	if !ok {
 		return nil, UnexpectedToken(p.curToken)
 	}

--- a/parser/custom_parser_test.go
+++ b/parser/custom_parser_test.go
@@ -49,9 +49,13 @@ func (d *DescribeStatement) String() string {
 
 type DescribeParser struct{}
 
-func (d *DescribeParser) Literal() string {
+func (d *DescribeParser) Ident() string {
 	return "describe"
 }
+func (d *DescribeParser) Token() token.TokenType {
+	return token.Custom("DESCRIBE")
+}
+
 func (d *DescribeParser) Parse(p *Parser) (ast.CustomStatement, error) {
 	stmt := &DescribeStatement{
 		Meta: p.curToken,
@@ -75,7 +79,7 @@ func (d *DescribeParser) Parse(p *Parser) (ast.CustomStatement, error) {
 				return nil, errors.WithStack(err)
 			}
 			stmt.Subroutines = append(stmt.Subroutines, sub)
-		case token.CUSTOM:
+		case token.TokenType("BEFORE_EACH"):
 			cs, err := p.ParseCustomToken()
 			if err != nil {
 				return nil, errors.WithStack(err)
@@ -125,8 +129,11 @@ func (b *BeforeEachStatement) String() string {
 
 type BeforeEachParser struct{}
 
-func (b *BeforeEachParser) Literal() string {
+func (b *BeforeEachParser) Ident() string {
 	return "before_each"
+}
+func (b *BeforeEachParser) Token() token.TokenType {
+	return token.Custom("BEFORE_EACH")
 }
 func (b *BeforeEachParser) Parse(p *Parser) (ast.CustomStatement, error) {
 	stmt := &BeforeEachStatement{

--- a/parser/option.go
+++ b/parser/option.go
@@ -5,7 +5,7 @@ type ParserOption func(p *Parser)
 func WithCustomParser(cps ...CustomParser) ParserOption {
 	return func(p *Parser) {
 		for i := range cps {
-			p.customParsers[cps[i].Literal()] = cps[i]
+			p.customParsers[cps[i].Token()] = cps[i]
 		}
 	}
 }

--- a/parser/statement_parser.go
+++ b/parser/statement_parser.go
@@ -61,8 +61,6 @@ func (p *Parser) ParseStatement() (ast.Statement, error) {
 		stmt, err = p.ParseBreakStatement()
 	case token.FALLTHROUGH:
 		stmt, err = p.ParseFallthroughStatement()
-	case token.CUSTOM:
-		stmt, err = p.ParseCustomToken()
 	case token.IDENT:
 		// Check if the current ident is a function call
 		if p.PeekTokenIs(token.LEFT_PAREN) {
@@ -76,7 +74,11 @@ func (p *Parser) ParseStatement() (ast.Statement, error) {
 			}
 		}
 	default:
-		err = UnexpectedToken(p.curToken)
+		if custom, ok := p.customParsers[p.curToken.Token.Type]; ok {
+			stmt, err = custom.Parse(p)
+		} else {
+			err = UnexpectedToken(p.curToken)
+		}
 	}
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/tester/syntax/hooks.go
+++ b/tester/syntax/hooks.go
@@ -2,6 +2,7 @@ package syntax
 
 import (
 	"bytes"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/ysugimoto/falco/ast"
@@ -42,8 +43,11 @@ type HookParser struct {
 	keyword string
 }
 
-func (h *HookParser) Literal() string {
+func (h *HookParser) Ident() string {
 	return h.keyword
+}
+func (h *HookParser) Token() token.TokenType {
+	return token.Custom(strings.ToUpper(h.keyword))
 }
 func (h *HookParser) Parse(p *parser.Parser) (ast.CustomStatement, error) {
 	stmt := &HookStatement{
@@ -60,4 +64,25 @@ func (h *HookParser) Parse(p *parser.Parser) (ast.CustomStatement, error) {
 	}
 
 	return stmt, nil
+}
+
+var hookParsers = map[token.TokenType]*HookParser{
+	token.Custom("BEFORE_RECV"):    {keyword: "before_recv"},
+	token.Custom("BEFORE_HASH"):    {keyword: "before_hash"},
+	token.Custom("BEFORE_HIT"):     {keyword: "before_hit"},
+	token.Custom("BEFORE_MISS"):    {keyword: "before_miss"},
+	token.Custom("BEFORE_PASS"):    {keyword: "before_pass"},
+	token.Custom("BEFORE_FETCH"):   {keyword: "before_fetch"},
+	token.Custom("BEFORE_ERROR"):   {keyword: "before_error"},
+	token.Custom("BEFORE_DELIVER"): {keyword: "before_deliver"},
+	token.Custom("BEFORE_LOG"):     {keyword: "before_log"},
+	token.Custom("AFTER_RECV"):     {keyword: "after_recv"},
+	token.Custom("AFTER_HASH"):     {keyword: "after_hash"},
+	token.Custom("AFTER_HIT"):      {keyword: "after_hit"},
+	token.Custom("AFTER_MISS"):     {keyword: "after_miss"},
+	token.Custom("AFTER_PASS"):     {keyword: "after_pass"},
+	token.Custom("AFTER_FETCH"):    {keyword: "after_fetch"},
+	token.Custom("AFTER_ERROR"):    {keyword: "after_error"},
+	token.Custom("AFTER_DELIVER"):  {keyword: "after_deliver"},
+	token.Custom("AFTER_LOG"):      {keyword: "after_log"},
 }

--- a/tester/syntax/parsers.go
+++ b/tester/syntax/parsers.go
@@ -3,30 +3,35 @@ package syntax
 import "github.com/ysugimoto/falco/parser"
 
 func CustomParsers() []parser.CustomParser {
-	return []parser.CustomParser{
+	customs := []parser.CustomParser{
 		// describe keyword
 		&DescribeParser{},
-
-		// before hooks
-		&HookParser{keyword: "before_recv"},
-		&HookParser{keyword: "before_hash"},
-		&HookParser{keyword: "before_hit"},
-		&HookParser{keyword: "before_miss"},
-		&HookParser{keyword: "before_pass"},
-		&HookParser{keyword: "before_fetch"},
-		&HookParser{keyword: "before_error"},
-		&HookParser{keyword: "before_deliver"},
-		&HookParser{keyword: "before_log"},
-
-		// after hooks
-		&HookParser{keyword: "after_recv"},
-		&HookParser{keyword: "after_hash"},
-		&HookParser{keyword: "after_hit"},
-		&HookParser{keyword: "after_miss"},
-		&HookParser{keyword: "after_pass"},
-		&HookParser{keyword: "after_fetch"},
-		&HookParser{keyword: "after_error"},
-		&HookParser{keyword: "after_deliver"},
-		&HookParser{keyword: "after_log"},
 	}
+	// hooks
+	for _, v := range hookParsers {
+		customs = append(customs, v)
+	}
+	return customs
+
+	// // before hooks
+	// &HookParser{keyword: "before_recv"},
+	// &HookParser{keyword: "before_hash"},
+	// &HookParser{keyword: "before_hit"},
+	// &HookParser{keyword: "before_miss"},
+	// &HookParser{keyword: "before_pass"},
+	// &HookParser{keyword: "before_fetch"},
+	// &HookParser{keyword: "before_error"},
+	// &HookParser{keyword: "before_deliver"},
+	// &HookParser{keyword: "before_log"},
+
+	// // after hooks
+	// &HookParser{keyword: "after_recv"},
+	// &HookParser{keyword: "after_hash"},
+	// &HookParser{keyword: "after_hit"},
+	// &HookParser{keyword: "after_miss"},
+	// &HookParser{keyword: "after_pass"},
+	// &HookParser{keyword: "after_fetch"},
+	// &HookParser{keyword: "after_error"},
+	// &HookParser{keyword: "after_deliver"},
+	// &HookParser{keyword: "after_log"},
 }

--- a/tester/syntax/parsers.go
+++ b/tester/syntax/parsers.go
@@ -12,26 +12,4 @@ func CustomParsers() []parser.CustomParser {
 		customs = append(customs, v)
 	}
 	return customs
-
-	// // before hooks
-	// &HookParser{keyword: "before_recv"},
-	// &HookParser{keyword: "before_hash"},
-	// &HookParser{keyword: "before_hit"},
-	// &HookParser{keyword: "before_miss"},
-	// &HookParser{keyword: "before_pass"},
-	// &HookParser{keyword: "before_fetch"},
-	// &HookParser{keyword: "before_error"},
-	// &HookParser{keyword: "before_deliver"},
-	// &HookParser{keyword: "before_log"},
-
-	// // after hooks
-	// &HookParser{keyword: "after_recv"},
-	// &HookParser{keyword: "after_hash"},
-	// &HookParser{keyword: "after_hit"},
-	// &HookParser{keyword: "after_miss"},
-	// &HookParser{keyword: "after_pass"},
-	// &HookParser{keyword: "after_fetch"},
-	// &HookParser{keyword: "after_error"},
-	// &HookParser{keyword: "after_deliver"},
-	// &HookParser{keyword: "after_log"},
 }

--- a/token/token.go
+++ b/token/token.go
@@ -28,6 +28,10 @@ var Null = Token{
 	Literal: "NULL",
 }
 
+func Custom(name string) TokenType {
+	return TokenType(name)
+}
+
 const (
 	ILLEGAL = "ILLEGAL"
 	EOF     = "EOF"
@@ -125,11 +129,6 @@ const (
 	DEFAULT          = "DEFAULT"          // default
 	BREAK            = "BREAK"            // break
 	FALLTHROUGH      = "FALLTHROUGH"      // fallthrough
-
-	// Custom Keywords
-	// This keyword is special usecase for extensible language definition.
-	// Token is processed via custom lexer/parser definition by literal
-	CUSTOM = "CUSTOM"
 
 	// Fastly Generated control syntaxes
 	// Fastly automatically generates some control syntaxes like "pragma".


### PR DESCRIPTION
This PR improves custom-token dealing
Before this PR we treated custom tokens as `token.CUSTOM` signature but we should distinguish for each custom tokens like `token.DESCRIBE`, etc.

After this PR, we could define custom token with `literal` and `token.XXX` tokenType and do parse and linting corresponds to custom parser.

This change may break user's custom parser but probably nobody is using it, only for internal system (testing).