### PR TITLE
implement assert.not_error assertion method

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -229,6 +229,7 @@ We describe them following table and examples:
 | assert.restart               | FUNCTION   | Assert restart statement has called                                                          |
 | assert.state                 | FUNCTION   | Assert after state is expected one                                                           |
 | assert.error                 | FUNCTION   | Assert error status code (and response) if error statement has called                        |
+| assert.not_error             | FUNCTION   | Assert runtime state will not move to error status                                           |
 
 ----
 
@@ -865,6 +866,22 @@ sub test_vcl {
 
     // Assert error statement has called with expected status and response text
     assert.error(900, "Fastly Internal");
+}
+```
+
+----
+
+### assert.not_error([STRING message])
+
+Assert runtime state will not move to error status.
+
+```vcl
+sub test_vcl {
+    // vcl_recv will call error statement with status code and response
+    testing.call_subroutine("vcl_recv");
+
+    // Assert error statement has not called
+    assert.not_error();
 }
 ```
 

--- a/tester/function/assert_not_error.go
+++ b/tester/function/assert_not_error.go
@@ -1,0 +1,53 @@
+package function
+
+import (
+	"github.com/ysugimoto/falco/interpreter"
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/function/errors"
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+const Assert_not_error_Name = "assert.not_error"
+
+var Assert_not_error_ArgumentTypes = []value.Type{value.IntegerType}
+
+func Assert_not_error_Validate(args []value.Value) error {
+	if len(args) > 1 {
+		return errors.ArgumentNotInRange(Assert_not_error_Name, 0, 1, args)
+	}
+
+	return nil
+}
+
+func Assert_not_error(
+	ctx *context.Context,
+	i *interpreter.Interpreter,
+	args ...value.Value,
+) (value.Value, error) {
+
+	if err := Assert_not_error_Validate(args); err != nil {
+		return nil, errors.NewTestingError(err.Error())
+	}
+
+	// extract arguments
+	var message string
+	if len(args) == 1 {
+		message = value.Unwrap[*value.String](args[0]).Value
+	}
+
+	// Check state doesn't move to ERROR internally
+	if i.TestingState == interpreter.ERROR {
+		if message == "" {
+			return &value.Boolean{}, errors.NewAssertionError(
+				&value.String{Value: i.TestingState.String()},
+				"State should not move to ERROR",
+			)
+		}
+		return &value.Boolean{}, errors.NewAssertionError(
+			&value.String{Value: i.TestingState.String()},
+			message,
+		)
+	}
+
+	return &value.Boolean{Value: true}, nil
+}

--- a/tester/function/assert_not_error_test.go
+++ b/tester/function/assert_not_error_test.go
@@ -1,0 +1,75 @@
+package function
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/ysugimoto/falco/interpreter"
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/function/errors"
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+func Test_Assert_not_error(t *testing.T) {
+
+	tests := []struct {
+		args   []value.Value
+		ip     *interpreter.Interpreter
+		ctx    *context.Context
+		err    error
+		expect *value.Boolean
+	}{
+		{
+			args: []value.Value{},
+			ip: &interpreter.Interpreter{
+				TestingState: interpreter.LOOKUP,
+			},
+			ctx: &context.Context{
+				ObjectStatus: &value.Integer{Value: 900},
+			},
+			expect: &value.Boolean{Value: true},
+		},
+		{
+			args: []value.Value{},
+			ip: &interpreter.Interpreter{
+				TestingState: interpreter.LOOKUP,
+			},
+			ctx: &context.Context{
+				ObjectStatus:   &value.Integer{Value: 900},
+				ObjectResponse: &value.String{Value: "Fastly Internal."},
+			},
+			expect: &value.Boolean{Value: true},
+		},
+		{
+			args: []value.Value{
+				&value.String{Value: "custom message"},
+			},
+			ip: &interpreter.Interpreter{
+				TestingState: interpreter.ERROR,
+			},
+			ctx: &context.Context{
+				ObjectStatus:   &value.Integer{Value: 900},
+				ObjectResponse: &value.String{Value: "Fastly Internal."},
+			},
+			expect: &value.Boolean{Value: false},
+			err:    &errors.AssertionError{},
+		},
+	}
+
+	for i := range tests {
+		_, err := Assert_not_error(
+			tests[i].ctx,
+			tests[i].ip,
+			tests[i].args...,
+		)
+		if diff := cmp.Diff(
+			tests[i].err,
+			err,
+			cmpopts.IgnoreFields(errors.AssertionError{}, "Message", "Actual"),
+			cmpopts.IgnoreFields(errors.TestingError{}, "Message"),
+		); diff != "" {
+			t.Errorf("Assert_error()[%d] error: diff=%s", i, diff)
+		}
+	}
+}


### PR DESCRIPTION
This PR impelements additional assertion function `assert.not_error()`.
This function asserts internal lifecycle state DOES NOT move to "ERROR".