### PR TITLE
Add github token to use github CLI

### DIFF
--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -43,4 +43,6 @@ jobs:
               -t "[Automated] Need to implement new variables/functions" \
               -l automated
           fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Continue to fix https://github.com/ysugimoto/falco/pull/396
Need to set `GH_TOKEN` environement to use github CLI.