### PR TITLE
fix header existence logic, exactly treat as null or empty string

### DIFF
--- a/examples/testing/default/default.test.vcl
+++ b/examples/testing/default/default.test.vcl
@@ -26,3 +26,19 @@ sub test_check_auth {
   assert.equal(testing.state, "ERROR");
   assert.equal(testing.inspect("obj.status"), 401);
 }
+
+// @scope: recv
+// @suite: condition with not set string header
+sub test_header_value {
+  declare local var.exists BOOL;
+  if (req.http.Check-Auth) {
+    set var.exists = true;
+  }
+  assert.false(var.exists);
+  set req.http.Check-Auth = "";
+  if (req.http.Check-Auth) {
+    set var.exists = true;
+  }
+  assert.true(var.exists);
+}
+

--- a/interpreter/variable/header.go
+++ b/interpreter/variable/header.go
@@ -12,11 +12,11 @@ import (
 func getRequestHeaderValue(r *http.Request, name string) *value.String {
 	// Header name can contain ":" for object-like value
 	if !strings.Contains(name, ":") {
-		v := strings.Join(r.Header.Values(name), ", ")
-		if v == "" {
-			return &value.String{IsNotSet: true}
+		if _, ok := r.Header[textproto.CanonicalMIMEHeaderKey(name)]; ok {
+			v := strings.Join(r.Header.Values(name), ", ")
+			return &value.String{Value: v}
 		}
-		return &value.String{Value: v}
+		return &value.String{IsNotSet: true}
 	}
 	spl := strings.SplitN(name, ":", 2)
 	// Request header can modify cookie, then we need to retrieve value from Cookie pointer
@@ -40,11 +40,11 @@ func getRequestHeaderValue(r *http.Request, name string) *value.String {
 func getResponseHeaderValue(r *http.Response, name string) *value.String {
 	// Header name can contain ":" for object-like value
 	if !strings.Contains(name, ":") {
-		v := strings.Join(r.Header.Values(name), ", ")
-		if v == "" {
-			return &value.String{IsNotSet: true}
+		if _, ok := r.Header[textproto.CanonicalMIMEHeaderKey(name)]; ok {
+			v := strings.Join(r.Header.Values(name), ", ")
+			return &value.String{Value: v}
 		}
-		return &value.String{Value: v}
+		return &value.String{IsNotSet: true}
 	}
 
 	spl := strings.SplitN(name, ":", 2)


### PR DESCRIPTION
This changes are pretty important that improves checking header key existence inside `if` condition.
In Fastly runtime, the _not-set_ header, means header is not exist will be false in if condition.
However, the empty string value even header key exists, it would be true in if condition.

```vcl
if (req.http.Foo) {
  log "exists"; // don't output because Foo header is not-set
}
set req.http.Foo = "";
if (req.http.Foo) {
  log "exists2"; // output because Foo header is set with empty string
}
```

Fastly fiddle: https://fiddle.fastly.dev/fiddle/ed2a5dbb

This bug comes from golang's zero-value relating things... it's very helpful for real world usage but not for reproducing VCL runtime X(