### PR TITLE
update falco simulate command in README

### DIFF
--- a/docs/simulator.md
+++ b/docs/simulator.md
@@ -93,7 +93,7 @@ See `simulator.edge_dictionary` field in [configuration.md](./configuration.md).
 You can run the debugger by providing `-debug` option on the simulator:
 
 ```
-falco local -debug /path/to/your/default.vcl
+falco simulate -debug /path/to/your/default.vcl
 ```
 
 ## Actual Proxy Behavior


### PR DESCRIPTION
### Summary

This PR updates the falco command example in the README. The old command:
`falco local -debug /path/to/your/default.vcl`
is replaced with:
`falco simulate -debug /path/to/your/default.vcl`.

### Changes

- Updated the README file to replace `local` with `simulate` in the falco command example.

### Reason

The `simulate` command is now the correct and recommended subcommand for this context.  The `local` command may no longer be applicable or up-to-date.
