### PR TITLE
Add support for long strings with heredoc delimiters

### DIFF
--- a/ast/vcl_types.go
+++ b/ast/vcl_types.go
@@ -71,9 +71,9 @@ func (s *String) ID() uint64     { return s.Meta.ID }
 func (s *String) Expression()    {}
 func (s *String) GetMeta() *Meta { return s.Meta }
 func (s *String) String() string {
-	if s.Token.Offset == 4 { // offset=4 means bracket string
+	if s.LongString { // offset=4 means bracket string
 		return strings.TrimSpace(
-			fmt.Sprintf(`%s{"%s"}%s`, s.LeadingComment(inline), s.Value, s.TrailingComment(inline)),
+			fmt.Sprintf(`%s{%s"%s"%s}%s`, s.LeadingComment(inline), s.Delimiter, s.Value, s.Delimiter, s.TrailingComment(inline)),
 		)
 	}
 	return strings.TrimSpace(

--- a/ast/vcl_types.go
+++ b/ast/vcl_types.go
@@ -71,7 +71,7 @@ func (s *String) ID() uint64     { return s.Meta.ID }
 func (s *String) Expression()    {}
 func (s *String) GetMeta() *Meta { return s.Meta }
 func (s *String) String() string {
-	if s.LongString { // offset=4 means bracket string
+	if s.LongString {
 		return strings.TrimSpace(
 			fmt.Sprintf(`%s{%s"%s"%s}%s`, s.LeadingComment(inline), s.Delimiter, s.Value, s.Delimiter, s.TrailingComment(inline)),
 		)

--- a/ast/vcl_types.go
+++ b/ast/vcl_types.go
@@ -60,6 +60,11 @@ func (i *Integer) String() string {
 type String struct {
 	*Meta
 	Value string
+	// Whether or not this string was parsed as a "long string", which has
+	// different output than a regular string.
+	LongString bool
+	// The optional delimiter for a "long string".
+	Delimiter string
 }
 
 func (s *String) ID() uint64     { return s.Meta.ID }

--- a/formatter/expression_format.go
+++ b/formatter/expression_format.go
@@ -84,9 +84,9 @@ func (f *Formatter) formatFloat(expr *ast.Float) string {
 }
 
 func (f *Formatter) formatString(expr *ast.String) string {
-	if expr.Token.Offset == 4 {
+	if expr.LongString {
 		// offset=4 means bracket string like {"..."}
-		return fmt.Sprintf(`{"%s"}`, expr.Value)
+		return fmt.Sprintf(`{%s"%s"%s}`, expr.Delimiter, expr.Value, expr.Delimiter)
 	}
 	// Otherwise, double-quoted string
 	return fmt.Sprintf(`"%s"`, expr.Value)

--- a/formatter/expression_format.go
+++ b/formatter/expression_format.go
@@ -85,7 +85,6 @@ func (f *Formatter) formatFloat(expr *ast.Float) string {
 
 func (f *Formatter) formatString(expr *ast.String) string {
 	if expr.LongString {
-		// offset=4 means bracket string like {"..."}
 		return fmt.Sprintf(`{%s"%s"%s}`, expr.Delimiter, expr.Value, expr.Delimiter)
 	}
 	// Otherwise, double-quoted string

--- a/formatter/statement_format_test.go
+++ b/formatter/statement_format_test.go
@@ -584,13 +584,24 @@ func TestFormatSynthticStatement(t *testing.T) {
 `,
 		},
 		{
-			name: "with multiple expressions",
+			name: "with bracket string with delimiter",
 			input: `sub vcl_error {
-	synthetic  {"foo bar baz"} "lorem" "ipsum" req.http.Hoost ;
+	synthetic  /* before_value */ {delimiter"foo bar baz"delimiter} /* after_value */;
 }
 `,
 			expect: `sub vcl_error {
-  synthetic {"foo bar baz"} "lorem" "ipsum" req.http.Hoost;
+  synthetic /* before_value */ {delimiter"foo bar baz"delimiter} /* after_value */;
+}
+`,
+		},
+		{
+			name: "with multiple expressions",
+			input: `sub vcl_error {
+	synthetic  {"foo bar baz"} "lorem" "ipsum" {delimiter"foo"delimiter} req.http.Hoost ;
+}
+`,
+			expect: `sub vcl_error {
+  synthetic {"foo bar baz"} "lorem" "ipsum" {delimiter"foo"delimiter} req.http.Hoost;
 }
 `,
 		},

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -167,6 +167,9 @@ func (l *Lexer) NextToken() token.Token {
 		l.skipBytes(len(delimiter))
 		t = newToken(token.STRING, l.char, line, index)
 		t.Literal = l.readBracketString(delimiter[:len(delimiter)-1])
+		// 2 for the enclosing braces plus the length of the pairs of delimiters
+		// which are "" at a minimum, or SOMEDELIMITER""SOMEDELIMITER for
+		// heredoc-style long strings.
 		t.Offset = 2 + len(delimiter)*2
 	case '}':
 		t = newToken(token.RIGHT_BRACE, l.char, line, index)

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -48,6 +48,14 @@ func (l *Lexer) RegisterCustomTokens(tokenMap map[string]token.TokenType) {
 	}
 }
 
+func (l *Lexer) skipBytes(n int) {
+	discarded, err := l.r.Discard(n)
+	if err != nil {
+		l.char = 0x00
+	}
+	l.index += discarded
+}
+
 func (l *Lexer) readChar() {
 	r, _, err := l.r.ReadRune()
 	if err != nil {
@@ -69,6 +77,22 @@ func (l *Lexer) peekChar() rune {
 		return 0x00
 	}
 	return rune(b[0])
+}
+
+func (l *Lexer) peekUntil(cond func(b byte) bool) (string, error) {
+	var peekBytes int
+	for {
+		r, err := l.r.Peek(peekBytes + 1)
+		if err != nil {
+			return "", err
+		}
+
+		peekBytes++
+
+		if cond(r[peekBytes-1]) {
+			return string(r), nil
+		}
+	}
 }
 
 func (l *Lexer) NewLine() {
@@ -127,15 +151,34 @@ func (l *Lexer) NextToken() token.Token {
 			t = newToken(token.MINUS, l.char, line, index)
 		}
 	case '{':
-		// VCL allows bracket enclosed string like {" foobar "},
-		// it is convenient to make string that includes whitespace, TAB, etc.
-		// So, lexer should lex it.
-		if l.peekChar() == '"' {
+		// Fastly VCL allows bracket enclosed strings like {" foobar "}, along
+		// with custom delimiters like {JSON" {"foo": "bar"} "JSON}. It is
+		// convenient for constructing strings thats include whitespace,
+		// creating JSON responses, etc.
+		c := l.peekChar()
+		switch {
+		case c == '"':
 			l.readChar()
 			t = newToken(token.STRING, l.char, line, index)
-			t.Literal = l.readBracketString()
+			t.Literal = l.readBracketString("")
 			t.Offset = 4 // {" and "}
-		} else {
+		case isLongStringDelimiter(c):
+			h, err := l.peekUntil(func(b byte) bool {
+				return !isLongStringDelimiter(rune(b))
+			})
+
+			if err != nil || h[len(h)-1] != '"' {
+				goto notLongString
+			}
+
+			l.skipBytes(len(h))
+			t = newToken(token.STRING, l.char, line, index)
+			t.Literal = l.readBracketString(h[:len(h)-1])
+			t.Offset = 2 + len(h)*2
+			break
+		notLongString:
+			fallthrough
+		default:
 			t = newToken(token.LEFT_BRACE, l.char, line, index)
 		}
 	case '}':
@@ -314,7 +357,7 @@ func (l *Lexer) NextToken() token.Token {
 		}
 
 		switch {
-		case l.isLetter(l.char):
+		case isLetter(l.char):
 			literal := l.readIdentifier()
 
 			// Switch's default case keyword needs special handling due to the header
@@ -418,7 +461,7 @@ func (l *Lexer) skipWhitespace() {
 	}
 }
 
-func (l *Lexer) isLetter(r rune) bool {
+func isLetter(r rune) bool {
 	// Letter allows [a-zA-Z_] character to parse ident of http header name like `req`, `http`, `X-Forwarded-For`.
 	return r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r == '_'
 }
@@ -426,6 +469,12 @@ func (l *Lexer) isLetter(r rune) bool {
 func isDigit(r rune) bool {
 	// Digit allows "." character to parse literal is INTEGER of FLOAT.
 	return (r >= '0' && r <= '9') || r == '.'
+}
+
+func isLongStringDelimiter(r rune) bool {
+	// Long string delimiters appear to be the valid isLetter and isDigit
+	// characters, except for '.'.
+	return (r != '.' && (isLetter(r) || isDigit(r)))
 }
 
 func newToken(tokenType token.TokenType, literal rune, line, index int) token.Token {

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -102,9 +102,13 @@ sub vcl_recv {
 
 	expects := []token.Token{
 		{Type: token.LF, Literal: "\n"},
+		{Type: token.OPEN_LONG_STRING, Literal: ""},
 		{Type: token.STRING, Literal: " foobar "},
+		{Type: token.CLOSE_LONG_STRING, Literal: ""},
 		{Type: token.LF, Literal: "\n"},
+		{Type: token.OPEN_LONG_STRING, Literal: ""},
 		{Type: token.STRING, Literal: ` foo\"bar `},
+		{Type: token.CLOSE_LONG_STRING, Literal: ""},
 		{Type: token.LF, Literal: "\n"},
 
 		// import
@@ -451,13 +455,17 @@ sub vcl_recv {
 		{Type: token.LF, Literal: "\n"},
 
 		{Type: token.SYNTHETIC_BASE64, Literal: "synthetic.base64"},
+		{Type: token.OPEN_LONG_STRING, Literal: ""},
 		{Type: token.STRING, Literal: "foo bar"},
+		{Type: token.CLOSE_LONG_STRING, Literal: ""},
 		{Type: token.SEMICOLON, Literal: ";"},
 		{Type: token.LF, Literal: "\n"},
 		{Type: token.LF, Literal: "\n"},
 
 		{Type: token.SYNTHETIC_BASE64, Literal: "synthetic.base64"},
+		{Type: token.OPEN_LONG_STRING, Literal: `JSON`},
 		{Type: token.STRING, Literal: "\n      {\"foo\": \"bar\"}\n"},
+		{Type: token.CLOSE_LONG_STRING, Literal: `JSON`},
 		{Type: token.SEMICOLON, Literal: ";"},
 		{Type: token.LF, Literal: "\n"},
 		{Type: token.LF, Literal: "\n"},
@@ -630,7 +638,9 @@ func TestComplecatedStatement(t *testing.T) {
 		{Type: token.LEFT_PAREN, Literal: "(", Line: 1, Position: 25},
 		{Type: token.IDENT, Literal: "var.payload", Line: 1, Position: 26},
 		{Type: token.COMMA, Literal: ",", Line: 1, Position: 37},
-		{Type: token.STRING, Literal: `^.*?"exp"\s*:\s*(\d+).*?$`, Line: 1, Position: 39},
+		{Type: token.OPEN_LONG_STRING, Literal: "", Line: 1, Position: 39},
+		{Type: token.STRING, Literal: `^.*?"exp"\s*:\s*(\d+).*?$`, Line: 1, Position: 40},
+		{Type: token.CLOSE_LONG_STRING, Literal: "", Line: 1, Position: 67},
 		{Type: token.COMMA, Literal: ",", Line: 1, Position: 68},
 		{Type: token.STRING, Literal: `\1`, Line: 1, Position: 70},
 		{Type: token.RIGHT_PAREN, Literal: ")", Line: 1, Position: 74},

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -81,6 +81,10 @@ sub vcl_recv {
 	return(pass);
 	synthetic.base64 {"foo bar"};
 
+	synthetic.base64 {JSON"
+      {"foo": "bar"}
+"JSON};
+
 	switch (req.url) {
 	case "/":
 		esi;
@@ -448,6 +452,12 @@ sub vcl_recv {
 
 		{Type: token.SYNTHETIC_BASE64, Literal: "synthetic.base64"},
 		{Type: token.STRING, Literal: "foo bar"},
+		{Type: token.SEMICOLON, Literal: ";"},
+		{Type: token.LF, Literal: "\n"},
+		{Type: token.LF, Literal: "\n"},
+
+		{Type: token.SYNTHETIC_BASE64, Literal: "synthetic.base64"},
+		{Type: token.STRING, Literal: "\n      {\"foo\": \"bar\"}\n"},
 		{Type: token.SEMICOLON, Literal: ";"},
 		{Type: token.LF, Literal: "\n"},
 		{Type: token.LF, Literal: "\n"},

--- a/parser/expression_parser_test.go
+++ b/parser/expression_parser_test.go
@@ -89,15 +89,17 @@ sub vcl_recv {
 								Meta:     ast.New(T, 1),
 								Operator: "+",
 								Right: &ast.String{
-									Meta:  ast.New(T, 1),
-									Value: "baz",
+									Meta:       ast.New(T, 1),
+									Value:      "baz",
+									LongString: true,
 								},
 								Left: &ast.InfixExpression{
 									Meta:     ast.New(T, 1),
 									Operator: "+",
 									Left: &ast.String{
-										Meta:  ast.New(T, 1),
-										Value: "foo bar",
+										Meta:       ast.New(T, 1),
+										Value:      "foo bar",
+										LongString: true,
 									},
 									Right: &ast.IfExpression{
 										Meta: ast.New(T, 1),

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -31,6 +31,7 @@ var precedences = map[token.TokenType]int{
 	token.NOT_REGEX_MATCH:    REGEX,
 	token.PLUS:               CONCAT,
 	token.STRING:             CONCAT,
+	token.OPEN_LONG_STRING:   CONCAT,
 	token.IDENT:              CONCAT,
 	token.IF:                 CONCAT,
 	token.LEFT_PAREN:         CALL,

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -81,7 +81,7 @@ func TestParseStringConcatExpression(t *testing.T) {
 	input := `// Subroutine
 sub vcl_recv {
 	declare local var.S STRING;
-	set var.S = "foo" "bar" + "baz";
+	set var.S = "foo" "bar" + "baz" {"long"} {delimited"long"delimited};
 }`
 	_, err := New(lexer.NewFromString(input)).ParseVCL()
 	if err != nil {
@@ -133,8 +133,9 @@ sub vcl_recv {
 								Operator: "=",
 							},
 							Value: &ast.String{
-								Meta:  ast.New(T, 1),
-								Value: "foo%20bar",
+								Meta:       ast.New(T, 1),
+								Value:      "foo%20bar",
+								LongString: true,
 							},
 						},
 					},

--- a/parser/statement_parser_test.go
+++ b/parser/statement_parser_test.go
@@ -2057,19 +2057,22 @@ sub vcl_recv {
 									Meta:     ast.New(T, 1),
 									Operator: "+",
 									Right: &ast.String{
-										Meta: ast.New(T, 1),
-										Value: "	timestamp:",
+										Meta:       ast.New(T, 1),
+										Value:      "	timestamp:",
+										LongString: true,
 									},
 									Left: &ast.InfixExpression{
 										Meta:     ast.New(T, 1, comments(), comments("/* c */")),
 										Operator: "+",
 										Right: &ast.String{
-											Meta:  ast.New(T, 1, comments(), comments("/* c */")),
-											Value: " fastly-log :: ",
+											Meta:       ast.New(T, 1, comments(), comments("/* c */")),
+											Value:      " fastly-log :: ",
+											LongString: true,
 										},
 										Left: &ast.String{
-											Meta:  ast.New(T, 1, comments("/* a */"), comments("// b")),
-											Value: "syslog ",
+											Meta:       ast.New(T, 1, comments("/* a */"), comments("// b")),
+											Value:      "syslog ",
+											LongString: true,
 										},
 									},
 								},
@@ -2190,13 +2193,15 @@ sub vcl_recv {
 								Value: &ast.InfixExpression{
 									Meta: ast.New(T, 1),
 									Left: &ast.String{
-										Meta:  ast.New(T, 1),
-										Value: "Access ",
+										Meta:       ast.New(T, 1),
+										Value:      "Access ",
+										LongString: true,
 									},
 									Operator: "+",
 									Right: &ast.String{
-										Meta:  ast.New(T, 1),
-										Value: "denied",
+										Meta:       ast.New(T, 1),
+										Value:      "denied",
+										LongString: true,
 									},
 								},
 							},
@@ -2234,13 +2239,15 @@ sub vcl_recv {
 								Value: &ast.InfixExpression{
 									Meta: ast.New(T, 1, comments(), comments("/* e */")),
 									Left: &ast.String{
-										Meta:  ast.New(T, 1, comments("/* b */"), comments("// c", "/* d */")),
-										Value: "Access ",
+										Meta:       ast.New(T, 1, comments("/* b */"), comments("// c", "/* d */")),
+										Value:      "Access ",
+										LongString: true,
 									},
 									Operator: "+",
 									Right: &ast.String{
-										Meta:  ast.New(T, 1, comments(), comments("/* e */")),
-										Value: "denied",
+										Meta:       ast.New(T, 1, comments(), comments("/* e */")),
+										Value:      "denied",
+										LongString: true,
 									},
 								},
 							},
@@ -2281,13 +2288,15 @@ sub vcl_recv {
 								Value: &ast.InfixExpression{
 									Meta: ast.New(T, 1),
 									Left: &ast.String{
-										Meta:  ast.New(T, 1),
-										Value: "Access ",
+										Meta:       ast.New(T, 1),
+										Value:      "Access ",
+										LongString: true,
 									},
 									Operator: "+",
 									Right: &ast.String{
-										Meta:  ast.New(T, 1),
-										Value: "denied",
+										Meta:       ast.New(T, 1),
+										Value:      "denied",
+										LongString: true,
 									},
 								},
 							},
@@ -2325,13 +2334,15 @@ sub vcl_recv {
 								Value: &ast.InfixExpression{
 									Meta: ast.New(T, 1, comments(), comments("/* e */")),
 									Left: &ast.String{
-										Meta:  ast.New(T, 1, comments("/* b */"), comments("// c", "/* d */")),
-										Value: "Access ",
+										Meta:       ast.New(T, 1, comments("/* b */"), comments("// c", "/* d */")),
+										Value:      "Access ",
+										LongString: true,
 									},
 									Operator: "+",
 									Right: &ast.String{
-										Meta:  ast.New(T, 1, comments(), comments("/* e */")),
-										Value: "denied",
+										Meta:       ast.New(T, 1, comments(), comments("/* e */")),
+										Value:      "denied",
+										LongString: true,
 									},
 								},
 							},
@@ -2344,6 +2355,7 @@ sub vcl_recv {
 		if err != nil {
 			t.Errorf("%+v", err)
 		}
+
 		assert(t, vcl, expect)
 	})
 }

--- a/parser/vcl_type_parser.go
+++ b/parser/vcl_type_parser.go
@@ -23,6 +23,30 @@ func (p *Parser) ParseIP() *ast.IP {
 	}
 }
 
+func (p *Parser) ParseLongString() (*ast.String, error) {
+	if !p.PeekTokenIs(token.STRING) {
+		return nil, errors.WithStack(UnexpectedToken(p.peekToken, token.STRING))
+	}
+
+	openToken := p.curToken
+	delimiter := p.curToken.Token.Literal
+	p.NextToken()
+
+	str, err := p.ParseString()
+	str.LongString = true
+	str.Delimiter = delimiter
+
+	if !p.PeekTokenIs(token.CLOSE_LONG_STRING) {
+		return nil, errors.WithStack(UnexpectedToken(p.peekToken, token.CLOSE_LONG_STRING))
+	}
+
+	str.GetMeta().Leading = openToken.Leading
+	str.GetMeta().Trailing = p.peekToken.Trailing
+	p.NextToken()
+
+	return str, err
+}
+
 func (p *Parser) ParseString() (*ast.String, error) {
 	var err error
 	Parsed := p.curToken.Token.Literal

--- a/token/token.go
+++ b/token/token.go
@@ -37,16 +37,18 @@ const (
 	EOF     = "EOF"
 
 	// Language idents
-	IDENT   = "IDENT"
-	INT     = "INT"
-	STRING  = "STRING"
-	FLOAT   = "FLOAT"
-	RTIME   = "RTIME"
-	COMMENT = "COMMENT"
-	TRUE    = "TRUE"
-	FALSE   = "FALSE"
-	PERCENT = "PERCENT"
-	LF      = "LF" // "\n"
+	IDENT             = "IDENT"
+	INT               = "INT"
+	STRING            = "STRING"
+	OPEN_LONG_STRING  = "OPEN_LONG_STRING"
+	CLOSE_LONG_STRING = "CLOSE_LONG_STRING"
+	FLOAT             = "FLOAT"
+	RTIME             = "RTIME"
+	COMMENT           = "COMMENT"
+	TRUE              = "TRUE"
+	FALSE             = "FALSE"
+	PERCENT           = "PERCENT"
+	LF                = "LF" // "\n"
 
 	// Operators
 	// https://developer.fastly.com/reference/vcl/operators/


### PR DESCRIPTION
Fastly VCL allows [two kinds of "long strings"](https://www.fastly.com/documentation/reference/vcl/types/string/), one kind is simply enclosed within braces, e.g.

```
{"some string content"}
```

However, to account for situations where it may be desirable to embed `"}` within a string (usually, creating JSON), they also support heredoc-style delimiters, e.g.

```
{JSON"{"some_key": "some_value"}"JSON}
```

This modifies the lexer to tokenise these long strings as three different tokens, introducing `token.OPEN_LONG_STRING` and `token.CLOSE_LONG_STRING`. The parser handles these new tokens and the `ast.String` structure now captures the delimiter used so it's appropriately handled when emitting VCL in the formatter.

Previously, handling VCL using this long string syntax failed with an error message along the lines of:

```
Failed to run test: Parse Error: Undefined prefix expression for { at /tmp/example.vcl, line: 198, position: 15
```

It is now appropriately processed.

Thank you for your hard work on Falco, it is much appreciated!