### PR TITLE
fix literal coparing issue for injected variables

### DIFF
--- a/examples/testing/inject_variables/main.test.vcl
+++ b/examples/testing/inject_variables/main.test.vcl
@@ -1,0 +1,7 @@
+// @scope: recv
+// @suite: foo
+sub test_vcl_recv {
+  testing.inject_variable("client.geo.country_code", "JP");
+  testing.call_subroutine("vcl_recv");
+  assert.state(pass);
+}

--- a/examples/testing/inject_variables/main.vcl
+++ b/examples/testing/inject_variables/main.vcl
@@ -1,0 +1,6 @@
+sub vcl_recv {
+  if (client.geo.country_code == "JP") {
+    return (pass);
+  }
+  return (lookup);
+}

--- a/tester/function/testing_inject_variable.go
+++ b/tester/function/testing_inject_variable.go
@@ -28,6 +28,33 @@ func Testing_inject_variable(
 	}
 
 	name := value.Unwrap[*value.String](args[0])
+
+	// Important: second argument will be provided as literal
+	// but overrided value must not be literal in the interpreter process
+	// so we turn off the literal flag to false.
+	// Unfortunately value.Value interface does not have to change the literal flag
+	// so need type assertion for primitive values - it's annoying but just special case.
+	switch t := args[1].(type) {
+	case *value.Acl:
+		t.Literal = false
+	case *value.Backend:
+		t.Literal = false
+	case *value.Boolean:
+		t.Literal = false
+	case *value.Float:
+		t.Literal = false
+	case *value.IP:
+		t.Literal = false
+	case *value.Ident:
+		t.Literal = false
+	case *value.Integer:
+		t.Literal = false
+	case *value.RTime:
+		t.Literal = false
+	case *value.String:
+		t.Literal = false
+		// Note: *value.Time value could not be specified as literal
+	}
 	ctx.OverrideVariables[name.Value] = args[1]
 	return value.Null, nil
 }


### PR DESCRIPTION
Fixes #350

Fix literal related issue on interpreter.
When some variable values are injected via `testing.inject_variable()` function, the value will be a literal.
And then an interpreter compares expression between left-side and right-side, injected values are treated as literal and it cause an error about literal comparison.

This PR fixes this problem by enforcing injected variables are NOT literal.
We add #350 reproduceable VCL as testing, they should be passed.