### PR TITLE
Fix tiny bug of base64 decode functions

### DIFF
--- a/cmd/falco/runner_test.go
+++ b/cmd/falco/runner_test.go
@@ -358,6 +358,12 @@ func TestTester(t *testing.T) {
 			filter: "*override_variables.test.vcl",
 			passes: 6,
 		},
+		{
+			name:   "base64 functional test",
+			main:   "../../examples/testing/base64/main.vcl",
+			filter: "*base64.test.vcl",
+			passes: 12,
+		},
 	}
 
 	for _, tt := range tests {

--- a/examples/testing/base64/base64.test.vcl
+++ b/examples/testing/base64/base64.test.vcl
@@ -1,0 +1,66 @@
+// https://fiddle.fastly.dev/fiddle/a3b006c4
+
+// @scope: recv
+// @suite: Test base64 decode
+sub test_base64_decode_recv {
+    declare local var.input STRING;
+    declare local var.decoded STRING;
+
+    set var.input = "aGVsbG8=0";
+
+    set var.decoded = digest.base64_decode(var.input);
+    assert.equal(std.strlen(var.decoded), 5);
+    assert.equal(var.decoded, "hello");
+
+    set var.decoded = digest.base64url_decode(var.input);
+    assert.equal(std.strlen(var.decoded), 5);
+    assert.equal(var.decoded, "hello");
+
+    set var.decoded = digest.base64url_nopad_decode(var.input);
+    assert.equal(std.strlen(var.decoded), 6);
+    assert.equal(var.decoded, "hello4");
+}
+
+// @scope: recv
+// @suite: Test base64 decode NULL string
+sub test_base64_decode_recv {
+    declare local var.input STRING;
+    declare local var.decoded STRING;
+
+    set var.input = "c29tZSBkYXRhIHdpdGggACBhbmQg77u/";
+
+    set var.decoded = digest.base64_decode(var.input);
+    assert.equal(std.strlen(var.decoded), 15);
+    assert.equal(var.decoded, "some data with ");
+
+    set var.decoded = digest.base64url_decode(var.input);
+    assert.equal(std.strlen(var.decoded), 15);
+    assert.equal(var.decoded, "some data with ");
+
+    set var.decoded = digest.base64url_nopad_decode(var.input);
+    assert.equal(std.strlen(var.decoded), 15);
+    assert.equal(var.decoded, "some data with ");
+}
+
+// @scope: recv
+// @suite: Test base64 decode BOM string
+sub test_base64_decode_recv {
+  // Skip tests because we suspects Fastly has a tiny bug in base64 decoding with BOM 
+    declare local var.input STRING;
+    declare local var.decoded STRING;
+
+    set var.input = "c29tZSBkYXRhIHdpdGgg77u/IGFuZCAA";
+
+    // set var.decoded = digest.base64_decode(var.input);
+    // assert.equal(std.strlen(var.decoded), 23);
+    # assert.equal(var.decoded, "some data with \xef\xbb\xbf and");
+
+    // set var.decoded = digest.base64url_decode(var.input);
+    // assert.equal(std.strlen(var.decoded), 22);
+    # assert.equal(var.decoded, "some data with ﻈ[�");
+
+    // set var.decoded = digest.base64url_nopad_decode(var.input);
+    // assert.equal(std.strlen(var.decoded), 22);
+    # assert.equal(var.decoded, "some data with ﻈ[�");
+}
+

--- a/examples/testing/base64/main.vcl
+++ b/examples/testing/base64/main.vcl
@@ -1,0 +1,5 @@
+# https://fiddle.fastly.dev/fiddle/6a433b2e
+
+backend default_0 {
+  .host = "example.com";
+}

--- a/interpreter/function/builtin/digest_base64_decode.go
+++ b/interpreter/function/builtin/digest_base64_decode.go
@@ -78,7 +78,7 @@ func Digest_base64_decode_removeInvalidCharacters(input string) string {
 			removed.WriteByte(b)
 		case b >= 0x61 && b <= 0x7A: // a-z
 			removed.WriteByte(b)
-		case b >= 0x31 && b <= 0x39: // 0-9
+		case b >= 0x30 && b <= 0x39: // 0-9
 			removed.WriteByte(b)
 		case b == 0x2B || b == 0x2F: // + or /
 			removed.WriteByte(b)

--- a/interpreter/function/builtin/digest_base64url_decode.go
+++ b/interpreter/function/builtin/digest_base64url_decode.go
@@ -61,7 +61,7 @@ func Digest_base64url_decode_removeInvalidCharacters(input string) string {
 			removed.WriteByte(b)
 		case b >= 0x61 && b <= 0x7A: // a-z
 			removed.WriteByte(b)
-		case b >= 0x31 && b <= 0x39: // 0-9
+		case b >= 0x30 && b <= 0x39: // 0-9
 			removed.WriteByte(b)
 		case b == 0x2B: // + should replace to -
 			removed.WriteByte(0x2D)

--- a/interpreter/function/builtin/digest_base64url_nopad_decode.go
+++ b/interpreter/function/builtin/digest_base64url_nopad_decode.go
@@ -61,7 +61,7 @@ func Digest_base64url_nopad_decode_removeInvalidCharacters(input string) string 
 			removed.WriteByte(b)
 		case b >= 0x61 && b <= 0x7A: // a-z
 			removed.WriteByte(b)
-		case b >= 0x31 && b <= 0x39: // 0-9
+		case b >= 0x30 && b <= 0x39: // 0-9
 			removed.WriteByte(b)
 		case b == 0x2B: // + should replace to -
 			removed.WriteByte(0x2D)

--- a/interpreter/function/builtin/digest_base64url_nopad_decode_test.go
+++ b/interpreter/function/builtin/digest_base64url_nopad_decode_test.go
@@ -49,6 +49,11 @@ func Test_Digest_base64url_nopad_decode(t *testing.T) {
 			input:  "YWJjZB==",
 			expect: "abcd",
 		},
+		{
+			name:   "Skip padding sign/2",
+			input:  "aGVsbG8=0",
+			expect: "hello4",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR fixes base64 decode related functions.

Note that we're not sure for Fastly's base64 decoding functionality including BOM so currenly we skip that tests.
Ensuting test comes from here: https://github.com/bungoume/falco-vcl-empty-test/blob/main/tests/base64_decode.test.vcl thanks @bungoume 