### PR TITLE
Fix hex display: pad 01-0F values to two digits

### DIFF
--- a/interpreter/function/shared/url_codec.go
+++ b/interpreter/function/shared/url_codec.go
@@ -52,7 +52,7 @@ func UrlEncode(src string) (string, error) {
 				return "", errors.WithStack(errors.New("Failed to encode bytes to rune"))
 			}
 			for _, v := range sb {
-				encoded = append(encoded, fmt.Sprintf("%%%X", v)...)
+				encoded = append(encoded, fmt.Sprintf("%%%02X", v)...)
 			}
 			continue
 		}
@@ -69,7 +69,7 @@ func UrlEncode(src string) (string, error) {
 
 			// Check 2 bytes are HEXDIG
 			if !isHexBytes(hex[0]) || !isHexBytes(hex[1]) {
-				encoded = append(encoded, fmt.Sprintf("%%%X", b)...)
+				encoded = append(encoded, fmt.Sprintf("%%%02X", b)...)
 				continue
 			}
 
@@ -91,7 +91,7 @@ func UrlEncode(src string) (string, error) {
 			encoded = append(encoded, byte(b))
 		default:
 			// Percent encoding
-			encoded = append(encoded, fmt.Sprintf("%%%X", b)...)
+			encoded = append(encoded, fmt.Sprintf("%%%02X", b)...)
 		}
 	}
 OUT:


### PR DESCRIPTION
- Change format specifier from %X to %02X
- Ensure values 01-0F are displayed with leading zero

Fixed this test.
```
declare local var.str STRING;

set var.str = urlencode("%01%02%03%04%05%06%07%08%09%0A%0B%0C%0D%0E%0F");
assert.equal(std.strlen(var.str), 45);
assert.equal(var.str, {"%01%02%03%04%05%06%07%08%09%0A%0B%0C%0D%0E%0F"});
```
```
Assertion Error
Assertion error: expect=45, actual=30
Assertion error: expect=%01%02%03%04%05%06%07%08%09%0A%0B%0C%0D%0E%0F, actual=%1%2%3%4%5%6%7%8%9%A%B%C%D%E%F
```