### PR TITLE
add remote director resource to lint

### DIFF
--- a/linter/declaration_linter.go
+++ b/linter/declaration_linter.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ysugimoto/falco/types"
 )
 
-func (l *Linter) lintAclDeclaration(decl *ast.AclDeclaration) types.Type {
+func (l *Linter) lintAclDeclaration(decl *ast.AclDeclaration, ctx *context.Context) types.Type {
 	// validate ACL name
 	if !isValidName(decl.Name.Value) {
 		l.Error(InvalidName(decl.Name.GetMeta(), decl.Name.Value, "acl").Match(ACL_SYNTAX))
@@ -34,6 +34,11 @@ func (l *Linter) lintAclDeclaration(decl *ast.AclDeclaration) types.Type {
 		}
 	}
 
+	// Check ignored UNUSED_DECLARATION rule and mark as used
+	if l.ignore.IsEnable(UNUSED_DECLARATION) {
+		ctx.Acls[decl.Name.Value].IsUsed = true
+	}
+
 	return types.NeverType
 }
 
@@ -46,6 +51,11 @@ func (l *Linter) lintBackendDeclaration(decl *ast.BackendDeclaration, ctx *conte
 	// lint property definitions
 	for i := range decl.Properties {
 		l.lintBackendProperty(decl.Properties[i], ctx)
+	}
+
+	// Check ignored UNUSED_DECLARATION rule and mark as used
+	if l.ignore.IsEnable(UNUSED_DECLARATION) {
+		ctx.Backends[decl.Name.Value].IsUsed = true
 	}
 
 	return types.NeverType
@@ -115,6 +125,11 @@ func (l *Linter) lintDirectorDeclaration(decl *ast.DirectorDeclaration, ctx *con
 	}
 
 	l.lintDirectorProperty(decl, ctx)
+
+	// Check ignored UNUSED_DECLARATION rule and mark as used
+	if l.ignore.IsEnable(UNUSED_DECLARATION) {
+		ctx.Directors[decl.Name.Value].IsUsed = true
+	}
 
 	return types.NeverType
 }
@@ -245,6 +260,11 @@ func (l *Linter) lintTableDeclaration(decl *ast.TableDeclaration, ctx *context.C
 		l.lintTableProperty(p, valueType, ctx)
 	}
 
+	// Check ignored UNUSED_DECLARATION rule and mark as used
+	if l.ignore.IsEnable(UNUSED_DECLARATION) {
+		ctx.Tables[decl.Name.Value].IsUsed = true
+	}
+
 	return types.NeverType
 }
 
@@ -363,6 +383,11 @@ func (l *Linter) lintSubRoutineDeclaration(decl *ast.SubroutineDeclaration, ctx 
 	// We are done linting inside the previous scope so
 	// we dont need the return type anymore
 	cc.ReturnType = nil
+
+	// Check ignored UNUSED_DECLARATION rule and mark as used
+	if l.ignore.IsEnable(UNUSED_DECLARATION) {
+		ctx.Subroutines[decl.Name.Value].IsUsed = true
+	}
 
 	return types.NeverType
 }

--- a/remote/client.go
+++ b/remote/client.go
@@ -185,6 +185,16 @@ func (c *FastlyClient) ListBackends(ctx context.Context, version int64) ([]*Back
 	return backends, nil
 }
 
