### PR TITLE
Change `fastly.error` from `FLOAT` to `STRING`

### DIFF
--- a/__generator__/predefined.yml
+++ b/__generator__/predefined.yml
@@ -1864,7 +1864,7 @@ math.TAU:
 fastly.error:
   reference: "https://developer.fastly.com/reference/vcl/variables/miscellaneous/fastly-error/"
   on: [RECV, HASH, HIT, MISS, PASS, FETCH, ERROR, DELIVER, LOG]
-  get: FLOAT
+  get: STRING
   unset: true
 
 fastly.ff.visits_this_pop:

--- a/context/predefined.go
+++ b/context/predefined.go
@@ -1787,7 +1787,7 @@ func predefinedVariables() Variables {
 				"error": &Object{
 					Items: map[string]*Object{},
 					Value: &Accessor{
-						Get:       types.FloatType,
+						Get:       types.StringType,
 						Set:       types.NeverType,
 						Unset:     true,
 						Scopes:    RECV | HASH | HIT | MISS | PASS | FETCH | ERROR | DELIVER | LOG,


### PR DESCRIPTION
The Fastly docs indicate that [`fastly.error` is a `STRING`](https://www.fastly.com/documentation/reference/vcl/variables/miscellaneous/fastly-error/), but it's currently defined as a `FLOAT`. This changes the definition in `predefined.yml` to a string and regenerates the Go code.

Thank you!