### PR TITLE
implement scheduler for documentation-check

### DIFF
--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -1,0 +1,40 @@
+name: Check lacked predefined variable and functions 
+
+on:
+  schedule:
+    # 0:00 UTC (9:00 JST)
+    - cron: "0 0 * * *"
+
+jobs:
+  check-documentation-update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.22.2
+      - name: run checker
+        id: checking
+        working-directory: cmd/documentation-checker
+        run:
+          echo "diff=$(go run .)" >> $GITHUB_OUTPUT
+      - name: create issue if exists
+        if: ${{ steps.checking.outputs.diff != "" }}
+        run: |
+          ISSUE=$(gh issue list -l automated --json title)
+          if [ "$ISSUE" == "[]" ]; then
+            gh issue create \
+              -b "${{ steps.checking.outputs.diff }}" \
+              -a ysugimoto \
+              -t "[Automated] Need to implement new variables/functions" \
+              -l automated
+          fi
+

--- a/cmd/documentation-checker/functions.go
+++ b/cmd/documentation-checker/functions.go
@@ -46,28 +46,31 @@ func factoryFunctions(ctx context.Context) (*sync.Map, error) {
 	return &m, nil
 }
 
-func checkFunctions(m *sync.Map) error {
+func checkFunctions(m *sync.Map) ([]Function, error) {
 	fp, err := os.Open(builtinPath)
 	if err != nil {
-		return errors.WithStack(err)
+		return nil, errors.WithStack(err)
 	}
 	defer fp.Close()
 
-	variables := make(map[string]interface{})
-	if err := yaml.NewDecoder(fp).Decode(variables); err != nil {
-		return errors.WithStack(err)
+	defined := make(map[string]interface{})
+	if err := yaml.NewDecoder(fp).Decode(defined); err != nil {
+		return nil, errors.WithStack(err)
 	}
 
+	var lacked []Function
 	m.Range(func(key, val interface{}) bool {
 		k := key.(string) // nolint:errcheck
 		v := val.(string) // nolint:errcheck
 
-		if _, ok := variables[k]; ok {
+		if _, ok := defined[k]; ok {
 			return true
 		}
-		write(yellow, "[!] ")
-		writeln(white, `"%s" is not defined, url: %s`, k, v)
+		lacked = append(lacked, Function{
+			name: k,
+			url:  v,
+		})
 		return true
 	})
-	return nil
+	return lacked, nil
 }


### PR DESCRIPTION
Frequently I check new variables and function by running `documentation-check` script on my local machine but this workflow should be automated.

I added scheduled GitHub Actions that runs evey 0:00 UTC on the GitHub Actions and create new issue when some new variables or functions are found in Fastly documentation site.