+func (c *FastlyClient) ListDirectors(ctx context.Context, version int64) ([]*Director, error) {
+	endpoint := fmt.Sprintf("/service/%s/version/%d/director", c.serviceId, version)
+	var directors []*Director
+	if err := c.request(ctx, endpoint, &directors); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return directors, nil
+}
+
 func (c *FastlyClient) ListSnippets(ctx context.Context, version int64) ([]*VCLSnippet, error) {
 	endpoint := fmt.Sprintf("/service/%s/version/%d/snippet", c.serviceId, version)
 	var snippets []*VCLSnippet

--- a/remote/entity.go
+++ b/remote/entity.go
@@ -48,6 +48,8 @@ type Director struct {
 	Name     string       `json:"name"`
 	Type     DirectorType `json:"type"`
 	Backends []string     `json:"backends"`
+	Retries  int          `json:"retries"`
+	Quorum   int          `json:"quorum"`
 }
 
 type VCLSnippet struct {

--- a/remote/fetcher.go
+++ b/remote/fetcher.go
@@ -50,6 +50,7 @@ func (f *FastlyApiFetcher) Backends() ([]*types.RemoteBackend, error) {
 	}
 	return r, nil
 }
+
 func (f *FastlyApiFetcher) Dictionaries() ([]*types.RemoteDictionary, error) {
 	c, timeout := _context.WithTimeout(_context.Background(), f.timeout)
 	defer timeout()
@@ -71,6 +72,7 @@ func (f *FastlyApiFetcher) Dictionaries() ([]*types.RemoteDictionary, error) {
 	}
 	return r, nil
 }
+
 func (f *FastlyApiFetcher) Acls() ([]*types.RemoteAcl, error) {
 	c, timeout := _context.WithTimeout(_context.Background(), f.timeout)
 	defer timeout()
@@ -88,6 +90,32 @@ func (f *FastlyApiFetcher) Acls() ([]*types.RemoteAcl, error) {
 	for _, a := range fastlyAcls {
 		r = append(r, &types.RemoteAcl{
 			Name: a.Name,
+		})
+	}
+	return r, nil
+}
+
+func (f *FastlyApiFetcher) Directors() ([]*types.RemoteDirector, error) {
+	c, timeout := _context.WithTimeout(_context.Background(), f.timeout)
+	defer timeout()
+	version, err := f.getVersion(c)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get latest version %w", err)
+	}
+
+	fastlyDirectors, err := f.client.ListDirectors(c, version)
+	if err != nil {
+		return nil, err
+	}
+
+	r := []*types.RemoteDirector{}
+	for _, d := range fastlyDirectors {
+		r = append(r, &types.RemoteDirector{
+			Type:     int(d.Type),
+			Name:     d.Name,
+			Backends: d.Backends,
+			Retries:  d.Retries,
+			Quorum:   d.Quorum,
 		})
 	}
 	return r, nil

--- a/snippets/snippets.go
+++ b/snippets/snippets.go
@@ -9,6 +9,7 @@ type Snippets struct {
 	Dictionaries     []SnippetItem
 	Acls             []SnippetItem
 	Backends         []SnippetItem
+	Directors        []SnippetItem
 	ScopedSnippets   map[string][]SnippetItem
 	IncludeSnippets  map[string]SnippetItem
 	LoggingEndpoints map[string]struct{}
@@ -23,6 +24,10 @@ func (s *Snippets) EmbedSnippets() []SnippetItem {
 	snippets = append(snippets, s.Acls...)
 	// Embed Backends
 	snippets = append(snippets, s.Backends...)
+	// Embed Directors
+	// Note that director must be placed after backends
+	// because director refers to backend
+	snippets = append(snippets, s.Directors...)
 
 	// And also we need to embed VCL snippets which is registered as "init" type
 	if scoped, ok := s.ScopedSnippets["init"]; ok {

--- a/snippets/template.go
+++ b/snippets/template.go
@@ -22,8 +22,21 @@ backend F_{{ .Name }} {
 }
 `
 
-// remote director should only have a shield type
 var directorTemplate = `
+director {{ .Name }} {{ .Type | printtype }} {
+	{{- if .Retries }}
+	.retries = {{ .Retries }};
+	{{- end }}
+	.quorum = {{ .Quorum }}%;
+	{{- range .Backends }}
+	{ .backend = F_{{ . }}; .weight = 1; }
+	{{- end }}
+}
+`
+
+// Shield director won't be used in custom VCL so we should ignore linting.
+var shieldDirectorTemplate = `
+// falco-ignore-next-line
 director {{ .Name }} {{ .Type | printtype }} {
 	{{- range .Backends }}
 	{ .backend = {{ . }}; .weight = 1; }

--- a/terraform/fetcher.go
+++ b/terraform/fetcher.go
@@ -69,6 +69,22 @@ func (f *TerraformFetcher) Acls() ([]*types.RemoteAcl, error) {
 	return a, nil
 }
 
+func (f *TerraformFetcher) Directors() ([]*types.RemoteDirector, error) {
+	var d []*types.RemoteDirector
+	for _, s := range f.filterService() {
+		for _, director := range s.Directors {
+			d = append(d, &types.RemoteDirector{
+				Type:     director.Type,
+				Name:     director.Name,
+				Backends: director.Backends,
+				Retries:  *director.Retries,
+				Quorum:   *director.Quorum,
+			})
+		}
+	}
+	return d, nil
+}
+
 func (f *TerraformFetcher) Snippets() ([]*types.RemoteVCL, error) {
 	var v []*types.RemoteVCL
 	for _, s := range f.filterService() {

--- a/terraform/terraform.go
+++ b/terraform/terraform.go
@@ -47,12 +47,21 @@ type TerraformBackend struct {
 	Address *string
 }
 
+type TerraformDirector struct {
+	Type     int
+	Name     string
+	Backends []string
+	Retries  *int
+	Quorum   *int
+}
+
 type FastlyService struct {
 	Name             string
 	Vcls             []*TerraformVcl
 	Backends         []*TerraformBackend
 	Acls             []*TerraformAcl
 	Dictionaries     []*TerraformDictionary
+	Directors        []*TerraformDirector
 	Snippets         []*TerraformSnippet
 	LoggingEndpoints []string
 }
@@ -62,6 +71,7 @@ type FastlyServiceValues struct {
 	Vcl        []*TerraformVcl        `json:"vcl"`
 	Acl        []*TerraformAcl        `json:"acl"`
 	Backend    []*TerraformBackend    `json:"backend"`
+	Director   []*TerraformDirector   `json:"director"`
 	Dictionary []*TerraformDictionary `json:"dictionary"`
 	Snippets   []*TerraformSnippet    `json:"snippet"`
 
@@ -144,6 +154,7 @@ func UnmarshalTerraformPlannedInput(buf []byte) ([]*FastlyService, error) {
 				Acls:             serviceValues.Acl,
 				Backends:         serviceValues.Backend,
 				Dictionaries:     serviceValues.Dictionary,
+				Directors:        serviceValues.Director,
 				Snippets:         serviceValues.Snippets,
 				LoggingEndpoints: factoryLoggingEndpoints(serviceValues),
 			})
@@ -167,6 +178,7 @@ func UnmarshalTerraformPlannedInput(buf []byte) ([]*FastlyService, error) {
 				Acls:             serviceValues.Acl,
 				Backends:         serviceValues.Backend,
 				Dictionaries:     serviceValues.Dictionary,
+				Directors:        serviceValues.Director,
 				Snippets:         serviceValues.Snippets,
 				LoggingEndpoints: factoryLoggingEndpoints(serviceValues),
 			})

--- a/types/types.go
+++ b/types/types.go
@@ -247,7 +247,8 @@ func (s *Subroutine) Token() token.Token { return s.Decl.Token }
 func (s *Subroutine) String() string     { return s.Decl.String() }
 
 type Director struct {
-	Decl *ast.DirectorDeclaration
+	Decl   *ast.DirectorDeclaration
+	IsUsed bool // mark this backend is accessed at least once
 }
 
 func (d *Director) Type() Type         { return DirectorType }
@@ -316,4 +317,12 @@ type RemoteVCL struct {
 	Type     string
 	Content  string
 	Priority int64
+}
+
+type RemoteDirector struct {
+	Type     int
+	Name     string
+	Backends []string
+	Retries  int
+	Quorum   int
 }


### PR DESCRIPTION
Fixes #358 

This PR implments feature that can fetch director resource in Fastly remote using API.
And includes some fixes like:

- mark ignoring unused for shield director for remote resource
- 