### PR TITLE
fix: formatting is broken if using elseif or elsif

### DIFF
--- a/formatter/statement_format_test.go
+++ b/formatter/statement_format_test.go
@@ -806,6 +806,46 @@ func TestFormatIfStatement(t *testing.T) {
 `,
 		},
 		{
+			name: "elseif and elsif",
+			input: `sub vcl_recv {
+	// if leading comment
+	if (req.http.Host) {
+		set req.http.Foo = req.http.Host;
+		// if infix comment
+	} /* elseif_leading */ elseif /* elseif_infix */ (/* elseif_condition_leading */ req.http.AnotherHost /* elseif_condition_trailing */) /* else_before_parenthesis */ {
+		set req.http.Foo = "another";
+	}
+	// More complecated case
+	elsif (req.http.Other) {
+		set req.http.Foo = "other";
+	} else {
+		set req.http.Foo = "unknown";
+		// else infix comment
+	} // if trailing comment
+}
+`,
+			expect: `sub vcl_recv {
+  // if leading comment
+  if (req.http.Host) {
+    set req.http.Foo = req.http.Host;
+    // if infix comment
+  } /* elseif_leading */ elseif /* elseif_infix */ (
+    /* elseif_condition_leading */ req.http.AnotherHost
+    /* elseif_condition_trailing */
+  ) /* else_before_parenthesis */ {
+    set req.http.Foo = "another";
+  }
+  // More complecated case
+  elsif (req.http.Other) {
+    set req.http.Foo = "other";
+  } else {
+    set req.http.Foo = "unknown";
+    // else infix comment
+  }  // if trailing comment
+}
+`,
+		},
+		{
 			name: "chunked condition format",
 			input: `sub vcl_recv {
 	if (req.http.Header1 == "1" && req.http.Header2 == "2" && req.http.Header3 == "3" && req.http.Header4 == "4") {

--- a/parser/statement_parser.go
+++ b/parser/statement_parser.go
@@ -629,7 +629,7 @@ func (p *Parser) ParseIfStatement() (*ast.IfStatement, error) {
 		// Note: VCL could define "else if" statement with "elseif", "elsif" keyword
 		case token.ELSEIF, token.ELSIF: // elseif, elsif
 			p.NextToken() // point to ELSEIF/ELSIF
-			another, err := p.ParseAnotherIfStatement(p.peekToken.Token.Literal)
+			another, err := p.ParseAnotherIfStatement(p.curToken.Token.Literal)
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}


### PR DESCRIPTION
## Overview

- formatting is broken if you use elseif or elsif statements
- should refer to curToken because `NextToken()` will move peekToken to the next token