### PR TITLE
Feature/lint custom statement

### DIFF
--- a/ast/custom_statement.go
+++ b/ast/custom_statement.go
@@ -6,4 +6,5 @@ package ast
 type CustomStatement interface {
 	Statement
 	Literal() string
+	Lint(func(Node)) error
 }

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -16,18 +16,18 @@ import (
 )
 
 type Linter struct {
-	Errors         []*LintError
-	FatalError     *FatalError
-	includexLexers map[string]*lexer.Lexer
-	ignore         *ignore
-	conf           *config.LinterConfig
+	Errors     []*LintError
+	FatalError *FatalError
+	lexers     map[string]*lexer.Lexer
+	ignore     *ignore
+	conf       *config.LinterConfig
 }
 
 func New(c *config.LinterConfig, opts ...optionFunc) *Linter {
 	l := &Linter{
-		includexLexers: make(map[string]*lexer.Lexer),
-		ignore:         &ignore{},
-		conf:           c,
+		lexers: make(map[string]*lexer.Lexer),
+		ignore: &ignore{},
+		conf:   c,
 	}
 	for i := range opts {
 		opts[i](l)
@@ -36,7 +36,7 @@ func New(c *config.LinterConfig, opts ...optionFunc) *Linter {
 }
 
 func (l *Linter) Lexers() map[string]*lexer.Lexer {
-	return l.includexLexers
+	return l.lexers
 }
 
 func (l *Linter) Error(err error) {
@@ -317,7 +317,7 @@ func (l *Linter) lintStatement(s ast.Statement, ctx *context.Context) {
 
 func (l *Linter) loadSnippetVCL(file, content string) []ast.Statement {
 	lx := lexer.NewFromString(content, lexer.WithFile(file))
-	l.includexLexers[file] = lx
+	l.lexers[file] = lx
 	statements, err := parser.New(lx).ParseSnippetVCL()
 	if err != nil {
 		lx.NewLine()
@@ -332,7 +332,7 @@ func (l *Linter) loadSnippetVCL(file, content string) []ast.Statement {
 
 func (l *Linter) loadVCL(file, content string) []ast.Statement {
 	lx := lexer.NewFromString(content, lexer.WithFile(file))
-	l.includexLexers[file] = lx
+	l.lexers[file] = lx
 	vcl, err := parser.New(lx).ParseVCL()
 	if err != nil {
 		lx.NewLine()

--- a/parser/custom_parser_test.go
+++ b/parser/custom_parser_test.go
@@ -46,6 +46,9 @@ func (d *DescribeStatement) String() string {
 
 	return buf.String()
 }
+func (d *DescribeStatement) Lint(nodeLinter func(ast.Node)) error {
+	return nil
+}
 
 type DescribeParser struct{}
 
@@ -125,6 +128,10 @@ func (b *BeforeEachStatement) String() string {
 	buf.WriteString(b.TrailingComment(" "))
 
 	return buf.String()
+}
+
+func (b *BeforeEachStatement) Lint(nodeLinter func(ast.Node)) error {
+	return nil
 }
 
 type BeforeEachParser struct{}

--- a/tester/syntax/describe.go
+++ b/tester/syntax/describe.go
@@ -53,6 +53,9 @@ func (d *DescribeStatement) String() string {
 
 	return buf.String()
 }
+func (d *DescribeStatement) Lint(nodeLinter func(node ast.Node)) error {
+	return nil
+}
 
 // Custome parser implementation for "describe" keyword
 type DescribeParser struct{}

--- a/tester/syntax/hooks.go
+++ b/tester/syntax/hooks.go
@@ -38,6 +38,9 @@ func (s *HookStatement) String() string {
 
 	return buf.String()
 }
+func (h *HookStatement) Lint(nodeLinter func(node ast.Node)) error {
+	return nil
+}
 
 type HookParser struct {
 	keyword string

--- a/tester/syntax/parsers.go
+++ b/tester/syntax/parsers.go
@@ -3,13 +3,15 @@ package syntax
 import "github.com/ysugimoto/falco/parser"
 
 func CustomParsers() []parser.CustomParser {
-	customs := []parser.CustomParser{
-		// describe keyword
-		&DescribeParser{},
-	}
-	// hooks
+	var i int
+	customs := make([]parser.CustomParser, len(hookParsers)+1)
+
+	customs[i] = &DescribeParser{}
+	i++
+
 	for _, v := range hookParsers {
-		customs = append(customs, v)
+		customs[i] = v
+		i++
 	}
 	return customs
 }


### PR DESCRIPTION
This PR implements the feature of lining for custom statement.

The custom statement additionally needs `Lint(func (node)) error` method to call linting from linter package.
The first argument of `func(node)` is just wrapped function to call `(*Linter).lint(ast.Node, *context.Context`.

This is because we could not pass the `Linter` pointer due to cyclic importation that comes from my mistake of package structure. However, this is workaround to avoid cyclic import and it's okay for now. 