### PR TITLE
improve url encode and decode built-in functions

### DIFF
--- a/interpreter/function/builtin/urldecode.go
+++ b/interpreter/function/builtin/urldecode.go
@@ -3,10 +3,9 @@
 package builtin
 
 import (
-	"net/url"
-
 	"github.com/ysugimoto/falco/interpreter/context"
 	"github.com/ysugimoto/falco/interpreter/function/errors"
+	"github.com/ysugimoto/falco/interpreter/function/shared"
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
@@ -37,11 +36,9 @@ func Urldecode(ctx *context.Context, args ...value.Value) (value.Value, error) {
 	}
 
 	input := value.Unwrap[*value.String](args[0]).Value
-	dec, err := url.QueryUnescape(input)
+	dec, err := shared.UrlDecode(input)
 	if err != nil {
-		return &value.String{IsNotSet: true}, errors.New(Urldecode_Name,
-			"Failed to urldecode string: %s", input,
-		)
+		return &value.String{IsNotSet: true}, errors.New(Urldecode_Name, err.Error())
 	}
 
 	return &value.String{Value: dec}, nil

--- a/interpreter/function/builtin/urldecode_test.go
+++ b/interpreter/function/builtin/urldecode_test.go
@@ -19,8 +19,50 @@ func Test_Urldecode(t *testing.T) {
 		input  string
 		expect string
 	}{
-		{input: "hello%20world+!", expect: "hello world !"},
-		{input: "hello%2520world+!", expect: "hello%20world !"},
+		{
+			input:  "",
+			expect: "",
+		},
+		{
+			input:  "ab",
+			expect: "ab",
+		},
+		{
+			input:  "%E3%81%82",
+			expect: "あ",
+		},
+		{
+			input:  "%01%02%03%04%05%06%07%08%09%0A%0B%0C%0D%0E%0F",
+			expect: string([]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}),
+		},
+		{
+			input:  "%10%11%12%13%14%15%16%17%18%19%1A%1B%1C%1D%1E%1F",
+			expect: string([]byte{0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F}),
+		},
+		{
+			input:  "%20%21%22%23%24%25%26%27%28%29%2A%2B%2C-.%2F",
+			expect: ` !"#$%&'()*+,-./`,
+		},
+		{
+			input:  "0123456789%3A%3B%3C%3D%3E%3F",
+			expect: "0123456789:;<=>?",
+		},
+		{
+			input:  "%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_",
+			expect: "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_",
+		},
+		{
+			input:  "%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~",
+			expect: "`abcdefghijklmnopqrstuvwxyz{|}~",
+		},
+		{
+			input:  "%7F",
+			expect: string([]byte{0x7F}),
+		},
+		{
+			input:  "hello%20world",
+			expect: "hello world",
+		},
 	}
 
 	for i, tt := range tests {

--- a/interpreter/function/builtin/urldecode_test.go
+++ b/interpreter/function/builtin/urldecode_test.go
@@ -32,6 +32,10 @@ func Test_Urldecode(t *testing.T) {
 			expect: "あ",
 		},
 		{
+			input:  "%F0%A0%AE%B7%F0%9F%98%AF",
+			expect: "𠮷😯",
+		},
+		{
 			input:  "%01%02%03%04%05%06%07%08%09%0A%0B%0C%0D%0E%0F",
 			expect: string([]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}),
 		},

--- a/interpreter/function/builtin/urlencode.go
+++ b/interpreter/function/builtin/urlencode.go
@@ -3,10 +3,9 @@
 package builtin
 
 import (
-	"net/url"
-
 	"github.com/ysugimoto/falco/interpreter/context"
 	"github.com/ysugimoto/falco/interpreter/function/errors"
+	"github.com/ysugimoto/falco/interpreter/function/shared"
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
@@ -37,9 +36,10 @@ func Urlencode(ctx *context.Context, args ...value.Value) (value.Value, error) {
 	}
 
 	input := value.Unwrap[*value.String](args[0]).Value
-	// url.QueryEscape encodes white space to "+" so we should use url.PathEscape
-	// in order to encode white space to "%20"
-	enc := url.PathEscape(input)
+	enc, err := shared.UrlEncode(input)
+	if err != nil {
+		return &value.String{IsNotSet: true}, errors.New(Urlencode_Name, err.Error())
+	}
 
 	return &value.String{Value: enc}, nil
 }

