### PR TITLE
use single quotation

### DIFF
--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -27,7 +27,7 @@ jobs:
         run:
           echo "diff=$(go run .)" >> $GITHUB_OUTPUT
       - name: create issue if exists
-        if: ${{ steps.checking.outputs.diff != "" }}
+        if: ${{ steps.checking.outputs.diff != '' }}
         run: |
           ISSUE=$(gh issue list -l automated --json title)
           if [ "$ISSUE" == "[]" ]; then


### PR DESCRIPTION
From GitHub documentation, `string` literal must be enclosed with single quotation `'`.
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#literals