### PR TITLE
Expose assert.not_error to tests

### DIFF
--- a/cmd/falco/runner_test.go
+++ b/cmd/falco/runner_test.go
@@ -345,7 +345,7 @@ func TestTester(t *testing.T) {
 			name:   "assertions test",
 			main:   "../../examples/testing/assertion/assertion.vcl",
 			filter: "*assertion.test.vcl",
-			passes: 5,
+			passes: 6,
 		},
 		{
 			name:   "grouping test",

--- a/examples/testing/assertion/assertion.test.vcl
+++ b/examples/testing/assertion/assertion.test.vcl
@@ -11,6 +11,12 @@ sub test_error {
 }
 
 // @scope: recv
+sub test_not_error {
+  testing.call_subroutine("noop");
+  assert.not_error();
+}
+
+// @scope: recv
 sub test_call_nested {
   testing.call_subroutine("call_nested");
   assert.subroutine_called("nested");

--- a/examples/testing/assertion/assertion.vcl
+++ b/examples/testing/assertion/assertion.vcl
@@ -6,6 +6,10 @@ sub force_error {
   error 800 "FORCE ERROR";
 }
 
+sub noop {
+
+}
+
 sub nested {
   set req.http.Foo = "1";
 }

--- a/linter/declaration_linter.go
+++ b/linter/declaration_linter.go
@@ -335,7 +335,7 @@ func (l *Linter) lintSubRoutineDeclaration(decl *ast.SubroutineDeclaration, ctx 
 			Severity: WARNING,
 			Token:    decl.Meta.Token,
 			Message: fmt.Sprintf(
-				`Cannot recognize subrountine call scope for "%s"`,
+				`Cannot recognize subroutine call scope for "%s"`,
 				decl.Name.Value,
 			),
 		}

--- a/tester/function/testing_functions.go
+++ b/tester/function/testing_functions.go
@@ -275,6 +275,26 @@ func assertionFunctions(i *interpreter.Interpreter, c Counter) Functions {
 				return false
 			},
 		},
+		"assert.not_error": {
+			Scope: allScope,
+			Call: func(ctx *context.Context, args ...value.Value) (value.Value, error) {
+				unwrapped, err := unwrapIdentArguments(i, args)
+				if err != nil {
+					return value.Null, errors.WithStack(err)
+				}
+				v, err := Assert_not_error(ctx, i, unwrapped...)
+				if err != nil {
+					c.Fail()
+				} else {
+					c.Pass()
+				}
+				return v, err
+			},
+			CanStatementCall: true,
+			IsIdentArgument: func(i int) bool {
+				return false
+			},
+		},
 		"assert.is_notset": {
 			Scope: allScope,
 			Call: func(ctx *context.Context, args ...value.Value) (value.Value, error) {


### PR DESCRIPTION
`assert.not_error` is documented as an available assertion and is implemented, it just hasn't been exposed to the testing context. This exposes it and adds a test.

Thank you!