--- a/interpreter/function/builtin/urlencode_test.go
+++ b/interpreter/function/builtin/urlencode_test.go
@@ -19,7 +19,50 @@ func Test_Urlencode(t *testing.T) {
 		input  string
 		expect string
 	}{
-		{input: "hello world", expect: "hello%20world"},
+		{
+			input:  "%00",
+			expect: "",
+		},
+		{
+			input:  "ab%00c",
+			expect: "ab",
+		},
+		{
+			input:  "あ",
+			expect: "%E3%81%82",
+		},
+		{
+			input:  "%01%02%03%04%05%06%07%08%09%0A%0B%0C%0D%0E%0F",
+			expect: "%01%02%03%04%05%06%07%08%09%0A%0B%0C%0D%0E%0F",
+		},
+		{
+			input:  "%10%11%12%13%14%15%16%17%18%19%1A%1B%1C%1D%1E%1F",
+			expect: "%10%11%12%13%14%15%16%17%18%19%1A%1B%1C%1D%1E%1F",
+		},
+		{
+			input:  " !\"#$%&'()*+,-./",
+			expect: "%20%21%22%23%24%25%26%27%28%29%2A%2B%2C-.%2F",
+		},
+		{
+			input:  "0123456789:;<=>?",
+			expect: "0123456789%3A%3B%3C%3D%3E%3F",
+		},
+		{
+			input:  "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_",
+			expect: "%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_",
+		},
+		{
+			input:  "`abcdefghijklmnopqrstuvwxyz{|}~",
+			expect: "%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~",
+		},
+		{
+			input:  "%7F",
+			expect: "%7F",
+		},
+		{
+			input:  "hello world",
+			expect: "hello%20world",
+		},
 	}
 
 	for i, tt := range tests {

--- a/interpreter/function/builtin/urlencode_test.go
+++ b/interpreter/function/builtin/urlencode_test.go
@@ -32,6 +32,10 @@ func Test_Urlencode(t *testing.T) {
 			expect: "%E3%81%82",
 		},
 		{
+			input:  "𠮷😯",
+			expect: "%F0%A0%AE%B7%F0%9F%98%AF",
+		},
+		{
 			input:  "%01%02%03%04%05%06%07%08%09%0A%0B%0C%0D%0E%0F",
 			expect: "%01%02%03%04%05%06%07%08%09%0A%0B%0C%0D%0E%0F",
 		},

--- a/interpreter/function/shared/url_codec.go
+++ b/interpreter/function/shared/url_codec.go
@@ -19,8 +19,9 @@ var ErrInvalidMultiByteSequence = errors.New("Invalid multi-byte sequence")
 // implement our own logic that is almost checked by actual Fastly behavior on the fiddle.
 // ref https://fiddle.fastly.dev/fiddle/bf3e21e5
 
-// Check byte is reserved byte
+// Check byte is unreserved byte
 func isUnreservedByte(b byte) bool {
+	// Ascii bytes, "-", ".", "_", "~"
 	return isHexBytes(b) || b == 0x2D || b == 0x2E || b == 0x5F || b == 0x7E
 }
 

--- a/interpreter/function/shared/url_codec.go
+++ b/interpreter/function/shared/url_codec.go
@@ -1,0 +1,192 @@
+package shared
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/pkg/errors"
+)
+
+var ErrInvalidMultiByteSequence = errors.New("Invalid multi-byte sequence")
+
+// Percent Encoding is described at [RFC3986](https://datatracker.ietf.org/doc/html/rfc3986#section-2.4)
+// But Fastly's urlencode / urldecode function seems to be a pretty different.
+// Therefore we don't use golang's net/url package to encode and decode,
+// implement our own logic that is almost checked by actual Fastly behavior on the fiddle.
+// ref https://fiddle.fastly.dev/fiddle/bf3e21e5
+
+// Check byte is reserved byte
+func isUnreservedByte(b byte) bool {
+	return isHexBytes(b) || b == 0x2D || b == 0x2E || b == 0x5F || b == 0x7E
+}
+
+// Check byte is [a-zA-Z0-9]
+func isHexBytes(b byte) bool {
+	return (0x41 <= b && b <= 0x5A) || (0x61 <= b && b <= 0x7A) || (0x30 <= b && b <= 0x39)
+}
+
+// Percent encoding function for urlencode() builtin function
+func UrlEncode(src string) (string, error) {
+	reader := bufio.NewReader(strings.NewReader(src))
+	var encoded []byte
+
+	for {
+		// Source string may contain multi-byte string so we encode using rune
+		b, s, err := reader.ReadRune()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return "", errors.WithStack(err)
+		}
+
+		// If size is greater then 1, it indicates the rune is multi-byte.
+		if s > 1 {
+			sb := make([]byte, s)
+			if n := utf8.EncodeRune(sb, b); n != s {
+				return "", errors.WithStack(errors.New("Failed to encode bytes to rune"))
+			}
+			for _, v := range sb {
+				encoded = append(encoded, fmt.Sprintf("%%%X", v)...)
+			}
+			continue
+		}
+
+		switch {
+		case b == 0x25: // "%"
+			// When percent sign found, encode following 2 bytes as following format
+			// % HEXDIG HEXDIG
+			// But following byte may not be HEXDIG (e.g %&), then encode as %25
+			hex, err := reader.Peek(2)
+			if err != nil {
+				return "", errors.WithStack(err)
+			}
+
+			// Check 2 bytes are HEXDIG
+			if !isHexBytes(hex[0]) || !isHexBytes(hex[1]) {
+				encoded = append(encoded, fmt.Sprintf("%%%X", b)...)
+				continue
+			}
+
+			// Decode 2 bytes to byte integer
+			n, err := strconv.ParseInt(string(hex), 16, 64)
+			if err != nil {
+				return "", errors.WithStack(err)
+			}
+			// If decoded byte is out of range of ascii code, stop encoding
+			if 0x01 > n || 0x7F < n {
+				goto OUT
+			}
+			encoded = append(encoded, byte(b))
+			encoded = append(encoded, hex...)
+			// forward 2 bytes
+			reader.Read(make([]byte, 2)) // nolint:errcheck
+		case isUnreservedByte(byte(b)):
+			// Unreserved byte does not need to percent encode, add raw byte
+			encoded = append(encoded, byte(b))
+		default:
+			// Percent encoding
+			encoded = append(encoded, fmt.Sprintf("%%%X", b)...)
+		}
+	}
+OUT:
+
+	return string(encoded), nil
+}
+
+// Percent decoding function for urldecode() builtin function
+func UrlDecode(src string) (string, error) {
+	reader := bufio.NewReader(strings.NewReader(src))
+	var decoded []byte
+
+	for {
+		// encoded string always only has bytes
+		b, err := reader.ReadByte()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return "", errors.WithStack(err)
+		}
+		switch {
+		case b == 0x25: // "%"
+			hex, err := reader.Peek(2)
+			if err != nil {
+				return "", errors.WithStack(err)
+			}
+
+			// Check 2 bytes are HEXDIG
+			if !isHexBytes(hex[0]) || !isHexBytes(hex[1]) {
+				decoded = append(decoded, b)
+				continue
+			}
+
+			n, err := strconv.ParseInt(string(hex), 16, 64)
+			if err != nil {
+				return "", errors.WithStack(err)
+			}
+
+			switch {
+			case n <= 0x00:
+				// Stop decoding if byte is nullbyte
+				goto OUT
+			case n <= 0x7F:
+				// If byte is within ascii code range, append raw bytes
+				decoded = append(decoded, byte(n))
+				// Forward 2 bytes
+				reader.Read(make([]byte, 2)) // nolint:errcheck
+			default:
+				// If byte is out of range of ascii code, decode as multi-byte string
+				reader.Read(make([]byte, 2)) // nolint:errcheck
+
+				multiBytes, err := decodeMultiBytes(reader, byte(n))
+				if err != nil {
+					return "", errors.WithStack(err)
+				}
+
+				decoded = append(decoded, multiBytes...)
+			}
+		default:
+			decoded = append(decoded, byte(b))
+		}
+	}
+OUT:
+
+	return string(decoded), nil
+}
+
+func decodeMultiBytes(reader *bufio.Reader, firstByte byte) ([]byte, error) {
+	mbs := []byte{firstByte}
+
+	for i := 0; i < utf8.UTFMax; i++ {
+		sb := make([]byte, 3) // create 3 bytes for %HH
+		if _, err := reader.Read(sb); err != nil {
+			return nil, errors.WithStack(err)
+		}
+		// First byte must be '%'
+		if sb[0] != 0x25 {
+			return nil, errors.WithStack(ErrInvalidMultiByteSequence)
+		}
+		sb = sb[1:]
+		if !isHexBytes(sb[0]) || !isHexBytes(sb[1]) {
+			return nil, errors.WithStack(ErrInvalidMultiByteSequence)
+		}
+
+		n, err := strconv.ParseInt(string(sb), 16, 64)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		mbs = append(mbs, byte(n))
+		// Try to decode as rune. If succeeded, break loop
+		if r, _ := utf8.DecodeRune(mbs); r != utf8.RuneError {
+			return mbs, nil
+		}
+	}
+
+	// If bytes did not return inside for-loop, raise an error of invalid multi-byte sequence
+	return nil, errors.WithStack(ErrInvalidMultiByteSequence)
+}

