### PR TITLE
add more logic and error definition for long string parsing

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -157,6 +157,7 @@ func (l *Lexer) NextToken() token.Token {
 		// with custom delimiters like {JSON" {"foo": "bar"} "JSON}. It is
 		// convenient for constructing strings thats include whitespace,
 		// creating JSON responses, etc.
+		// see: https://www.fastly.com/documentation/reference/vcl/types/string/
 		delimiter, err := l.peekUntil(func(b byte) bool {
 			return !isLongStringDelimiter(rune(b))
 		})

--- a/parser/error.go
+++ b/parser/error.go
@@ -101,3 +101,10 @@ func InvalidEscape(m *ast.Meta, msg string) *ParseError {
 		Message: msg,
 	}
 }
+
+func LongStringDelimiterMismatch(m *ast.Meta, openDelim, closeDelim string) *ParseError {
+	return &ParseError{
+		Token:   m.Token,
+		Message: fmt.Sprintf("Long String delimiter mismatch. open=%s, close=%s", openDelim, closeDelim),
+	}
+}

--- a/parser/expression_parser.go
+++ b/parser/expression_parser.go
@@ -211,7 +211,7 @@ func (p *Parser) ParseInfixStringConcatExpression(left ast.Expression, explicit 
 	// Unsure if this is a bug, but previous versions of this code carried over
 	// all of the ast.String's Meta field. This means that trailing comments on
 	// the ast.String end up on the ast.InfixExpression as well. The tests
-	// validated this so assuming it's intentional behaviour for now and
+	// validated this so assuming it's intentional behavior for now and
 	// carrying it across with the new long string parsing.
 	if p.CurTokenIs(token.OPEN_LONG_STRING) && p.PeekTokenIs(token.STRING) {
 		meta = p.peekToken

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -89,6 +89,18 @@ sub vcl_recv {
 	}
 }
 
+func TestLongStringDelimiterMismatch(t *testing.T) {
+	input := `// Subroutine
+sub vcl_recv {
+	declare local var.S STRING;
+	set var.S = {delimited"long"mismatch};
+}`
+	_, err := New(lexer.NewFromString(input)).ParseVCL()
+	if err == nil {
+		t.Errorf("expects error but got nil")
+	}
+}
+
 func TestStringLiteralEscapes(t *testing.T) {
 	// % escapes are only expanded in double-quote strings.
 	input := `

--- a/parser/vcl_type_parser.go
+++ b/parser/vcl_type_parser.go
@@ -39,6 +39,10 @@ func (p *Parser) ParseLongString() (*ast.String, error) {
 	if !p.PeekTokenIs(token.CLOSE_LONG_STRING) {
 		return nil, errors.WithStack(UnexpectedToken(p.peekToken, token.CLOSE_LONG_STRING))
 	}
+	// Check open and close delimiter string is the same
+	if delimiter != p.peekToken.Token.Literal {
+		return nil, errors.WithStack(UnexpectedToken(p.peekToken, token.CLOSE_LONG_STRING))
+	}
 
 	str.GetMeta().Leading = openToken.Leading
 	str.GetMeta().Trailing = p.peekToken.Trailing


### PR DESCRIPTION
Related #379 

To support long string feature, we'd like to improve parser that checks open/close delimiter character is mathed explicitly.
cc @gabrielg 