### PR TITLE
Reset regex captured group when matched

### DIFF
--- a/__generator__/template.go
+++ b/__generator__/template.go
@@ -10,7 +10,11 @@ import (
 	"github.com/ysugimoto/falco/types"
 )
 
-var ErrDeprecated = errors.New("deprecated")
+var (
+	ErrDeprecated              = errors.New("deprecated")
+	ErrUncapturedRegexVariable = errors.New("uncaptured-regex-variable")
+	ErrRegexVariableOverridden = errors.New("overridden-regex-variable")
+)
 
 func predefinedVariables() Variables {
 	return {{ .Variables }}

--- a/cmd/falco/runner_test.go
+++ b/cmd/falco/runner_test.go
@@ -375,7 +375,7 @@ func TestTester(t *testing.T) {
 			name:   "regex grouped variables test",
 			main:   "../../examples/testing/regex/regex.vcl",
 			filter: "*regex.test.vcl",
-			passes: 2,
+			passes: 4,
 		},
 	}
 

--- a/cmd/falco/runner_test.go
+++ b/cmd/falco/runner_test.go
@@ -42,7 +42,7 @@ func loadRepoExampleTestMetadata() []RepoExampleTestMetadata {
 			fileName: "../../examples/linter/default03.vcl",
 			errors:   0,
 			warnings: 0,
-			infos:    1,
+			infos:    2,
 		},
 		{
 			name:     "example 4",

--- a/cmd/falco/runner_test.go
+++ b/cmd/falco/runner_test.go
@@ -371,6 +371,12 @@ func TestTester(t *testing.T) {
 			filter: "*base64.test.vcl",
 			passes: 12,
 		},
+		{
+			name:   "regex grouped variables test",
+			main:   "../../examples/testing/regex/regex.vcl",
+			filter: "*regex.test.vcl",
+			passes: 2,
+		},
 	}
 
 	for _, tt := range tests {

--- a/examples/testing/regex/regex.test.vcl
+++ b/examples/testing/regex/regex.test.vcl
@@ -8,8 +8,26 @@ sub test_regex_recv {
         set var.group1 = re.group.1;
     }
     assert.equal(re.group.1, "abc");
+    // will be reset re.group.N when matched
     if (var.input ~ ".*") {
         set var.group1 = re.group.1;
     }
     assert.is_notset(re.group.1);
+}
+
+// @scope: recv
+// @suite: Test regex match without reset groups
+sub test_regex_recv {
+    declare local var.input STRING;
+    declare local var.group1 STRING;
+    set var.input = "abc";
+    if (var.input ~ "^(\w+)$") {
+        set var.group1 = re.group.1;
+    }
+    assert.equal(re.group.1, "abc");
+    // will not be reset re.group.N when not matched
+    if (var.input ~ "xyz*") {
+        set var.group1 = re.group.1;
+    }
+    assert.equal(re.group.1, "abc");
 }

--- a/examples/testing/regex/regex.test.vcl
+++ b/examples/testing/regex/regex.test.vcl
@@ -1,0 +1,15 @@
+// @scope: recv
+// @suite: Test regex match
+sub test_regex_recv {
+    declare local var.input STRING;
+    declare local var.group1 STRING;
+    set var.input = "abc";
+    if (var.input ~ "^(\w+)$") {
+        set var.group1 = re.group.1;
+    }
+    assert.equal(re.group.1, "abc");
+    if (var.input ~ ".*") {
+        set var.group1 = re.group.1;
+    }
+    assert.is_notset(re.group.1);
+}