--- a/interpreter/function/shared/url_codec_test.go
+++ b/interpreter/function/shared/url_codec_test.go
@@ -1,0 +1,139 @@
+package shared
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestUrlEncode(t *testing.T) {
+	tests := []struct {
+		input  string
+		expect string
+	}{
+		{
+			input:  "%00",
+			expect: "",
+		},
+		{
+			input:  "ab%00c",
+			expect: "ab",
+		},
+		{
+			input:  "あ",
+			expect: "%E3%81%82",
+		},
+		{
+			input:  "𠮷😯",
+			expect: "%F0%A0%AE%B7%F0%9F%98%AF",
+		},
+		{
+			input:  "%01%02%03%04%05%06%07%08%09%0A%0B%0C%0D%0E%0F",
+			expect: "%01%02%03%04%05%06%07%08%09%0A%0B%0C%0D%0E%0F",
+		},
+		{
+			input:  "%10%11%12%13%14%15%16%17%18%19%1A%1B%1C%1D%1E%1F",
+			expect: "%10%11%12%13%14%15%16%17%18%19%1A%1B%1C%1D%1E%1F",
+		},
+		{
+			input:  " !\"#$%&'()*+,-./",
+			expect: "%20%21%22%23%24%25%26%27%28%29%2A%2B%2C-.%2F",
+		},
+		{
+			input:  "0123456789:;<=>?",
+			expect: "0123456789%3A%3B%3C%3D%3E%3F",
+		},
+		{
+			input:  "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_",
+			expect: "%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_",
+		},
+		{
+			input:  "`abcdefghijklmnopqrstuvwxyz{|}~",
+			expect: "%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~",
+		},
+		{
+			input:  "%7F",
+			expect: "%7F",
+		},
+		{
+			input:  "hello world",
+			expect: "hello%20world",
+		},
+	}
+
+	for i, tt := range tests {
+		ret, err := UrlEncode(tt.input)
+		if err != nil {
+			t.Errorf("[%d] Unexpected error: %s", i, err)
+		}
+		if diff := cmp.Diff(tt.expect, ret); diff != "" {
+			t.Errorf("[%d] Return value unmatch, diff=%s", i, diff)
+		}
+	}
+}
+
+func TestUrlDecode(t *testing.T) {
+	tests := []struct {
+		input  string
+		expect string
+	}{
+		{
+			input:  "",
+			expect: "",
+		},
+		{
+			input:  "ab",
+			expect: "ab",
+		},
+		{
+			input:  "%E3%81%82",
+			expect: "あ",
+		},
+		{
+			input:  "%F0%A0%AE%B7%F0%9F%98%AF",
+			expect: "𠮷😯",
+		},
+		{
+			input:  "%01%02%03%04%05%06%07%08%09%0A%0B%0C%0D%0E%0F",
+			expect: string([]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}),
+		},
+		{
+			input:  "%10%11%12%13%14%15%16%17%18%19%1A%1B%1C%1D%1E%1F",
+			expect: string([]byte{0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F}),
+		},
+		{
+			input:  "%20%21%22%23%24%25%26%27%28%29%2A%2B%2C-.%2F",
+			expect: ` !"#$%&'()*+,-./`,
+		},
+		{
+			input:  "0123456789%3A%3B%3C%3D%3E%3F",
+			expect: "0123456789:;<=>?",
+		},
+		{
+			input:  "%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_",
+			expect: "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_",
+		},
+		{
+			input:  "%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~",
+			expect: "`abcdefghijklmnopqrstuvwxyz{|}~",
+		},
+		{
+			input:  "%7F",
+			expect: string([]byte{0x7F}),
+		},
+		{
+			input:  "hello%20world",
+			expect: "hello world",
+		},
+	}
+
+	for i, tt := range tests {
+		ret, err := UrlDecode(tt.input)
+		if err != nil {
+			t.Errorf("[%d] Unexpected error: %s", i, err)
+		}
+		if diff := cmp.Diff(tt.expect, ret); diff != "" {
+			t.Errorf("[%d] Return value unmatch, diff=%s", i, diff)
+		}
+	}
+}


### PR DESCRIPTION
This PR improves urlencode() and urldecode built-in functions.

Underlying URL-encoding (Percent-Encoding) logic will be described at [RFC3986](https://datatracker.ietf.org/doc/html/rfc3986#section-2.4) but Fastly's `urlencode()` and `urldecode()` function seems to be defferent from its specification.

We investigated behaviros from actual testing in [fiddle](https://fiddle.fastly.dev/fiddle/bf3e21e5) and improve implementation without using golang `net/url` package to reproduce them. 