### PR TITLE
Allow access to body set by `synthetic` in tests

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -200,6 +200,7 @@ We describe them following table and examples:
 | Name                         | Type       | Description                                                                                  |
 |:-----------------------------|:----------:|:---------------------------------------------------------------------------------------------|
 | testing.state                | STRING     | Return state which is called `return` statement in a subroutine                              |
+| testing.synthetic_body       | STRING     | The body generated via a call to `synthetic` or `synthetic.base64`                           |
 | testing.call_subroutine      | FUNCTION   | Call subroutine which is defined in main VCL                                                 |
 | testing.fixed_time           | FUNCTION   | Use fixed time whole the test suite                                                          |
 | testing.override_host        | FUNCTION   | Override request host with provided argument in the test case                                |
@@ -207,7 +208,7 @@ We describe them following table and examples:
 | testing.table_set            | FUNCTION   | Inject value for key to main VCL table                                                       |
 | testing.table_merge          | FUNCTION   | Merge values from testing VCL table to main VCL table                                        |
 | testing.mock                 | FUNCTION   | Mock the subroutine with specified subroutine in the testing VCL                             |
-| testing.resotre_mock         | FUNCTION   | Restore specific mocked subroutine                                                           |
+| testing.restore_mock         | FUNCTION   | Restore specific mocked subroutine                                                           |
 | testing.restore_all_mocks    | FUNCTION   | Restore all mocked subroutines                                                               |
 | assert                       | FUNCTION   | Assert provided expression should be true                                                    |
 | assert.true                  | FUNCTION   | Assert actual value should be true                                                           |
@@ -230,6 +231,26 @@ We describe them following table and examples:
 | assert.state                 | FUNCTION   | Assert after state is expected one                                                           |
 | assert.error                 | FUNCTION   | Assert error status code (and response) if error statement has called                        |
 | assert.not_error             | FUNCTION   | Assert runtime state will not move to error status                                           |
+
+----
+
+### testing.synthetic_body STRING
+
+Returns the response body as set by a call to `synthetic` or `synthetic.base64`.
+Only valid in the `error` scope.
+
+```vcl
+// @scope: error
+sub generate_response {
+    synthetic "No dice.";
+}
+
+// @scope: error
+sub test_vcl {
+    testing.call_subroutine("generate_response");
+    assert.equal(testing.synthetic_body, "No dice.");
+}
+```
 
 ----
 

--- a/examples/testing/default/default.test.vcl
+++ b/examples/testing/default/default.test.vcl
@@ -42,3 +42,11 @@ sub test_header_value {
   assert.true(var.exists);
 }
 
+// @scope: error
+// @suite: synthetic response available in testing
+sub test_synthetic_response_available {
+  testing.call_subroutine("error_response");
+  assert.equal(testing.synthetic_body, "foobar");
+  // Two var accesses in a row should return the same string
+  assert.equal(testing.synthetic_body, "foobar");
+}

--- a/examples/testing/default/default.vcl
+++ b/examples/testing/default/default.vcl
@@ -31,6 +31,11 @@ sub custom_logger {
   log req.http.header;
 }
 
+//@scope: error
+sub error_response {
+  synthetic "foobar";
+}
+
 sub vcl_recv {
 
   #Fastly recv

--- a/interpreter/statement.go
+++ b/interpreter/statement.go
@@ -18,6 +18,17 @@ import (
 	"github.com/ysugimoto/falco/types"
 )
 
+// _nopSeekCloser is like io.NopCloser, but for wrapping io.ReadSeeker.
+type _nopSeekCloser struct {
+	io.ReadSeeker
+}
+
+func (_nopSeekCloser) Close() error { return nil }
+
+func nopSeekCloser(r io.ReadSeeker) io.ReadSeekCloser {
+	return _nopSeekCloser{r}
+}
+
 // nolint: gocognit
 func (i *Interpreter) ProcessBlockStatement(
 	statements []ast.Statement,
@@ -393,7 +404,7 @@ func (i *Interpreter) ProcessSyntheticStatement(stmt *ast.SyntheticStatement) er
 	if err := assign.Assign(v, val); err != nil {
 		return exception.Runtime(&stmt.GetMeta().Token, err.Error())
 	}
-	i.ctx.Object.Body = io.NopCloser(strings.NewReader(v.Value))
+	i.ctx.Object.Body = nopSeekCloser(strings.NewReader(v.Value))
 	return nil
 }
 
@@ -406,7 +417,7 @@ func (i *Interpreter) ProcessSyntheticBase64Statement(stmt *ast.SyntheticBase64S
 	if err := assign.Assign(v, val); err != nil {
 		return exception.Runtime(&stmt.GetMeta().Token, err.Error())
 	}
-	i.ctx.Object.Body = io.NopCloser(strings.NewReader(v.Value))
+	i.ctx.Object.Body = nopSeekCloser(strings.NewReader(v.Value))
 	return nil
 }
 

--- a/tester/variable/testing.go
+++ b/tester/variable/testing.go
@@ -2,6 +2,7 @@ package variable
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/ysugimoto/falco/interpreter/context"
@@ -11,7 +12,8 @@ import (
 
 // Dedicated for testing variables
 const (
-	TESTING_STATE = "testing.state"
+	TESTING_STATE          = "testing.state"
+	TESTING_SYNTHETIC_BODY = "testing.synthetic_body"
 )
 
 type TestingVariables struct {
@@ -22,6 +24,17 @@ func (v *TestingVariables) Get(ctx *context.Context, scope context.Scope, name s
 	switch name { // nolint:gocritic
 	case TESTING_STATE:
 		return &value.String{Value: strings.ToUpper(ctx.ReturnState.Value)}, nil
+	case TESTING_SYNTHETIC_BODY:
+		if b, err := io.ReadAll(ctx.Object.Body); err == nil {
+			// Just assuming that seeking it back to the start is fine. Nothing
+			// else _should_ have left this in a weird state.
+			if _, err := ctx.Object.Body.(io.Seeker).Seek(0, io.SeekStart); err != nil {
+				return nil, err
+			}
+			return &value.String{Value: string(b)}, nil
+		} else {
+			return nil, err
+		}
 	}
 
 	return nil, fmt.Errorf("Not Found")


### PR DESCRIPTION
It's useful to be able to access the body as set by calls to `synthetic` and `synthetic.base64` in tests, e.g. for asserting that error handling code generates expected responses. This exposes the body via a new variable, `testing.synthetic_body`. There's some mild tomfoolery to be able to rewind the response body after it's read, but nothing too egregious.

Thanks again for Falco!