### PR TITLE
update golang 1.23.5 and golangci-lint v1.63, fix new reports

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.2
+          go-version: 1.23.5
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.2
+          go-version: 1.23.5
       - name: Checkout
         uses: actions/checkout@v4
       - name: Run benchmark for head branch
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.2
+          go-version: 1.23.5
       - name: Checkout
         uses: actions/checkout@v4
       - name: Download base benchmark result

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22.2
+        go-version: 1.23.5
     - name: Run tests
       run: |
         make plugin_ci
@@ -25,7 +25,7 @@ jobs:
     - name: Lint programs
       uses: golangci/golangci-lint-action@v6
       with:
-        version: v1.58
+        version: v1.63
         skip-cache: true
         skip-save-cache: true
         install-mode: binary

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22.2
+        go-version: 1.23.5
     - name: Run tests
       run: |
         make plugin_ci
@@ -20,7 +20,7 @@ jobs:
     - name: Lint programs
       uses: golangci/golangci-lint-action@v6
       with:
-        version: v1.58
+        version: v1.63
         skip-cache: true
         skip-save-cache: true
         install-mode: binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.2
+          go-version: 1.23.5
       - name: Run tests
         run: |
           make plugin_ci
@@ -22,7 +22,7 @@ jobs:
       - name: Lint programs
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.58
+          version: v1.63
           skip-cache: true
           skip-save-cache: true
           install-mode: binary

--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -21,7 +21,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.2
+          go-version: 1.23.5
       - name: run checker
         id: checking
         working-directory: cmd/documentation-checker

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ request.json
 .falco.yaml
 *.pem
 bench.*.txt
+issue-*

