### PR TITLE
Fix header subfield handling

### DIFF
--- a/interpreter/variable/header.go
+++ b/interpreter/variable/header.go
@@ -74,6 +74,8 @@ func setRequestHeaderValue(r *http.Request, name string, val value.Value) {
 		r.AddCookie(c)
 		return
 	}
+
+	unsetRequestHeaderValue(r, name)
 	r.Header.Add(spl[0], fmt.Sprintf("%s=%s", spl[1], val.String()))
 }
 
@@ -84,6 +86,7 @@ func setResponseHeaderValue(r *http.Response, name string, val value.Value) {
 	}
 
 	// If name contains ":" like req.http.VARS:xxx, add with key-value format
+	unsetResponseHeaderValue(r, name)
 	spl := strings.SplitN(name, ":", 2)
 	r.Header.Add(spl[0], fmt.Sprintf("%s=%s", spl[1], val.String()))
 }
@@ -114,7 +117,7 @@ func unsetRequestHeaderValue(r *http.Request, name string) {
 	if len(filtered) > 0 {
 		r.Header[spl[0]] = filtered
 	} else {
-		r.Header.Del(name)
+		r.Header.Del(spl[0])
 	}
 }
 
@@ -178,6 +181,6 @@ func unsetResponseHeaderValue(r *http.Response, name string) {
 	if len(filtered) > 0 {
 		r.Header[spl[0]] = filtered
 	} else {
-		r.Header.Del(name)
+		r.Header.Del(spl[0])
 	}
 }

--- a/interpreter/variable/header_test.go
+++ b/interpreter/variable/header_test.go
@@ -80,6 +80,24 @@ func TestSetRequestHeaderValue(t *testing.T) {
 	}
 
 }
+
+func TestSetRequestHeaderValueOverwrite(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+	setRequestHeaderValue(req, "Foo:abc", &value.String{Value: "123"})
+	setRequestHeaderValue(req, "Foo:bar", &value.String{Value: "baz"})
+	setRequestHeaderValue(req, "Foo:bar", &value.String{Value: "snafu"})
+
+	ret := getRequestHeaderValue(req, "Foo:bar")
+	if ret.Value != "snafu" {
+		t.Errorf("Return value unmatch, expect=%s, got=%s", "snafu", ret.Value)
+	}
+
+	ret = getRequestHeaderValue(req, "Foo")
+	if ret.Value != "abc=123, bar=snafu" {
+		t.Errorf("Return value unmatch, expect=%s, got=%s", "abc=123, bar=snafu", ret.Value)
+	}
+}
+
 func TestSetResponseHeaderValue(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -99,6 +117,24 @@ func TestSetResponseHeaderValue(t *testing.T) {
 	}
 
 }
+
+func TestSetResponseHeaderValueOverwrite(t *testing.T) {
+	resp := &http.Response{Header: http.Header{}}
+	setResponseHeaderValue(resp, "Foo:abc", &value.String{Value: "123"})
+	setResponseHeaderValue(resp, "Foo:bar", &value.String{Value: "baz"})
+	setResponseHeaderValue(resp, "Foo:bar", &value.String{Value: "snafu"})
+
+	ret := getResponseHeaderValue(resp, "Foo:bar")
+	if ret.Value != "snafu" {
+		t.Errorf("Return value unmatch, expect=%s, got=%s", "snafu", ret.Value)
+	}
+
+	ret = getResponseHeaderValue(resp, "Foo")
+	if ret.Value != "abc=123, bar=snafu" {
+		t.Errorf("Return value unmatch, expect=%s, got=%s", "abc=123, bar=snafu", ret.Value)
+	}
+}
+
 func TestUnsetRequestHeaderValue(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Multiple set calls for the same header subfield in a row, e.g.

	set req.http.Foo:bar = "baz";
	set req.http.Foo:bar = "snafu";

were resulting in multiple values for `bar` being present, e.g.

	"bar=baz, bar=snafu"

rather than the expected

	"bar=snafu"

You can confirm that this is Fastly's behaviour via this Fiddle:

https://fiddle.fastly.dev/fiddle/7af1b6c9