### PR TITLE
fix objective header set like foo:bar

### DIFF
--- a/interpreter/variable/header.go
+++ b/interpreter/variable/header.go
@@ -105,19 +105,15 @@ func unsetRequestHeaderValue(r *http.Request, name string) {
 		return
 	}
 
-	var filtered []string
-	for _, hv := range r.Header.Values(spl[0]) {
+	// Store old header values, clear header, and add filtered values only
+	oldHeaders := r.Header.Values(spl[0])
+	r.Header.Del(spl[0])
+	for _, hv := range oldHeaders {
 		kvs := strings.SplitN(hv, "=", 2)
 		if kvs[0] == spl[1] {
 			continue
 		}
-		filtered = append(filtered, hv)
-	}
-
-	if len(filtered) > 0 {
-		r.Header[spl[0]] = filtered
-	} else {
-		r.Header.Del(spl[0])
+		r.Header.Add(spl[0], hv)
 	}
 }
 
@@ -169,18 +165,15 @@ func unsetResponseHeaderValue(r *http.Response, name string) {
 
 	// Header name contains ":" character, then filter value by key
 	spl := strings.SplitN(name, ":", 2)
-	var filtered []string
-	for _, hv := range r.Header.Values(spl[0]) {
+
+	// Store old header values, delete header, and add filtered values
+	oldHeaders := r.Header.Values(spl[0])
+	r.Header.Del(spl[0])
+	for _, hv := range oldHeaders {
 		kvs := strings.SplitN(hv, "=", 2)
 		if kvs[0] == spl[1] {
 			continue
 		}
-		filtered = append(filtered, hv)
-	}
-
-	if len(filtered) > 0 {
-		r.Header[spl[0]] = filtered
-	} else {
-		r.Header.Del(spl[0])
+		r.Header.Add(spl[0], hv)
 	}
 }

--- a/interpreter/variable/header_test.go
+++ b/interpreter/variable/header_test.go
@@ -96,6 +96,13 @@ func TestSetRequestHeaderValueOverwrite(t *testing.T) {
 	if ret.Value != "abc=123, bar=snafu" {
 		t.Errorf("Return value unmatch, expect=%s, got=%s", "abc=123, bar=snafu", ret.Value)
 	}
+
+	// Check exact http.Header struct data
+	if diff := cmp.Diff(req.Header, http.Header{
+		"Foo": []string{"abc=123", "bar=snafu"},
+	}); diff != "" {
+		t.Errorf(diff)
+	}
 }
 
 func TestSetResponseHeaderValue(t *testing.T) {
@@ -133,6 +140,13 @@ func TestSetResponseHeaderValueOverwrite(t *testing.T) {
 	if ret.Value != "abc=123, bar=snafu" {
 		t.Errorf("Return value unmatch, expect=%s, got=%s", "abc=123, bar=snafu", ret.Value)
 	}
+
+	// Check exact http.Header struct data
+	if diff := cmp.Diff(resp.Header, http.Header{
+		"Foo": []string{"abc=123", "bar=snafu"},
+	}); diff != "" {
+		t.Errorf(diff)
+	}
 }
 
 func TestUnsetRequestHeaderValue(t *testing.T) {
@@ -146,13 +160,14 @@ func TestUnsetRequestHeaderValue(t *testing.T) {
 		{name: "Cookie:foo"},
 		{name: "Cookie:baz"},
 	}
-	req := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
-	req.Header.Set("Foo", "bar")
-	req.Header.Add("Text", "lorem=ipsum")
-	req.Header.Add("Text", "dolor=sit")
-	req.Header.Set("Cookie", "foo=bar")
 
 	for _, tt := range tests {
+		req := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+		req.Header.Set("Foo", "bar")
+		req.Header.Add("Text", "lorem=ipsum")
+		req.Header.Add("Text", "dolor=sit")
+		req.Header.Set("Cookie", "foo=bar")
+
 		unsetRequestHeaderValue(req, tt.name)
 		ret := getRequestHeaderValue(req, tt.name)
 		if diff := cmp.Diff(ret, &value.String{IsNotSet: true}); diff != "" {
@@ -170,13 +185,14 @@ func TestUnsetResponseHeaderValue(t *testing.T) {
 		{name: "Text:lorem"},
 		{name: "Text:amet"},
 	}
-	header := http.Header{}
-	header.Set("Foo", "bar")
-	header.Add("Text", "lorem=ipsum")
-	header.Add("Text", "dolor=sit")
-	resp := &http.Response{Header: header}
 
 	for _, tt := range tests {
+		header := http.Header{}
+		header.Set("Foo", "bar")
+		header.Add("Text", "lorem=ipsum")
+		header.Add("Text", "dolor=sit")
+		resp := &http.Response{Header: header}
+
 		unsetResponseHeaderValue(resp, tt.name)
 		ret := getResponseHeaderValue(resp, tt.name)
 		if diff := cmp.Diff(ret, &value.String{IsNotSet: true}); diff != "" {


### PR DESCRIPTION
This PR fixes objective header dealing (e.g `set req.http.Foo:bar`).

Current implemenation has a bug that objective header holds the multiple key-value in the header name for example:

```vcl
set req.http.OBJ:v1 = "value1";
set req.http.OBJ:v1 = "value2";
```

Then the falco stores objective header in `http.Header` struct:

```go
http.Header{
  "OBJ": []string{"v1=value1", "v1=value2"},
}
```

Then we sould merge/override the key of `v1`:

```go
http.Header{
  "OBJ": []string{v1=value2"},
}
```

To solve this problem, we improve header manipulation that reset all headers and set exact header values we needed.