--- a/__generator__/template.go
+++ b/__generator__/template.go
@@ -6,7 +6,7 @@ const linterPredefinedVariables = `
 package context
 
 import (
-	"errors"
+	"github.com/pkg/errors"
 	"github.com/ysugimoto/falco/types"
 )
 

--- a/cmd/falco/runner.go
+++ b/cmd/falco/runner.go
@@ -121,11 +121,11 @@ func NewRunner(c *config.Config, fetcher snippets.Fetcher) *Runner {
 	if fetcher != nil {
 		s, err := snippets.Fetch(fetcher)
 		if err != nil {
-			r.message(red, err.Error()+"\n")
+			r.message(red, "%s\n", err.Error())
 		}
 		r.snippets = s
 		if err := r.snippets.FetchLoggingEndpoint(fetcher); err != nil {
-			r.message(red, err.Error()+"\n")
+			r.message(red, "%s\n", err.Error())
 		}
 	}
 

--- a/cmd/falco/transform.go
+++ b/cmd/falco/transform.go
@@ -34,8 +34,8 @@ func (t *Transformer) Execute(d io.Reader) error {
 }
 
 func (t *Transformer) Write(v []byte) (int, error) {
-	write(magenta, "["+t.command+"] ")
-	write(white, string(v))
+	write(magenta, "[%s]", t.command)
+	write(white, "%s", string(v))
 
 	return len(v), nil
 }

--- a/console/console.go
+++ b/console/console.go
@@ -8,6 +8,7 @@ import (
 	"github.com/c-bata/go-prompt"
 	"github.com/fatih/color"
 	"github.com/mattn/go-colorable"
+	"github.com/pkg/errors"
 	"github.com/ysugimoto/falco/interpreter"
 	"github.com/ysugimoto/falco/interpreter/context"
 	"github.com/ysugimoto/falco/interpreter/exception"
@@ -168,7 +169,7 @@ func evaluateExpression(ip *interpreter.Interpreter, line string) (string, error
 	val, err := ip.ProcessExpression(exp, false)
 	if err != nil {
 		if re, ok := err.(*exception.Exception); ok {
-			return "", fmt.Errorf(re.Message) // DO NOT diplay line and position info
+			return "", errors.New(re.Message) // DO NOT diplay line and position info
 		}
 		return "", err
 	}

--- a/debugger/debugger.go
+++ b/debugger/debugger.go
@@ -45,7 +45,7 @@ func (d *Debugger) Run(node ast.Node) interpreter.DebugState {
 }
 
 func (d *Debugger) Message(msg string) {
-	d.message.Append(messageview.Runtime, msg)
+	d.message.Append(messageview.Runtime, "%s", msg)
 }
 
 func (d *Debugger) breakPoint(t token.Token) interpreter.DebugState {

--- a/debugger/repl.go
+++ b/debugger/repl.go
@@ -3,6 +3,7 @@ package debugger
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/ysugimoto/falco/interpreter/exception"
 	"github.com/ysugimoto/falco/interpreter/value"
 	"github.com/ysugimoto/falco/lexer"
@@ -36,7 +37,7 @@ func (c *Console) evaluate(input string) (string, error) {
 	val, err := c.interpreter.ProcessExpression(exp, false)
 	if err != nil {
 		if re, ok := err.(*exception.Exception); ok {
-			return "", fmt.Errorf(re.Message) // DO NOT diplay line and position info
+			return "", errors.New(re.Message) // DO NOT diplay line and position info
 		}
 		return "", err
 	}

--- a/interpreter/expression.go
+++ b/interpreter/expression.go
@@ -330,7 +330,7 @@ func (i *Interpreter) ProcessInfixExpression(exp *ast.InfixExpression, withCondi
 
 	if opErr != nil {
 		return value.Null, errors.WithStack(
-			exception.Runtime(&exp.GetMeta().Token, opErr.Error()),
+			exception.Runtime(&exp.GetMeta().Token, "%s", opErr.Error()),
 		)
 	}
 

--- a/interpreter/include.go
+++ b/interpreter/include.go
@@ -17,7 +17,7 @@ func (i *Interpreter) resolveIncludeStatement(statements []ast.Statement, isRoot
 		if include, ok := stmt.(*ast.IncludeStatement); ok {
 			if strings.HasPrefix(include.Module.Value, "snippet::") {
 				if included, err := i.includeSnippet(include, isRoot); err != nil {
-					return nil, ex.Runtime(&stmt.GetMeta().Token, err.Error())
+					return nil, ex.Runtime(&stmt.GetMeta().Token, "%s", err.Error())
 				} else {
 					resolved = append(resolved, included...)
 				}
@@ -25,7 +25,7 @@ func (i *Interpreter) resolveIncludeStatement(statements []ast.Statement, isRoot
 			}
 			included, err := i.includeFile(include, isRoot)
 			if err != nil {
-				return nil, ex.Runtime(&stmt.GetMeta().Token, err.Error())
+				return nil, ex.Runtime(&stmt.GetMeta().Token, "%s", err.Error())
 			}
 			recursive, err := i.resolveIncludeStatement(included, isRoot)
 			if err != nil {

--- a/interpreter/statement.go
+++ b/interpreter/statement.go
@@ -263,7 +263,7 @@ func (i *Interpreter) ProcessAddStatement(stmt *ast.AddStatement) error {
 		return errors.WithStack(err)
 	}
 	if err := i.vars.Add(i.ctx.Scope, stmt.Ident.Value, right); err != nil {
-		return exception.Runtime(&stmt.GetMeta().Token, err.Error())
+		return exception.Runtime(&stmt.GetMeta().Token, "%s", err.Error())
 	}
 	return nil
 }
@@ -277,7 +277,7 @@ func (i *Interpreter) ProcessUnsetStatement(stmt *ast.UnsetStatement) error {
 	}
 
 	if err != nil {
-		return exception.Runtime(&stmt.GetMeta().Token, err.Error())
+		return exception.Runtime(&stmt.GetMeta().Token, "%s", err.Error())
 	}
 	return nil
 }
@@ -292,7 +292,7 @@ func (i *Interpreter) ProcessRemoveStatement(stmt *ast.RemoveStatement) error {
 	}
 
 	if err != nil {
-		return exception.Runtime(&stmt.GetMeta().Token, err.Error())
+		return exception.Runtime(&stmt.GetMeta().Token, "%s", err.Error())
 	}
 	return nil
 }
@@ -343,7 +343,7 @@ func (i *Interpreter) ProcessErrorStatement(stmt *ast.ErrorStatement) error {
 		}
 		// set obj.status and obj.response variable internally
 		if err := assign.Assign(i.ctx.ObjectStatus, code); err != nil {
-			return exception.Runtime(&stmt.GetMeta().Token, err.Error())
+			return exception.Runtime(&stmt.GetMeta().Token, "%s", err.Error())
 		}
 	}
 	// Possibility error response is not defined
@@ -354,7 +354,7 @@ func (i *Interpreter) ProcessErrorStatement(stmt *ast.ErrorStatement) error {
 		}
 
 		if err := assign.Assign(i.ctx.ObjectResponse, arg); err != nil {
-			return exception.Runtime(&stmt.GetMeta().Token, err.Error())
+			return exception.Runtime(&stmt.GetMeta().Token, "%s", err.Error())
 		}
 	}
 	return nil
@@ -402,7 +402,7 @@ func (i *Interpreter) ProcessSyntheticStatement(stmt *ast.SyntheticStatement) er
 
 	v := &value.String{}
 	if err := assign.Assign(v, val); err != nil {
-		return exception.Runtime(&stmt.GetMeta().Token, err.Error())
+		return exception.Runtime(&stmt.GetMeta().Token, "%s", err.Error())
 	}
 	i.ctx.Object.Body = nopSeekCloser(strings.NewReader(v.Value))
 	return nil
@@ -415,7 +415,7 @@ func (i *Interpreter) ProcessSyntheticBase64Statement(stmt *ast.SyntheticBase64S
 	}
 	v := &value.String{}
 	if err := assign.Assign(v, val); err != nil {
-		return exception.Runtime(&stmt.GetMeta().Token, err.Error())
+		return exception.Runtime(&stmt.GetMeta().Token, "%s", err.Error())
 	}
 	i.ctx.Object.Body = nopSeekCloser(strings.NewReader(v.Value))
 	return nil
@@ -433,7 +433,7 @@ func (i *Interpreter) ProcessFunctionCallStatement(stmt *ast.FunctionCallStateme
 	// Builtin function will not change any state
 	fn, err := function.Exists(i.ctx.Scope, stmt.Function.Value)
 	if err != nil {
-		return NONE, exception.Runtime(&stmt.GetMeta().Token, err.Error())
+		return NONE, exception.Runtime(&stmt.GetMeta().Token, "%s", err.Error())
 	}
 	// Check the function can call in statement (means a function that returns VOID type can call)
 	if !fn.CanStatementCall {
@@ -480,7 +480,7 @@ func (i *Interpreter) ProcessFunctionCallStatement(stmt *ast.FunctionCallStateme
 			t.Token = stmt.GetMeta().Token
 			return NONE, errors.WithStack(t)
 		default:
-			return NONE, exception.Runtime(&stmt.GetMeta().Token, err.Error())
+			return NONE, exception.Runtime(&stmt.GetMeta().Token, "%s", err.Error())
 		}
 	}
 	return NONE, nil

--- a/linter/context/context.go
+++ b/linter/context/context.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/ysugimoto/falco/ast"
 	"github.com/ysugimoto/falco/resolver"
 	"github.com/ysugimoto/falco/snippets"
@@ -71,7 +72,7 @@ func CanAccessVariableInScope(objScope int, objReference, name string, currentSc
 		if objReference != "" {
 			message += "\nSee reference documentation: " + objReference
 		}
-		return fmt.Errorf(message)
+		return errors.New(message)
 	}
 	return nil
 }
@@ -501,7 +502,7 @@ func (c *Context) Get(name string) (types.Type, error) {
 		if obj.Value.Reference != "" {
 			message += "\nSee reference documentation: " + obj.Value.Reference
 		}
-		return types.NullType, fmt.Errorf(message)
+		return types.NullType, errors.New(message)
 	}
 
 	// Mark as accessed
@@ -564,7 +565,7 @@ func (c *Context) Set(name string) (types.Type, error) {
 		if obj.Value.Reference != "" {
 			message += "\nSee reference documentation: " + obj.Value.Reference
 		}
-		return types.NullType, fmt.Errorf(message)
+		return types.NullType, errors.New(message)
 	}
 
 	// Mark as accessed
@@ -662,7 +663,7 @@ func (c *Context) Unset(name string) error {
 		if obj.Value.Reference != "" {
 			message += "\nSee reference documentation: " + obj.Value.Reference
 		}
-		return fmt.Errorf(message)
+		return errors.New(message)
 	}
 
 	// Mark as accessed

--- a/linter/context/predefined.go
+++ b/linter/context/predefined.go
@@ -3,7 +3,7 @@
 package context
 
 import (
-	"errors"
+	"github.com/pkg/errors"
 	"github.com/ysugimoto/falco/types"
 )
 

--- a/linter/declaration_linter.go
+++ b/linter/declaration_linter.go
@@ -110,9 +110,16 @@ func (l *Linter) lintBackendProperty(prop *ast.BackendProperty, ctx *context.Con
 
 		// share_key must consist of alphanumeric or ASCII characters
 		if prop.Key.Value == "share_key" {
-			v := prop.Value.(*ast.String).Value
-			if !isValidBackendShareKey(v) {
-				l.Error(InvalidValue(prop.Value.GetMeta(), "share_key", v).Match(BACKEND_SYNTAX))
+			if v, ok := prop.Value.(*ast.String); ok {
+				if !isValidBackendShareKey(v.Value) {
+					l.Error(InvalidValue(prop.Value.GetMeta(), "share_key", v.Value).Match(BACKEND_SYNTAX))
+				}
+			} else {
+				l.Error(&LintError{
+					Severity: ERROR,
+					Token:    prop.Value.GetMeta().Token,
+					Message:  "share_key field value must be STRING",
+				})
 			}
 		}
 	}

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -1,10 +1,10 @@
 package linter
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/ysugimoto/falco/ast"
 	"github.com/ysugimoto/falco/config"
 	"github.com/ysugimoto/falco/lexer"

--- a/remote/client_test.go
+++ b/remote/client_test.go
@@ -2,12 +2,13 @@ package remote
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"testing"
 
 	"io/ioutil"
 	"net/http"
+
+	"github.com/pkg/errors"
 )
 
 type TestRoundTripper struct {

--- a/terraform/terraform.go
+++ b/terraform/terraform.go
@@ -177,7 +177,7 @@ func findFastlyServicesInTerraformModule(mod *TerraformModule) ([]*FastlyService
 	}
 
 	// Check child_modules existence and return found services if not found
-	if mod.ChildModules == nil || len(mod.ChildModules) == 0 {
+	if len(mod.ChildModules) == 0 {
 		return services, nil
 	}
 	// If module has child_modules, find Fastly service recursively

--- a/tester/function/assert.go
+++ b/tester/function/assert.go
@@ -25,7 +25,7 @@ func Assert_Validate(args []value.Value) error {
 
 func Assert(ctx *context.Context, args ...value.Value) (value.Value, error) {
 	if err := Assert_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	// Check custom message

--- a/tester/function/assert_contains.go
+++ b/tester/function/assert_contains.go
@@ -33,7 +33,7 @@ func Assert_contains_Validate(args []value.Value) error {
 
 func Assert_contains(ctx *context.Context, args ...value.Value) (value.Value, error) {
 	if err := Assert_contains_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	// Check custom message
@@ -48,7 +48,7 @@ func Assert_contains(ctx *context.Context, args ...value.Value) (value.Value, er
 	ret := &value.Boolean{Value: strings.Contains(actual.Value, expect.Value)}
 	if !ret.Value {
 		if message != "" {
-			return ret, errors.NewAssertionError(actual, message)
+			return ret, errors.NewAssertionError(actual, "%s", message)
 		}
 		return ret, errors.NewAssertionError(
 			actual,

--- a/tester/function/assert_ends_with.go
+++ b/tester/function/assert_ends_with.go
@@ -33,7 +33,7 @@ func Assert_ends_with_Validate(args []value.Value) error {
 
 func Assert_ends_with(ctx *context.Context, args ...value.Value) (value.Value, error) {
 	if err := Assert_ends_with_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	// Check custom message
@@ -48,7 +48,7 @@ func Assert_ends_with(ctx *context.Context, args ...value.Value) (value.Value, e
 	ret := &value.Boolean{Value: strings.HasSuffix(actual.Value, expect.Value)}
 	if !ret.Value {
 		if message != "" {
-			return ret, errors.NewAssertionError(actual, message)
+			return ret, errors.NewAssertionError(actual, "%s", message)
 		}
 		return ret, errors.NewAssertionError(
 			actual,

--- a/tester/function/assert_equal.go
+++ b/tester/function/assert_equal.go
@@ -22,7 +22,7 @@ func Assert_equal_Validate(args []value.Value) error {
 
 func Assert_equal(ctx *context.Context, args ...value.Value) (value.Value, error) {
 	if err := Assert_equal_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	// assert.equal is alias for assert.strict_equal

--- a/tester/function/assert_equal_fold.go
+++ b/tester/function/assert_equal_fold.go
@@ -24,7 +24,7 @@ func Assert_equal_fold_Validate(args []value.Value) error {
 
 func Assert_equal_fold(ctx *context.Context, args ...value.Value) (value.Value, error) {
 	if err := Assert_equal_fold_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	return assert_equal_fold(args...)
@@ -47,13 +47,13 @@ func assert_equal_fold(args ...value.Value) (value.Value, error) {
 				actual.Type(),
 			)
 		}
-		return &value.Boolean{}, errors.NewAssertionError(actual, message)
+		return &value.Boolean{}, errors.NewAssertionError(actual, "%s", message)
 	}
 
 	ok := &value.Boolean{Value: strings.EqualFold(actual.String(), expect.String())}
 	if !ok.Value {
 		if message != "" {
-			return ok, errors.NewAssertionError(actual, message)
+			return ok, errors.NewAssertionError(actual, "%s", message)
 		}
 		return ok, errors.NewAssertionError(actual,
 			"Assertion error: expect=%v, actual=%v", expect, actual)

--- a/tester/function/assert_error.go
+++ b/tester/function/assert_error.go
@@ -32,7 +32,7 @@ func Assert_error(
 ) (value.Value, error) {
 
 	if err := Assert_error_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	// extract arguments
@@ -52,7 +52,7 @@ func Assert_error(
 		}
 		return &value.Boolean{}, errors.NewAssertionError(
 			&value.String{Value: i.TestingState.String()},
-			message,
+			"%s", message,
 		)
 	}
 
@@ -67,8 +67,7 @@ func Assert_error(
 			)
 		}
 		return &value.Boolean{}, errors.NewAssertionError(
-			ctx.ObjectStatus,
-			message,
+			ctx.ObjectStatus, "%s", message,
 		)
 	}
 
@@ -84,8 +83,7 @@ func Assert_error(
 				)
 			}
 			return &value.Boolean{}, errors.NewAssertionError(
-				ctx.ObjectResponse,
-				message,
+				ctx.ObjectResponse, "%s", message,
 			)
 		}
 	}

--- a/tester/function/assert_false.go
+++ b/tester/function/assert_false.go
@@ -23,7 +23,7 @@ func Assert_false_Validate(args []value.Value) error {
 
 func Assert_false(ctx *context.Context, args ...value.Value) (value.Value, error) {
 	if err := Assert_false_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	// Check custom message

--- a/tester/function/assert_is_notset.go
+++ b/tester/function/assert_is_notset.go
@@ -18,7 +18,7 @@ func Assert_is_notset_Validate(args []value.Value) error {
 
 func Assert_is_notset(ctx *context.Context, args ...value.Value) (value.Value, error) {
 	if err := Assert_is_notset_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	// Check custom message

--- a/tester/function/assert_match.go
+++ b/tester/function/assert_match.go
@@ -33,7 +33,7 @@ func Assert_match_Validate(args []value.Value) error {
 
 func Assert_match(ctx *context.Context, args ...value.Value) (value.Value, error) {
 	if err := Assert_match_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	// Check custom message
@@ -55,7 +55,7 @@ func Assert_match(ctx *context.Context, args ...value.Value) (value.Value, error
 	ret := &value.Boolean{Value: re.MatchString(actual.Value)}
 	if !ret.Value {
 		if message != "" {
-			return ret, errors.NewAssertionError(actual, message)
+			return ret, errors.NewAssertionError(actual, "%s", message)
 		}
 		return ret, errors.NewAssertionError(
 			actual,

--- a/tester/function/assert_not_contains.go
+++ b/tester/function/assert_not_contains.go
@@ -33,7 +33,7 @@ func Assert_not_contains_Validate(args []value.Value) error {
 
 func Assert_not_contains(ctx *context.Context, args ...value.Value) (value.Value, error) {
 	if err := Assert_not_contains_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	// Check custom message
@@ -48,7 +48,7 @@ func Assert_not_contains(ctx *context.Context, args ...value.Value) (value.Value
 	ret := &value.Boolean{Value: !strings.Contains(actual.Value, expect.Value)}
 	if !ret.Value {
 		if message != "" {
-			return ret, errors.NewAssertionError(actual, message)
+			return ret, errors.NewAssertionError(actual, "%s", message)
 		}
 		return ret, errors.NewAssertionError(
 			actual,

--- a/tester/function/assert_not_equal.go
+++ b/tester/function/assert_not_equal.go
@@ -22,7 +22,7 @@ func Assert_not_equal_Validate(args []value.Value) error {
 
 func Assert_not_equal(ctx *context.Context, args ...value.Value) (value.Value, error) {
 	if err := Assert_not_equal_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	// assert.not_equal is alias for assert.not_strict_equal

--- a/tester/function/assert_not_error.go
+++ b/tester/function/assert_not_error.go
@@ -24,7 +24,7 @@ func Assert_not_error(
 ) (value.Value, error) {
 
 	if err := Assert_not_error_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	// extract arguments
@@ -43,7 +43,7 @@ func Assert_not_error(
 		}
 		return &value.Boolean{}, errors.NewAssertionError(
 			&value.String{Value: i.TestingState.String()},
-			message,
+			"%s", message,
 		)
 	}
 

--- a/tester/function/assert_not_match.go
+++ b/tester/function/assert_not_match.go
@@ -33,7 +33,7 @@ func Assert_not_match_Validate(args []value.Value) error {
 
 func Assert_not_match(ctx *context.Context, args ...value.Value) (value.Value, error) {
 	if err := Assert_not_match_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	// Check custom message
@@ -55,7 +55,7 @@ func Assert_not_match(ctx *context.Context, args ...value.Value) (value.Value, e
 	ret := &value.Boolean{Value: re.MatchString(actual.Value)}
 	if ret.Value {
 		if message != "" {
-			return ret, errors.NewAssertionError(actual, message)
+			return ret, errors.NewAssertionError(actual, "%s", message)
 		}
 		return ret, errors.NewAssertionError(
 			actual,

--- a/tester/function/assert_not_strict_equal.go
+++ b/tester/function/assert_not_strict_equal.go
@@ -22,7 +22,7 @@ func Assert_not_strict_equal_Validate(args []value.Value) error {
 
 func Assert_not_strict_equal(ctx *context.Context, args ...value.Value) (value.Value, error) {
 	if err := Assert_not_strict_equal_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	return assert_not_strict_equal(args...)
@@ -45,7 +45,7 @@ func assert_not_strict_equal(args ...value.Value) (value.Value, error) {
 				actual.Type(),
 			)
 		}
-		return &value.Boolean{}, errors.NewAssertionError(actual, message)
+		return &value.Boolean{}, errors.NewAssertionError(actual, "%s", message)
 	}
 
 	return assert_not(actual, actual.String(), expect.String(), message)

--- a/tester/function/assert_not_subroutine_called.go
+++ b/tester/function/assert_not_subroutine_called.go
@@ -21,7 +21,7 @@ func Assert_not_subroutine_called_Validate(args []value.Value) error {
 
 func Assert_not_subroutine_called(ctx *context.Context, args ...value.Value) (value.Value, error) {
 	if err := Assert_not_subroutine_called_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	name := value.Unwrap[*value.String](args[0]).Value
@@ -41,7 +41,7 @@ func Assert_not_subroutine_called(ctx *context.Context, args ...value.Value) (va
 	_, ok := ctx.SubroutineCalls[name]
 	if ok {
 		if message != "" {
-			return &value.Boolean{}, errors.NewAssertionError(args[0], message)
+			return &value.Boolean{}, errors.NewAssertionError(args[0], "%s", message)
 		}
 		return &value.Boolean{}, errors.NewAssertionError(args[0], "Subroutine %s is called", name)
 	}

--- a/tester/function/assert_restart.go
+++ b/tester/function/assert_restart.go
@@ -30,7 +30,7 @@ func Assert_restart(
 ) (value.Value, error) {
 
 	if err := Assert_restart_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	var message string
@@ -41,7 +41,7 @@ func Assert_restart(
 	}
 
 	if i.TestingState != interpreter.RESTART {
-		return &value.Boolean{}, errors.NewAssertionError(&value.String{Value: ""}, message)
+		return &value.Boolean{}, errors.NewAssertionError(&value.String{Value: ""}, "%s", message)
 	}
 	return &value.Boolean{Value: true}, nil
 }

--- a/tester/function/assert_starts_with.go
+++ b/tester/function/assert_starts_with.go
@@ -33,7 +33,7 @@ func Assert_starts_with_Validate(args []value.Value) error {
 
 func Assert_starts_with(ctx *context.Context, args ...value.Value) (value.Value, error) {
 	if err := Assert_starts_with_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	// Check custom message
@@ -48,7 +48,7 @@ func Assert_starts_with(ctx *context.Context, args ...value.Value) (value.Value,
 	ret := &value.Boolean{Value: strings.HasPrefix(actual.Value, expect.Value)}
 	if !ret.Value {
 		if message != "" {
-			return ret, errors.NewAssertionError(actual, message)
+			return ret, errors.NewAssertionError(actual, "%s", message)
 		}
 		return ret, errors.NewAssertionError(
 			actual,

--- a/tester/function/assert_state.go
+++ b/tester/function/assert_state.go
@@ -34,7 +34,7 @@ func Assert_state(
 ) (value.Value, error) {
 
 	if err := Assert_state_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	state := value.Unwrap[*value.Ident](args[0])

--- a/tester/function/assert_strict_equal.go
+++ b/tester/function/assert_strict_equal.go
@@ -22,7 +22,7 @@ func Assert_strict_equal_Validate(args []value.Value) error {
 
 func Assert_strict_equal(ctx *context.Context, args ...value.Value) (value.Value, error) {
 	if err := Assert_strict_equal_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	return assert_strict_equal(args...)
@@ -45,7 +45,7 @@ func assert_strict_equal(args ...value.Value) (value.Value, error) {
 				actual.Type(),
 			)
 		}
-		return &value.Boolean{}, errors.NewAssertionError(actual, message)
+		return &value.Boolean{}, errors.NewAssertionError(actual, "%s", message)
 	}
 
 	return assert(actual, actual.String(), expect.String(), message)

--- a/tester/function/assert_subroutine_called.go
+++ b/tester/function/assert_subroutine_called.go
@@ -21,7 +21,7 @@ func Assert_subroutine_called_Validate(args []value.Value) error {
 
 func Assert_subroutine_called(ctx *context.Context, args ...value.Value) (value.Value, error) {
 	if err := Assert_subroutine_called_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	name := value.Unwrap[*value.String](args[0]).Value
@@ -57,7 +57,7 @@ func Assert_subroutine_called(ctx *context.Context, args ...value.Value) (value.
 	call, ok := ctx.SubroutineCalls[name]
 	if !ok {
 		if message != "" {
-			return &value.Boolean{}, errors.NewAssertionError(args[0], message)
+			return &value.Boolean{}, errors.NewAssertionError(args[0], "%s", message)
 		}
 		return &value.Boolean{}, errors.NewAssertionError(args[0], "Subroutine %s is not called", name)
 	}
@@ -69,7 +69,7 @@ func Assert_subroutine_called(ctx *context.Context, args ...value.Value) (value.
 		if message != "" {
 			return &value.Boolean{}, errors.NewAssertionError(
 				&value.Integer{Value: int64(call)},
-				message,
+				"%s", message,
 			)
 		}
 		return &value.Boolean{}, errors.NewAssertionError(

--- a/tester/function/assert_true.go
+++ b/tester/function/assert_true.go
@@ -23,7 +23,7 @@ func Assert_true_Validate(args []value.Value) error {
 
 func Assert_true(ctx *context.Context, args ...value.Value) (value.Value, error) {
 	if err := Assert_true_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	// Check custom message

--- a/tester/function/assertions.go
+++ b/tester/function/assertions.go
@@ -13,7 +13,7 @@ func assert[T assertable](v value.Value, actual, expect T, message string) (*val
 	ok := &value.Boolean{Value: actual == expect}
 	if !ok.Value {
 		if message != "" {
-			return ok, errors.NewAssertionError(v, message)
+			return ok, errors.NewAssertionError(v, "%s", message)
 		}
 		return ok, errors.NewAssertionError(v,
 			"Assertion error: expect=%v, actual=%v", expect, actual)
@@ -25,7 +25,7 @@ func assert_not[T assertable](v value.Value, actual, expect T, message string) (
 	ok := &value.Boolean{Value: actual != expect}
 	if !ok.Value {
 		if message != "" {
-			return ok, errors.NewAssertionError(v, message)
+			return ok, errors.NewAssertionError(v, "%s", message)
 		}
 		return ok, errors.NewAssertionError(v,
 			"Assertion error: expect=%v, actual=%v", expect, actual)

--- a/tester/function/testing_call_subroutine.go
+++ b/tester/function/testing_call_subroutine.go
@@ -35,7 +35,7 @@ func Testing_call_subroutine(
 ) (value.Value, error) {
 
 	if err := Testing_call_subroutine_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	var state interpreter.State
@@ -53,7 +53,7 @@ func Testing_call_subroutine(
 		return value.Null, errors.NewTestingError("subroutine %s is not defined in VCL", name)
 	}
 	if err != nil {
-		return value.Null, errors.NewTestingError(err.Error())
+		return value.Null, errors.NewTestingError("%s", err.Error())
 	}
 	return &value.String{Value: string(state)}, nil
 }

--- a/tester/function/testing_fixed_time.go
+++ b/tester/function/testing_fixed_time.go
@@ -25,7 +25,7 @@ func Testing_fixed_time(
 ) (value.Value, error) {
 
 	if err := Testing_fixed_time_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	switch args[0].Type() {

--- a/tester/function/testing_inject_variable.go
+++ b/tester/function/testing_inject_variable.go
@@ -24,7 +24,7 @@ func Testing_inject_variable(
 ) (value.Value, error) {
 
 	if err := Testing_inject_variable_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	name := value.Unwrap[*value.String](args[0])

--- a/tester/function/testing_inspect.go
+++ b/tester/function/testing_inspect.go
@@ -22,7 +22,7 @@ func Testing_inspect(
 ) (value.Value, error) {
 
 	if err := Testing_inspect_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	if args[0].Type() != value.StringType {

--- a/tester/function/testing_mock.go
+++ b/tester/function/testing_mock.go
@@ -32,7 +32,7 @@ func Testing_mock(
 ) (value.Value, error) {
 
 	if err := Testing_mock_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	from := value.Unwrap[*value.String](args[0]).Value

--- a/tester/function/testing_override_host.go
+++ b/tester/function/testing_override_host.go
@@ -21,7 +21,7 @@ func Testing_override_host(
 ) (value.Value, error) {
 
 	if err := Testing_override_host_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	switch args[0].Type() {

--- a/tester/function/testing_restore_all_mocks.go
+++ b/tester/function/testing_restore_all_mocks.go
@@ -22,7 +22,7 @@ func Testing_restore_all_mocks(
 ) (value.Value, error) {
 
 	if err := Testing_restore_all_mocks_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	// clear all mocked subroutines

--- a/tester/function/testing_restore_mock.go
+++ b/tester/function/testing_restore_mock.go
@@ -30,7 +30,7 @@ func Testing_restore_mock(
 ) (value.Value, error) {
 
 	if err := Testing_restore_mock_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	for i := range args {

--- a/tester/function/testing_table_merge.go
+++ b/tester/function/testing_table_merge.go
@@ -33,7 +33,7 @@ func Testing_table_merge(
 ) (value.Value, error) {
 
 	if err := Testing_table_merge_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	baseTable := value.Unwrap[*value.Ident](args[0]).Value

--- a/tester/function/testing_table_set.go
+++ b/tester/function/testing_table_set.go
@@ -33,7 +33,7 @@ func Testing_table_set(
 ) (value.Value, error) {
 
 	if err := Testing_table_set_Validate(args); err != nil {
-		return nil, errors.NewTestingError(err.Error())
+		return nil, errors.NewTestingError("%s", err.Error())
 	}
 
 	tableName := value.Unwrap[*value.Ident](args[0]).Value


### PR DESCRIPTION
This PR updates build golang version to `1.23.5` and also update golangci-lint to `1.63.4` accordingly.

Note that golangci-lint v1.63.4 reports new issues that relate to printf format constant string.
I fixed these issues so we have a lot of changed files in this PR. 