### PR TITLE
fix: support --version option

### DIFF
--- a/cmd/falco/main.go
+++ b/cmd/falco/main.go
@@ -79,10 +79,10 @@ func main() {
 	}
 	if c.Help {
 		printHelp(c.Commands.At(0))
-		os.Exit(1)
+		os.Exit(0)
 	} else if c.Version {
 		writeln(white, version)
-		os.Exit(1)
+		os.Exit(0)
 	}
 
 	var fetcher snippets.Fetcher

--- a/config/config.go
+++ b/config/config.go
@@ -113,7 +113,7 @@ type Config struct {
 	// Root configurations
 	IncludePaths []string `cli:"I,include_path" yaml:"include_paths"`
 	Help         bool     `cli:"h,help"`
-	Version      bool     `cli:"V"`
+	Version      bool     `cli:"V,version"`
 	Remote       bool     `cli:"r,remote" yaml:"remote"`
 	Json         bool     `cli:"json"`
 	Request      string   `cli:"request"`


### PR DESCRIPTION
## Overview

1. Although the output of printHelp included a description of the --version flag[^1], it was not supported, so I added it.
2. Since the results of the -V and -h flags generally terminate with exit 0, I modified the exit status accordingly.

[^1]: https://github.com/ysugimoto/falco/blob/8ec8d6b9d3f0f4d68575da2d34ff2dc69c3583b8/cmd/falco/help.go#L65