### PR TITLE
remove goling linter-settings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -90,8 +90,6 @@ linters-settings:
     min-complexity: 50
   gofmt:
     simplify: true
-  golint:
-    min-confidence: 0.8
   lll:
     line-length: 150
   misspell:


### PR DESCRIPTION
From recent GitHub Actions running at [here](https://github.com/ysugimoto/falco/actions/runs/13432388528/job/37526946065?pr=410) golangci-lint raises an error about `linter-settings` field definition from validating expect json schema.

This PR fixes that problem by adjusting configuration file.