### PR TITLE
add assert.not_error function to function table

### DIFF
--- a/tester/function/assert_not_error.go
+++ b/tester/function/assert_not_error.go
@@ -9,8 +9,6 @@ import (
 
 const Assert_not_error_Name = "assert.not_error"
 
-var Assert_not_error_ArgumentTypes = []value.Type{value.IntegerType}
-
 func Assert_not_error_Validate(args []value.Value) error {
 	if len(args) > 1 {
 		return errors.ArgumentNotInRange(Assert_not_error_Name, 0, 1, args)

--- a/tester/function/testing_functions.go
+++ b/tester/function/testing_functions.go
@@ -275,6 +275,26 @@ func assertionFunctions(i *interpreter.Interpreter, c Counter) Functions {
 				return false
 			},
 		},
+		"assert.not_error": {
+			Scope: allScope,
+			Call: func(ctx *context.Context, args ...value.Value) (value.Value, error) {
+				unwrapped, err := unwrapIdentArguments(i, args)
+				if err != nil {
+					return value.Null, errors.WithStack(err)
+				}
+				v, err := Assert_not_error(ctx, i, unwrapped...)
+				if err != nil {
+					c.Fail()
+				} else {
+					c.Pass()
+				}
+				return v, err
+			},
+			CanStatementCall: true,
+			IsIdentArgument: func(i int) bool {
+				return false
+			},
+		},
 		"assert.is_notset": {
 			Scope: allScope,
 			Call: func(ctx *context.Context, args ...value.Value) (value.Value, error) {


### PR DESCRIPTION
We implemented `assert.not_error` assertion function but did not register to function table.
This PR should fix it.