### PR TITLE
Allows subroutine calls in return statments

### DIFF
--- a/interpreter/subroutine.go
+++ b/interpreter/subroutine.go
@@ -204,12 +204,6 @@ func (i *Interpreter) ProcessExpressionReturnStatement(stmt *ast.ReturnStatement
 	if err != nil {
 		return value.Null, NONE, errors.WithStack(err)
 	}
-	if !val.IsLiteral() {
-		return value.Null, NONE, exception.Runtime(
-			&stmt.GetMeta().Token,
-			"Functional subroutine only can return value only accepts a literal value",
-		)
-	}
 
 	switch t := val.(type) {
 	case *value.Ident:

--- a/interpreter/subroutine_test.go
+++ b/interpreter/subroutine_test.go
@@ -134,6 +134,24 @@ func TestFunctionSubroutine(t *testing.T) {
 				"req.http.X-Int-Value": &value.String{Value: "2"},
 			},
 		},
+		{
+			name: "Functional subroutine allows non-literals in return statement",
+			vcl: `sub compute INTEGER {
+				{
+					return std.toupper("test");
+				}
+			}
+
+			sub vcl_recv {
+				declare local var.mystr STRING;
+				set var.mystr = compute();
+				set req.http.X-Str-Value = var.mystr;
+			}
+			`,
+			assertions: map[string]value.Value{
+				"req.http.X-Str-Value": &value.String{Value: "TEST"},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Not sure why this check was added, but Fastly, as of writing, _does_ allow subroutine calls in returns. For example, see these subroutines defined in `init`:

	sub return_test_str STRING {
		return std.toupper("test");
	}

	sub return_test_bool BOOL {
		return randombool(1, 2);
	}

These can be called from `vcl_recv` successfully like so:

	declare local var.strret STRING;
	declare local var.boolret BOOL;

	set var.strret = return_test_str();
	set var.boolret = return_test_bool();

	log "testing returns: " var.strret ", " var.boolret;

Here's an example Fiddle: https://fiddle.fastly.dev/fiddle/b872e5de

----

Has Fastly's behaviour perhaps changed recently and Falco is reflecting a previous behaviour?