### PR TITLE
implement edge dictionary injectable for testing process

### DIFF
--- a/cmd/falco/runner.go
+++ b/cmd/falco/runner.go
@@ -466,6 +466,9 @@ func (r *Runner) Test(rslv resolver.Resolver) (*tester.TestFactory, error) {
 	if tc.OverrideHost != "" {
 		options = append(options, icontext.WithOverrideHost(tc.OverrideHost))
 	}
+	if tc.OverrideEdgeDictionaries != nil {
+		options = append(options, icontext.WithInjectEdgeDictionaries(tc.OverrideEdgeDictionaries))
+	}
 
 	// Factory override variables.
 	// The order is imporotant, should do yaml -> cli order because cli could override yaml configuration

--- a/config/config.go
+++ b/config/config.go
@@ -72,6 +72,9 @@ type TestConfig struct {
 	// Override Request configuration
 	OverrideRequest *RequestConfig
 
+	// Inject Edge Dictionary items
+	OverrideEdgeDictionaries map[string]EdgeDictionary `yaml:"edge_dictionary"`
+
 	// Override tentative variable values
 	CLIOverrideVariables  []string       `cli:"o,override"` // from CLI
 	YamlOverrideVariables map[string]any `yaml:"overrides"` // from .falco.yaml

--- a/examples/testing/inject_dictionary/inject_dictionary.test.vcl
+++ b/examples/testing/inject_dictionary/inject_dictionary.test.vcl
@@ -1,0 +1,7 @@
+// @scope: RECV
+// @suite: state should be pass when dictionary is injected
+sub test_return_pass {
+  testing.call_subroutine("vcl_recv");
+  assert.state(pass);
+}
+

--- a/examples/testing/inject_dictionary/inject_dictionary.vcl
+++ b/examples/testing/inject_dictionary/inject_dictionary.vcl
@@ -1,0 +1,7 @@
+sub vcl_recv {
+  // Dictionary will be injected by testing configurations.
+  if (table.lookup(injected_dictionary, "is_maintenance") == "1") {
+    return(pass);
+  }
+  return(lookup);
+}

--- a/interpreter/edge_dictionary.go
+++ b/interpreter/edge_dictionary.go
@@ -10,7 +10,7 @@ import (
 // Edge dictionary value is managed in Fastly could so typically items are readonly.
 // However we need to set some items in local simulator, particularly write-only edge dictionary
 // So the interpreter can inject virtual value from falco coniguration.
-func (i *Interpreter) InjectEdgeDictionaryItem(table *ast.TableDeclaration, dict config.EdgeDictionary) error {
+func (i *Interpreter) InjectEdgeDictionaryItem(table *ast.TableDeclaration, dict config.EdgeDictionary) {
 	for key, val := range dict {
 		idx := -1
 		// Find existing key index
@@ -30,7 +30,45 @@ func (i *Interpreter) InjectEdgeDictionaryItem(table *ast.TableDeclaration, dict
 			table.Properties[idx] = inject
 		}
 	}
-	return nil
+}
+
+// Create EdgeDictionary declaration from config
+func (i *Interpreter) createEdgeDictionaryDeclaration(name string, dict config.EdgeDictionary) *ast.TableDeclaration {
+	decl := &ast.TableDeclaration{
+		Meta: ast.New(token.Token{
+			Type:     token.TABLE,
+			Literal:  "table",
+			Line:     0,
+			Position: 0,
+			Offset:   0,
+			File:     "EdgeDictionary.Injected",
+		}, 0),
+		Name: &ast.Ident{
+			Meta: ast.New(token.Token{
+				Type:     token.IDENT,
+				Literal:  name,
+				Line:     0,
+				Position: 0,
+				Offset:   0,
+				File:     "EdgeDictionary.Injected",
+			}, 0),
+			Value: name,
+		},
+		ValueType: &ast.Ident{
+			Meta: ast.New(token.Token{
+				Type:     token.IDENT,
+				Literal:  "STRING",
+				Line:     0,
+				Position: 0,
+				Offset:   0,
+				File:     "EdgeDictionary.Injected",
+			}, 0),
+			Value: "STRING",
+		},
+		Properties: []*ast.TableProperty{},
+	}
+	i.InjectEdgeDictionaryItem(decl, dict)
+	return decl
 }
 
 // Create virtual ast.TableProperty node with injected value

--- a/tester/finder.go
+++ b/tester/finder.go
@@ -21,6 +21,9 @@ func (f *finder) find(path string, entry fs.DirEntry, err error) error {
 		}
 		return err
 	}
+	if entry.IsDir() {
+		return nil
+	}
 	if !f.filter.Match(path) {
 		return nil
 	}


### PR DESCRIPTION
Fixes #404 

This PR implements injectable edge dictionary as a table declaration on testing process like simulator configuration.

## Configuration

We will define the `config.testing.edge_dictionary` as the same as `config.simulator.edge_dictionary`.
Once I thought that we can use `config.simulator.edge_dictionary` also in the testing process but I decided that the simulator and testing should work independenctly so I divided configuration.

```yaml
...
testing:
  edge_dictionary:
    foo:
      some: value
...
```

## Changes

And I added a tiny improvement, We only can override dictionary **items** for existing table, but now we can also inject the edge dictionary as a **new table declaration**.
This makes the user can inject any edge dictionary even not defined in main VCL (or Fastly Service) - it's better performace for testing because we don't need to fetch the remote edge dictionary  - but need to take care that the main VCL will have dependency to the injected dictionary.
Please make sure the tests should pass without dictionary injection before deployments.