--- a/examples/testing/regex/regex.test.vcl
+++ b/examples/testing/regex/regex.test.vcl
@@ -17,7 +17,7 @@ sub test_regex_recv {
 
 // @scope: recv
 // @suite: Test regex match without reset groups
-sub test_regex_recv {
+sub test_regex_no_reset_recv {
     declare local var.input STRING;
     declare local var.group1 STRING;
     set var.input = "abc";

--- a/examples/testing/regex/regex.vcl
+++ b/examples/testing/regex/regex.vcl
@@ -1,0 +1,1 @@
+sub vcl_recv {}

--- a/interpreter/operator/operator.go
+++ b/interpreter/operator/operator.go
@@ -711,10 +711,10 @@ func Regex(ctx *context.Context, left, right value.Value) (value.Value, error) {
 					fmt.Errorf("Failed to compile regular expression from string %s", rv.Value),
 				)
 			}
-			// Important: regex matched group variables are always reset for each matching
-			// see: https://fiddle.fastly.dev/fiddle/3e5320ef
-			ctx.RegexMatchedValues = make(map[string]*value.String)
 			if matches := re.FindStringSubmatch(lv.Value); len(matches) > 0 {
+				// Important: regex matched group variables are reset if matching is succeeded
+				// see: https://fiddle.fastly.dev/fiddle/3e5320ef
+				ctx.RegexMatchedValues = make(map[string]*value.String)
 				for j, m := range matches {
 					ctx.RegexMatchedValues[fmt.Sprint(j)] = &value.String{Value: m}
 				}

--- a/interpreter/operator/operator.go
+++ b/interpreter/operator/operator.go
@@ -711,6 +711,9 @@ func Regex(ctx *context.Context, left, right value.Value) (value.Value, error) {
 					fmt.Errorf("Failed to compile regular expression from string %s", rv.Value),
 				)
 			}
+			// Important: regex matched group variables are always reset for each matching
+			// see: https://fiddle.fastly.dev/fiddle/3e5320ef
+			ctx.RegexMatchedValues = make(map[string]*value.String)
 			if matches := re.FindStringSubmatch(lv.Value); len(matches) > 0 {
 				for j, m := range matches {
 					ctx.RegexMatchedValues[fmt.Sprint(j)] = &value.String{Value: m}

--- a/interpreter/variable/all.go
+++ b/interpreter/variable/all.go
@@ -705,6 +705,9 @@ func (v *AllScopeVariables) getFromRegex(name string) value.Value {
 		if val, ok := v.ctx.RegexMatchedValues[match[1]]; ok {
 			return val
 		}
+		// regex captured variable always returns string values even nothing capturing
+		// see: https://fiddle.fastly.dev/fiddle/3e5320ef
+		return &value.String{IsNotSet: true}
 	}
 
 	// HTTP request header matching

--- a/linter/context/context.go
+++ b/linter/context/context.go
@@ -150,10 +150,10 @@ func New(opts ...Option) *Context {
 		Ratecounters:     make(map[string]*types.Ratecounter),
 		Gotos:            make(map[string]*types.Goto),
 		GotoDestinations: make(map[string]struct{}),
+		RegexVariables:   newRegexMatchedValues(),
 		Identifiers:      builtinIdentifiers(),
 		functions:        builtinFunctions(),
 		Variables:        predefinedVariables(),
-		RegexVariables:   newRegexMatchedValues(),
 	}
 
 	for i := range opts {
@@ -222,11 +222,18 @@ func (c *Context) UserDefinedFunctionScope(name string, mode int, returnType typ
 	return c
 }
 
+func (c *Context) PushRegexVariables(matchN int) {
+	for i := 0; i < matchN; i++ {
+		c.RegexVariables[fmt.Sprintf("re.group.%d", i)]++
+	}
+}
+
+// Get regex group variable.
 // Regex variables, "re.group.N" is a special variable in VCL.
 // These variables could use if(else) block statement when condition has regex operator like "~" or "!~".
 // Note that group matched variable has potential of making bugs due to its spec:
 // 1. re.group.N variable scope is subroutine-global, does not have block scope
-// 2. matched value may override on second regex matching
+// 2. matched value will be reset on next regex matching in the same subroutine scope
 //
 // For example:
 //
@@ -237,41 +244,35 @@ func (c *Context) UserDefinedFunctionScope(name string, mode int, returnType typ
 //	if (req.http.Host) {
 //		if (var.S) {
 //			if (var.S !~ "(foo)\s(bar)\s(baz)") { // make matched values first (1)
-//				set req.http.First = "1";
+//				set req.http.First = re.group.2; // bar
 //			}
 //			set var.S = "hoge huga";
-//			if (var.S ~ "(hoge)\s(huga)") { // override matched values (2)
-//				set req.http.First = re.group.1;
+//			if (var.S ~ "(hoge)\s(huga)") { // reset and override matched values (2)
+//				set req.http.First = re.group.1; // hoge
 //			}
 //		}
-//		set req.http.Third = re.group.2; // difficult to know which (1) or (2) matched result is used
+//		// Difficult to know which (1) or (2) matched result is used
+//		set req.http.Third = re.group.2; // huga
 //	}
 //
 //	if (req.http.Host) {
-//		set req.http.Fourth = re.group.3; // difficult to know which (1) or (2) matched result is used or empty
+//		// Difficult to know which (1) or (2) matched result is used or empty
+//		set req.http.Fourth = re.group.3; // null
 //	}
 //
 // ```
-//
-// Therefore we will raise warning if matched value is overridden in subroutine.
-func (c *Context) PushRegexVariables(matchN int) error {
-	for i := 0; i < matchN; i++ {
-		c.RegexVariables[fmt.Sprintf("re.group.%d", i)]++
-	}
-
-	// If pushed count is greater than 1, variable is overridden in the subroutine statement
-	if c.RegexVariables["re.group.0"] > 1 {
-		return fmt.Errorf("Regex captured variable may override older one")
-	}
-	return nil
-}
-
-// Get regex group variable
+// So the linter will report error if the captured variable is assumed to be overridden
 func (c *Context) GetRegexGroupVariable(name string) (types.Type, error) {
-	if _, ok := c.RegexVariables[name]; !ok {
-		return types.NullType, fmt.Errorf(`Undefined variable "%s"`, name)
+	if cnt, ok := c.RegexVariables[name]; !ok {
+		// the `re.group.N` variable is always accessible but get notset string if not captured.
+		// It's correct spec in Faslty but we should raise as uncaptured variable error because it may causes a potencial bug.
+		return types.StringType, ErrUncapturedRegexVariable
+	} else if cnt > 1 {
+		// If group matched count is greater than 1, the matched variable may be overridden
+		return types.StringType, ErrRegexVariableOverridden
 	}
-	// group matched value is always STRING
+
+	// Group matched value is always STRING
 	return types.StringType, nil
 }
 

--- a/linter/context/predefined.go
+++ b/linter/context/predefined.go
@@ -7,7 +7,11 @@ import (
 	"github.com/ysugimoto/falco/types"
 )
 
-var ErrDeprecated = errors.New("deprecated")
+var (
+	ErrDeprecated              = errors.New("deprecated")
+	ErrUncapturedRegexVariable = errors.New("uncaptured-regex-variable")
+	ErrRegexVariableOverridden = errors.New("overridden-regex-variable")
+)
 
 func predefinedVariables() Variables {
 	return Variables{

--- a/linter/errors.go
+++ b/linter/errors.go
@@ -401,6 +401,24 @@ func DeprecatedVariable(name string, m *ast.Meta) *LintError {
 	}
 }
 
+func UncapturedRegexVariable(name string, m *ast.Meta) *LintError {
+	err := &LintError{
+		Severity: WARNING,
+		Token:    m.Token,
+		Message:  fmt.Sprintf(`Regex captured variable "%s" is uncaptured`, name),
+	}
+	return err.Match(DEPRECATED)
+}
+
+func CapturedRegexVariableOverridden(name string, m *ast.Meta) *LintError {
+	err := &LintError{
+		Severity: INFO,
+		Token:    m.Token,
+		Message:  fmt.Sprintf(`Regex captured variable "%s" may be overridden in previous expression`, name),
+	}
+	return err.Match(REGEX_MATCHED_VALUE_MAY_OVERRIDE)
+}
+
 func FromPluginError(pe *plugin.Error, m *ast.Meta) *LintError {
 	e := &LintError{
 		Token:   m.Token,

--- a/linter/errors.go
+++ b/linter/errors.go
@@ -405,7 +405,10 @@ func UncapturedRegexVariable(name string, m *ast.Meta) *LintError {
 	err := &LintError{
 		Severity: WARNING,
 		Token:    m.Token,
-		Message:  fmt.Sprintf(`Regex captured variable "%s" is uncaptured`, name),
+		Message: fmt.Sprintf(
+			`Regex captured variable "%s" is uncaptured or reset on previous regular expression matching`,
+			name,
+		),
 	}
 	return err.Match(DEPRECATED)
 }
@@ -414,7 +417,10 @@ func CapturedRegexVariableOverridden(name string, m *ast.Meta) *LintError {
 	err := &LintError{
 		Severity: INFO,
 		Token:    m.Token,
-		Message:  fmt.Sprintf(`Regex captured variable "%s" may be overridden in previous expression`, name),
+		Message: fmt.Sprintf(
+			`Regex captured variable "%s" may be overridden in previous expression`,
+			name,
+		),
 	}
 	return err.Match(REGEX_MATCHED_VALUE_MAY_OVERRIDE)
 }

--- a/linter/expression_linter.go
+++ b/linter/expression_linter.go
@@ -317,14 +317,7 @@ func (l *Linter) lintInfixExpression(exp *ast.InfixExpression, ctx *context.Cont
 
 func (l *Linter) lintIfExpression(exp *ast.IfExpression, ctx *context.Context) types.Type {
 	l.lintIfCondition(exp.Condition, ctx)
-	if err := pushRegexGroupVars(exp.Condition, ctx); err != nil {
-		err := &LintError{
-			Severity: INFO,
-			Token:    exp.Condition.GetMeta().Token,
-			Message:  err.Error(),
-		}
-		l.Error(err.Match(REGEX_MATCHED_VALUE_MAY_OVERRIDE))
-	}
+	pushRegexGroupVars(exp.Condition, ctx)
 
 	if isConstantExpression(exp.Consequence) {
 		l.Error(&LintError{

--- a/linter/helper.go
+++ b/linter/helper.go
@@ -213,6 +213,8 @@ func pushRegexGroupVars(exp ast.Expression, ctx *context.Context) {
 			m := captureRegex.FindAllStringSubmatch(t.Right.String(), -1)
 			if len(m) > 0 {
 				ctx.PushRegexVariables(len(m) + 1)
+			} else {
+				ctx.ResetRegexVariables()
 			}
 		} else {
 			pushRegexGroupVars(t.Right, ctx)

--- a/linter/helper.go
+++ b/linter/helper.go
@@ -201,21 +201,23 @@ func isValidReturnExpression(exp ast.Expression) error {
 	return nil
 }
 
-func pushRegexGroupVars(exp ast.Expression, ctx *context.Context) error {
+// Push regex captured variable to the context if needed
+func pushRegexGroupVars(exp ast.Expression, ctx *context.Context) {
 	switch t := exp.(type) {
 	case *ast.PrefixExpression:
-		return pushRegexGroupVars(t.Right, ctx)
+		pushRegexGroupVars(t.Right, ctx)
+	case *ast.GroupedExpression:
+		pushRegexGroupVars(t.Right, ctx)
 	case *ast.InfixExpression:
 		if t.Operator == "~" || t.Operator == "!~" {
 			m := captureRegex.FindAllStringSubmatch(t.Right.String(), -1)
-			if m != nil {
-				return ctx.PushRegexVariables(len(m) + 1)
+			if len(m) > 0 {
+				ctx.PushRegexVariables(len(m) + 1)
 			}
 		} else {
-			return pushRegexGroupVars(t.Right, ctx)
+			pushRegexGroupVars(t.Right, ctx)
 		}
 	}
-	return nil
 }
 
 func isBooleanOperator(operator string) bool {
@@ -562,7 +564,10 @@ func toSeriesExpressions(expr ast.Expression, ctx *context.Context) ([]*Series, 
 		// If expression is ident, must be a variable
 		// e.g req.http.Header, var.declaredVariable
 		if _, err := ctx.Get(t.Value); err != nil {
-			if err != context.ErrDeprecated {
+			switch err {
+			case context.ErrDeprecated, context.ErrUncapturedRegexVariable, context.ErrRegexVariableOverridden:
+				break
+			default:
 				return nil, InvalidStringConcatenation(expr.GetMeta(), t.Value)
 			}
 		}

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -80,6 +80,7 @@ func assertErrorWithSeverity(t *testing.T, input string, severity Severity, opts
 	l.lint(vcl, context.New(opts...))
 	if len(l.Errors) == 0 {
 		t.Errorf("Expect one lint error but empty returned")
+		return
 	}
 	le := l.Errors[0]
 	if le.Severity != severity {

--- a/linter/rules.go
+++ b/linter/rules.go
@@ -72,6 +72,7 @@ const (
 	FORBIDDEN_BACKWARD_JUMP              = "goto/forbidden-backward-jump"
 	TIME_CALCULATION                     = "operator/time-calculation"
 	DEPRECATED                           = "deprecated"
+	UNCAPTURED_REGEX_VARIABLE            = "regex/uncaptured-variable"
 )
 
 var references = map[Rule]string{


### PR DESCRIPTION
This PR fixes regex grouped variables related bug.
### Reset previous matched group variables on the next matching

We find some regex matching of condition expression in `if` statement or expression has unexpected behaivor in Fastly.
On regex matching with capturing data, the context holds matched values and could access via `re.group.N` variable.

```vcl
set req.http.Re = "foo-bar-baz";
if (req.http.Re ~ "^(\w+)\-(\w+)\-(\w+)$") {
  log "first match " re.group.1; // foo
  log "second match " re.group.2; // bar
  log "third match " re.group.3; // baz
}
```

Above example will be expected for us, but the following example may be unexpectable.

```vcl
set req.http.Re = "foo-bar-baz";
if (req.http.Re ~ "^(\w+)\-(\w+)\-(\w+)$") {
  log if(req.http.Some-Header ~ ".+", "system access", "not system access");
  log "first match " re.group.1; // what?
  log "second match " re.group.2; // what?
  log "third match " re.group.3; // what?
}
```

1. If `req.http.Some-Header` is **not** present, `re.group.N` log output will be `system access`, `foo`, `bar`, `baz`
2. If `req.http.Some-Header` is present, log output will be `not system access`, `(null)`, `(null)`, `(null)`

This is becuse the `Some-Header` matching is succeeded, previous `re.group.N` will reset all even nothing capturing in regular expression.
The `re.group.N` variable always depends on the matching just before, and this behavior could find both `if` statement and expression. This is a correct syntax in Fastly but may cause a bug for user's VCL.

### Linter

Linter could not recognize whether the regex is matched so will report error with `INFO` level.

### Interpreter

Follow the Fastly behavior.


You can see some behavior relted regular expression matched variables on [Fastly Fiddle](https://fiddle.fastly.dev/fiddle/3e5320ef) in detail.