### PR TITLE
Implement test coverage measurement

### DIFF
--- a/cmd/falco/main.go
+++ b/cmd/falco/main.go
@@ -470,6 +470,14 @@ func runTest(runner *Runner, rslv resolver.Resolver) error {
 	write(white, "%d total, ", totalCount)
 	writeln(white, "%d assertions", factory.Statistics.Asserts)
 
+	if factory.Coverage != nil {
+		c := factory.Coverage
+		write(white, "%s: ", "Coverage")
+		write(white, "%% Stmts: %.2f (%d/%d), ", c.Statements.Percent, c.Statements.Executed, c.Statements.Total)
+		write(white, "%% Branch: %.2f (%d/%d), ", c.Branches.Percent, c.Branches.Executed, c.Branches.Total)
+		writeln(white, "%% Subroutines: %.2f (%d/%d)", c.Subroutines.Percent, c.Subroutines.Executed, c.Subroutines.Total)
+	}
+
 	if factory.Statistics.Fails > 0 {
 		return ErrExit
 	}

--- a/cmd/falco/main.go
+++ b/cmd/falco/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ysugimoto/falco/snippets"
 	"github.com/ysugimoto/falco/terraform"
 	"github.com/ysugimoto/falco/tester"
+	"github.com/ysugimoto/falco/tester/shared"
 	"github.com/ysugimoto/falco/token"
 )
 
@@ -380,7 +381,7 @@ func runTest(runner *Runner, rslv resolver.Resolver) error {
 		enc.SetIndent("", "  ")
 		if err := enc.Encode(struct {
 			Tests   []*tester.TestResult `json:"tests"`
-			Summary *tester.TestCounter  `json:"summary"`
+			Summary *shared.Counter      `json:"summary"`
 		}{
 			Tests:   factory.Results,
 			Summary: factory.Statistics,

--- a/config/config.go
+++ b/config/config.go
@@ -67,7 +67,9 @@ type TestConfig struct {
 	Filter       string   `cli:"f,filter" default:"*.test.vcl"`
 	IncludePaths []string // Copy from root field
 	OverrideHost string   `yaml:"host" cli:"host"`
-	Watch        bool     `cli:"watch"` // Enable only in CLI option
+	Watch        bool     `cli:"watch"`        // Enable only in CLI option
+	Coverage     bool     `cli:"coverage"`     // Enable only in CLI option
+	CoverageOut  string   `cli:"coverage-out"` // Enable only in CLI option
 
 	// Override Request configuration
 	OverrideRequest *RequestConfig

--- a/interpreter/context/context.go
+++ b/interpreter/context/context.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 	"github.com/ysugimoto/falco/resolver"
 	"github.com/ysugimoto/falco/snippets"
+	"github.com/ysugimoto/falco/tester/shared"
 )
 
 // Reserved vcl names in Fastly
@@ -151,6 +152,9 @@ type Context struct {
 	ReturnState     *value.String
 	FixedTime       *time.Time
 	SubroutineCalls map[string]int
+
+	// Coverage marker pointer. not nil if testing with coverage measurement
+	Coverage *shared.Coverage
 
 	// Regex captured values like "re.group.N" and local declared variables are volatile,
 	// reset this when process is outgoing for each subroutines

--- a/interpreter/context/option.go
+++ b/interpreter/context/option.go
@@ -5,6 +5,7 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 	"github.com/ysugimoto/falco/resolver"
 	"github.com/ysugimoto/falco/snippets"
+	"github.com/ysugimoto/falco/tester/shared"
 )
 
 type Option func(c *Context)
@@ -77,5 +78,11 @@ func WithOverrideVariales(variables map[string]any) Option {
 				c.OverrideVariables[k] = &value.Boolean{Value: t}
 			}
 		}
+	}
+}
+
+func WithCoverage(cv *shared.Coverage) Option {
+	return func(c *Context) {
+		c.Coverage = cv
 	}
 }

--- a/interpreter/coverage.go
+++ b/interpreter/coverage.go
@@ -1,0 +1,267 @@
+package interpreter
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/tester/shared"
+	"github.com/ysugimoto/falco/token"
+)
+
+var fake = &ast.Meta{Token: token.Null}
+
+// Add coverage marker to entire VCL
+// Note that our coverage measurement will ignores root statig declarations like backend, table, etc.
+func (i *Interpreter) instrument(vcl *ast.VCL) {
+	for _, v := range vcl.Statements {
+		if sub, ok := v.(*ast.SubroutineDeclaration); ok {
+			i.instrumentSubroutine(sub)
+		}
+	}
+}
+
+// Add coverage marker to subroutine declaration
+func (i *Interpreter) instrumentSubroutine(sub *ast.SubroutineDeclaration) {
+	var statements []ast.Statement
+
+	statements = append(statements, i.createMarker(shared.CoverageTypeSubroutine, sub))
+	statements = append(statements, i.instrumentStatements(sub.Block.Statements)...)
+	sub.Block.Statements = statements
+}
+
+// Add coverage marker to statements
+func (i *Interpreter) instrumentStatements(stmts []ast.Statement) []ast.Statement {
+	var statements []ast.Statement
+
+	for j := range stmts {
+		statements = append(statements, i.instrumentStatement(stmts[j])...)
+		statements = append(statements, stmts[j])
+	}
+
+	return statements
+}
+
+// Add coverage marker to statement
+func (i *Interpreter) instrumentStatement(stmt ast.Statement) []ast.Statement {
+	var statements []ast.Statement
+
+	switch t := stmt.(type) {
+	// Statement which has sub block statements
+	case *ast.BlockStatement:
+		// Only put instrumentation to the block inside statements
+		t.Statements = i.instrumentStatements(t.Statements)
+	case *ast.IfStatement:
+		statements = append(statements, i.createMarker(shared.CoverageTypeStatement, t))
+		i.instrumentIfStatement(t)
+	case *ast.SwitchStatement:
+		statements = append(statements, i.createMarker(shared.CoverageTypeStatement, t))
+		i.instrumentSwitchStatement(t)
+
+	case *ast.FunctionCallStatement:
+		statements = append(statements, i.instrumentFunctionCallStatement(t)...)
+
+	// Common expression value instruments
+	case *ast.ErrorStatement:
+		statements = append(statements, i.createMarker(shared.CoverageTypeStatement, stmt))
+		statements = append(statements, i.instrumentExpression(t.Code)...)
+		statements = append(statements, i.instrumentExpression(t.Argument)...)
+	case *ast.ReturnStatement:
+		statements = append(statements, i.createMarker(shared.CoverageTypeStatement, stmt))
+		statements = append(statements, i.instrumentExpression(t.ReturnExpression)...)
+	case *ast.SetStatement:
+		statements = append(statements, i.createMarker(shared.CoverageTypeStatement, stmt))
+		statements = append(statements, i.instrumentExpression(t.Value)...)
+	case *ast.AddStatement:
+		statements = append(statements, i.createMarker(shared.CoverageTypeStatement, stmt))
+		statements = append(statements, i.instrumentExpression(t.Value)...)
+	case *ast.LogStatement:
+		statements = append(statements, i.createMarker(shared.CoverageTypeStatement, stmt))
+		statements = append(statements, i.instrumentExpression(t.Value)...)
+	case *ast.SyntheticStatement:
+		statements = append(statements, i.createMarker(shared.CoverageTypeStatement, stmt))
+		statements = append(statements, i.instrumentExpression(t.Value)...)
+	case *ast.SyntheticBase64Statement:
+		statements = append(statements, i.createMarker(shared.CoverageTypeStatement, stmt))
+		statements = append(statements, i.instrumentExpression(t.Value)...)
+
+	// Default without expression instrument
+	default:
+		// *ast.EsiStatement
+		// *ast.RestartStatement
+		// *ast.DeclareStatement
+		// *ast.UnsetStatement
+		// *ast.RemoveStatement
+		// *ast.BreakStatement
+		// *ast.FallthroughStatement
+		// *ast.GotoStatement
+		// *ast.IncludeStatement
+		statements = append(statements, i.createMarker(shared.CoverageTypeStatement, stmt))
+	}
+
+	return statements
+}
+
+// Put conditions and branches instruments
+func (i *Interpreter) instrumentIfStatement(stmt *ast.IfStatement) {
+	branch := 1
+
+	// instrument consequence
+	stmt.Consequence.Statements = append(
+		[]ast.Statement{
+			i.createMarker(shared.CoverageTypeBranch, stmt, fmt.Sprint(branch)),
+		},
+		i.instrumentStatements(stmt.Consequence.Statements)...,
+	)
+
+	// Store the else block for if statement
+	alternative := stmt.Alternative
+
+	// Transform else-if statement to nested else block
+	nest := stmt
+	for _, a := range stmt.Another {
+		branch++
+		a.Keyword = "if"
+		i.instrumentIfStatement(a)
+		nest.Alternative = &ast.ElseStatement{
+			Meta: fake,
+			Consequence: &ast.BlockStatement{
+				Meta: fake,
+				Statements: []ast.Statement{
+					i.createMarker(shared.CoverageTypeBranch, stmt, fmt.Sprint(branch)),
+					a,
+				},
+			},
+		}
+		nest = a
+	}
+	// Reset root else-if statements
+	stmt.Another = nil
+
+	// Attach root else estatement to the nested else statement
+	if alternative != nil {
+		branch++
+		nest.Alternative = alternative
+		nest.Alternative.Consequence.Statements = append(
+			[]ast.Statement{
+				i.createMarker(shared.CoverageTypeBranch, stmt, fmt.Sprint(branch)),
+			},
+			i.instrumentStatements(nest.Alternative.Consequence.Statements)...,
+		)
+	}
+}
+
+func (i *Interpreter) instrumentSwitchStatement(stmt *ast.SwitchStatement) {
+	branch := 1
+
+	for _, c := range stmt.Cases {
+		c.Statements = append(
+			[]ast.Statement{
+				i.createMarker(shared.CoverageTypeBranch, stmt, fmt.Sprint(branch)),
+				i.createMarker(shared.CoverageTypeBranch, c),
+			},
+			i.instrumentStatements(c.Statements)...,
+		)
+		branch++
+	}
+}
+
+func (i *Interpreter) instrumentFunctionCallStatement(stmt *ast.FunctionCallStatement) []ast.Statement {
+	var statements []ast.Statement
+
+	for _, arg := range stmt.Arguments {
+		statements = append(statements, i.instrumentExpression(arg)...)
+	}
+
+	return statements
+}
+
+func (i *Interpreter) instrumentExpression(expr ast.Expression) []ast.Statement {
+	var statements []ast.Statement
+
+	switch t := expr.(type) {
+	case *ast.FunctionCallExpression:
+		for _, arg := range t.Arguments {
+			statements = append(statements, i.instrumentExpression(arg)...)
+		}
+	case *ast.GroupedExpression:
+		statements = append(statements, i.instrumentExpression(t.Right)...)
+	case *ast.InfixExpression:
+		statements = append(statements, i.instrumentExpression(t.Left)...)
+		statements = append(statements, i.instrumentExpression(t.Right)...)
+	case *ast.PostfixExpression:
+		statements = append(statements, i.instrumentExpression(t.Left)...)
+	case *ast.PrefixExpression:
+		statements = append(statements, i.instrumentExpression(t.Right)...)
+	case *ast.IfExpression:
+		statements = append(statements, i.instrumentIfExpression(t)...)
+	}
+
+	return statements
+}
+
+func (i *Interpreter) instrumentIfExpression(expr *ast.IfExpression) []ast.Statement {
+	branch := &ast.IfStatement{
+		Keyword:   "if",
+		Meta:      fake,
+		Condition: expr.Condition,
+		Consequence: &ast.BlockStatement{
+			Meta: fake,
+			Statements: []ast.Statement{
+				i.createMarker(shared.CoverageTypeBranch, expr, "true"),
+			},
+		},
+		Alternative: &ast.ElseStatement{
+			Meta: fake,
+			Consequence: &ast.BlockStatement{
+				Meta: fake,
+				Statements: []ast.Statement{
+					i.createMarker(shared.CoverageTypeBranch, expr, "false"),
+				},
+			},
+		},
+	}
+
+	return []ast.Statement{branch}
+}
+
+func (i *Interpreter) createMarker(t shared.CoverageType, node ast.Node, suffix ...string) ast.Statement {
+	name := "coverage." + t.String()
+	tok := node.GetMeta().Token
+
+	var s string
+	if len(suffix) > 0 {
+		s = "_" + strings.Join(suffix, "_")
+	}
+
+	var id string
+	switch t {
+	case shared.CoverageTypeSubroutine:
+		id = fmt.Sprintf("sub_%d_%d", tok.Line, tok.Position) + s
+		i.ctx.Coverage.SetupSubroutine(id, node)
+	case shared.CoverageTypeStatement:
+		id = fmt.Sprintf("stmt_%d_%d", tok.Line, tok.Position) + s
+		i.ctx.Coverage.SetupStatement(id, node)
+	case shared.CoverageTypeBranch:
+		id = fmt.Sprintf("branch_%d_%d", tok.Line, tok.Position) + s
+		i.ctx.Coverage.SetupBranch(id, node)
+	}
+
+	return &ast.FunctionCallStatement{
+		Meta: fake,
+		Function: &ast.Ident{
+			Meta: &ast.Meta{
+				Token: token.Token{Type: token.STRING, Literal: name},
+			},
+			Value: name,
+		},
+		Arguments: []ast.Expression{
+			&ast.String{
+				Meta: &ast.Meta{
+					Token: token.Token{Type: token.STRING, Literal: id},
+				},
+				Value: id,
+			},
+		},
+	}
+}

--- a/interpreter/coverage_test.go
+++ b/interpreter/coverage_test.go
@@ -21,7 +21,7 @@ type testTable struct {
 	name     string
 	input    string
 	expect   string
-	coverage *shared.Coverage
+	coverage *shared.CoverageFactory
 }
 type testTables []testTable
 
@@ -48,7 +48,7 @@ func assertInstrument(t *testing.T, tests testTables) {
 				t.Errorf("instrumented vcl mismatch, diff=%s", diff)
 				return
 			}
-			if diff := cmp.Diff(c, tt.coverage); diff != "" {
+			if diff := cmp.Diff(c.Factory(), tt.coverage); diff != "" {
 				t.Errorf("coverage state mismatch, diff=%s", diff)
 				return
 			}
@@ -80,16 +80,16 @@ sub instrument2 {
 	set req.http.Bar = "baz";
 }
 `,
-			coverage: &shared.Coverage{
-				Subroutines: shared.CoverageMap{
+			coverage: &shared.CoverageFactory{
+				Subroutines: shared.CoverageFactoryItem{
 					"sub_2_1": 0,
 					"sub_5_1": 0,
 				},
-				Statements: shared.CoverageMap{
+				Statements: shared.CoverageFactoryItem{
 					"stmt_3_2": 0,
 					"stmt_6_2": 0,
 				},
-				Branches: shared.CoverageMap{},
+				Branches: shared.CoverageFactoryItem{},
 				NodeMap: map[string]token.Token{
 					"sub_2_1":  {Type: token.SUBROUTINE, Literal: "sub", Line: 2, Position: 1},
 					"sub_5_1":  {Type: token.SUBROUTINE, Literal: "sub", Line: 5, Position: 1},
@@ -166,11 +166,11 @@ sub instrument {
 	set req.http.V = var.V;
 }
 `,
-			coverage: &shared.Coverage{
-				Subroutines: shared.CoverageMap{
+			coverage: &shared.CoverageFactory{
+				Subroutines: shared.CoverageFactoryItem{
 					"sub_2_1": 0,
 				},
-				Statements: shared.CoverageMap{
+				Statements: shared.CoverageFactoryItem{
 					"stmt_3_2":  0,
 					"stmt_4_2":  0,
 					"stmt_5_3":  0,
@@ -181,7 +181,7 @@ sub instrument {
 					"stmt_14_4": 0,
 					"stmt_17_2": 0,
 				},
-				Branches: shared.CoverageMap{
+				Branches: shared.CoverageFactoryItem{
 					"branch_4_2_1":  0,
 					"branch_4_2_2":  0,
 					"branch_4_2_3":  0,
@@ -278,11 +278,11 @@ sub instrument {
 	}
 }
 `,
-			coverage: &shared.Coverage{
-				Subroutines: shared.CoverageMap{
+			coverage: &shared.CoverageFactory{
+				Subroutines: shared.CoverageFactoryItem{
 					"sub_2_1": 0,
 				},
-				Statements: shared.CoverageMap{
+				Statements: shared.CoverageFactoryItem{
 					"stmt_3_2":  0,
 					"stmt_4_2":  0,
 					"stmt_6_3":  0,
@@ -294,7 +294,7 @@ sub instrument {
 					"stmt_15_3": 0,
 					"stmt_16_3": 0,
 				},
-				Branches: shared.CoverageMap{
+				Branches: shared.CoverageFactoryItem{
 					"branch_4_2_1": 0,
 					"branch_4_2_2": 0,
 					"branch_4_2_3": 0,
@@ -355,15 +355,15 @@ sub instrument {
 	set var.V = if(req.http.Foo, "bar", "baz");
 }
 `,
-			coverage: &shared.Coverage{
-				Subroutines: shared.CoverageMap{
+			coverage: &shared.CoverageFactory{
+				Subroutines: shared.CoverageFactoryItem{
 					"sub_2_1": 0,
 				},
-				Statements: shared.CoverageMap{
+				Statements: shared.CoverageFactoryItem{
 					"stmt_3_2": 0,
 					"stmt_4_2": 0,
 				},
-				Branches: shared.CoverageMap{
+				Branches: shared.CoverageFactoryItem{
 					"branch_4_14_true":  0,
 					"branch_4_14_false": 0,
 				},

--- a/interpreter/coverage_test.go
+++ b/interpreter/coverage_test.go
@@ -1,0 +1,381 @@
+package interpreter
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/lexer"
+	"github.com/ysugimoto/falco/parser"
+	"github.com/ysugimoto/falco/tester/shared"
+	"github.com/ysugimoto/falco/token"
+)
+
+var opts = cmp.Options{
+	cmpopts.IgnoreFields(ast.Meta{}, "Token", "ID", "Leading", "Trailing", "Infix", "Nest", "PreviousEmptyLines"),
+}
+
+type testTable struct {
+	name     string
+	input    string
+	expect   string
+	coverage *shared.Coverage
+}
+type testTables []testTable
+
+func assertInstrument(t *testing.T, tests testTables) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vcl, err := parser.New(lexer.NewFromString(tt.input)).ParseVCL()
+			if err != nil {
+				t.Errorf("Unexpected input VCL parse error: %s", err)
+				return
+			}
+			c := shared.NewCoverage()
+			ip := &Interpreter{
+				ctx: context.New(context.WithCoverage(c)),
+			}
+			ip.instrument(vcl)
+
+			expect, err := parser.New(lexer.NewFromString(tt.expect)).ParseVCL()
+			if err != nil {
+				t.Errorf("Unexpected expect VCL parse error: %s", err)
+				return
+			}
+			if diff := cmp.Diff(vcl, expect, opts...); diff != "" {
+				t.Errorf("instrumented vcl mismatch, diff=%s", diff)
+				return
+			}
+			if diff := cmp.Diff(c, tt.coverage); diff != "" {
+				t.Errorf("coverage state mismatch, diff=%s", diff)
+				return
+			}
+		})
+	}
+}
+
+func TestInstrumentSubroutine(t *testing.T) {
+	tests := testTables{
+		{
+			name: "subroutine instrumenting",
+			input: `
+sub instrument1 {
+	set req.http.Foo = "bar";
+}
+sub instrument2 {
+	set req.http.Bar = "baz";
+}
+`,
+			expect: `
+sub instrument1 {
+	coverage.subroutine("sub_2_1");
+	coverage.statement("stmt_3_2");
+	set req.http.Foo = "bar";
+}
+sub instrument2 {
+	coverage.subroutine("sub_5_1");
+	coverage.statement("stmt_6_2");
+	set req.http.Bar = "baz";
+}
+`,
+			coverage: &shared.Coverage{
+				Subroutines: shared.CoverageMap{
+					"sub_2_1": 0,
+					"sub_5_1": 0,
+				},
+				Statements: shared.CoverageMap{
+					"stmt_3_2": 0,
+					"stmt_6_2": 0,
+				},
+				Branches: shared.CoverageMap{},
+				NodeMap: map[string]token.Token{
+					"sub_2_1":  {Type: token.SUBROUTINE, Literal: "sub", Line: 2, Position: 1},
+					"sub_5_1":  {Type: token.SUBROUTINE, Literal: "sub", Line: 5, Position: 1},
+					"stmt_3_2": {Type: token.SET, Literal: "set", Line: 3, Position: 2},
+					"stmt_6_2": {Type: token.SET, Literal: "set", Line: 6, Position: 2},
+				},
+			},
+		},
+	}
+	assertInstrument(t, tests)
+}
+
+func TestInstrumentIfStatement(t *testing.T) {
+	tests := testTables{
+		{
+			name: "if statement instrumenting",
+			input: `
+sub instrument {
+	declare local var.V STRING;
+	if (req.http.Foo) {
+		set var.V = req.http.Foo;
+	} else if (req.http.Bar) {
+		set var.V = req.http.Bar;
+	} elsif (req.http.Baz) {
+		set var.V = req.http.Bar;
+	} else {
+		if (req.http.Other) {
+			set var.V = "other";
+		} else {
+			set var.V = "unknown";
+		}
+	}
+	set req.http.V = var.V;
+}
+`,
+			expect: `
+sub instrument {
+	coverage.subroutine("sub_2_1");
+	coverage.statement("stmt_3_2");
+	declare local var.V STRING;
+	coverage.statement("stmt_4_2");
+	if (req.http.Foo) {
+		coverage.branch("branch_4_2_1");
+		coverage.statement("stmt_5_3");
+		set var.V = req.http.Foo;
+	} else {
+		coverage.branch("branch_4_2_2");
+		if (req.http.Bar) {
+			coverage.branch("branch_6_9_1");
+			coverage.statement("stmt_7_3");
+			set var.V = req.http.Bar;
+		} else {
+			coverage.branch("branch_4_2_3");
+			if (req.http.Baz) {
+				coverage.branch("branch_8_4_1");
+				coverage.statement("stmt_9_3");
+				set var.V = req.http.Bar;
+			} else {
+				coverage.branch("branch_4_2_4");
+				coverage.statement("stmt_11_3");
+				if (req.http.Other) {
+					coverage.branch("branch_11_3_1");
+					coverage.statement("stmt_12_4");
+					set var.V = "other";
+				} else {
+					coverage.branch("branch_11_3_2");
+					coverage.statement("stmt_14_4");
+					set var.V = "unknown";
+				}
+			}
+		}
+	}
+	coverage.statement("stmt_17_2");
+	set req.http.V = var.V;
+}
+`,
+			coverage: &shared.Coverage{
+				Subroutines: shared.CoverageMap{
+					"sub_2_1": 0,
+				},
+				Statements: shared.CoverageMap{
+					"stmt_3_2":  0,
+					"stmt_4_2":  0,
+					"stmt_5_3":  0,
+					"stmt_7_3":  0,
+					"stmt_9_3":  0,
+					"stmt_11_3": 0,
+					"stmt_12_4": 0,
+					"stmt_14_4": 0,
+					"stmt_17_2": 0,
+				},
+				Branches: shared.CoverageMap{
+					"branch_4_2_1":  0,
+					"branch_4_2_2":  0,
+					"branch_4_2_3":  0,
+					"branch_4_2_4":  0,
+					"branch_6_9_1":  0,
+					"branch_8_4_1":  0,
+					"branch_11_3_1": 0,
+					"branch_11_3_2": 0,
+				},
+				NodeMap: map[string]token.Token{
+					"sub_2_1":       {Type: token.SUBROUTINE, Literal: "sub", Line: 2, Position: 1},
+					"stmt_3_2":      {Type: token.DECLARE, Literal: "declare", Line: 3, Position: 2},
+					"stmt_4_2":      {Type: token.IF, Literal: "if", Line: 4, Position: 2},
+					"stmt_5_3":      {Type: token.SET, Literal: "set", Line: 5, Position: 3},
+					"stmt_7_3":      {Type: token.SET, Literal: "set", Line: 7, Position: 3},
+					"stmt_9_3":      {Type: token.SET, Literal: "set", Line: 9, Position: 3},
+					"stmt_11_3":     {Type: token.IF, Literal: "if", Line: 11, Position: 3},
+					"stmt_12_4":     {Type: token.SET, Literal: "set", Line: 12, Position: 4},
+					"stmt_14_4":     {Type: token.SET, Literal: "set", Line: 14, Position: 4},
+					"stmt_17_2":     {Type: token.SET, Literal: "set", Line: 17, Position: 2},
+					"branch_4_2_1":  {Type: token.IF, Literal: "if", Line: 4, Position: 2},
+					"branch_4_2_2":  {Type: token.IF, Literal: "if", Line: 4, Position: 2},
+					"branch_4_2_3":  {Type: token.IF, Literal: "if", Line: 4, Position: 2},
+					"branch_4_2_4":  {Type: token.IF, Literal: "if", Line: 4, Position: 2},
+					"branch_6_9_1":  {Type: token.IF, Literal: "if", Line: 6, Position: 9},
+					"branch_8_4_1":  {Type: token.ELSIF, Literal: "elsif", Line: 8, Position: 4},
+					"branch_11_3_1": {Type: token.IF, Literal: "if", Line: 11, Position: 3},
+					"branch_11_3_2": {Type: token.IF, Literal: "if", Line: 11, Position: 3},
+				},
+			},
+		},
+	}
+	assertInstrument(t, tests)
+}
+
+func TestInstrumentSwitchStatement(t *testing.T) {
+	tests := testTables{
+		{
+			name: "switch statement instrumenting",
+			input: `
+sub instrument {
+	declare local var.V STRING;
+	switch (req.http.Item) {
+	case "1":
+		set var.V = "foo";
+		break;
+	case "2":
+		set var.V = "bar";
+		break;
+	case "3":
+		set var.V = "baz";
+		fallthrough;
+	default:
+		set var.V = "unknown";
+		break;
+	}
+}
+`,
+			expect: `
+sub instrument {
+	coverage.subroutine("sub_2_1");
+	coverage.statement("stmt_3_2");
+	declare local var.V STRING;
+	coverage.statement("stmt_4_2");
+	switch (req.http.Item) {
+	case "1":
+		coverage.branch("branch_4_2_1");
+		coverage.branch("branch_5_2");
+		coverage.statement("stmt_6_3");
+		set var.V = "foo";
+		coverage.statement("stmt_7_3");
+		break;
+	case "2":
+		coverage.branch("branch_4_2_2");
+		coverage.branch("branch_8_2");
+		coverage.statement("stmt_9_3");
+		set var.V = "bar";
+		coverage.statement("stmt_10_3");
+		break;
+	case "3":
+		coverage.branch("branch_4_2_3");
+		coverage.branch("branch_11_2");
+		coverage.statement("stmt_12_3");
+		set var.V = "baz";
+		coverage.statement("stmt_13_3");
+		fallthrough;
+	default:
+		coverage.branch("branch_4_2_4");
+		coverage.branch("branch_14_2");
+		coverage.statement("stmt_15_3");
+		set var.V = "unknown";
+		coverage.statement("stmt_16_3");
+		break;
+	}
+}
+`,
+			coverage: &shared.Coverage{
+				Subroutines: shared.CoverageMap{
+					"sub_2_1": 0,
+				},
+				Statements: shared.CoverageMap{
+					"stmt_3_2":  0,
+					"stmt_4_2":  0,
+					"stmt_6_3":  0,
+					"stmt_7_3":  0,
+					"stmt_9_3":  0,
+					"stmt_10_3": 0,
+					"stmt_12_3": 0,
+					"stmt_13_3": 0,
+					"stmt_15_3": 0,
+					"stmt_16_3": 0,
+				},
+				Branches: shared.CoverageMap{
+					"branch_4_2_1": 0,
+					"branch_4_2_2": 0,
+					"branch_4_2_3": 0,
+					"branch_4_2_4": 0,
+					"branch_5_2":   0,
+					"branch_8_2":   0,
+					"branch_11_2":  0,
+					"branch_14_2":  0,
+				},
+				NodeMap: map[string]token.Token{
+					"sub_2_1":      {Type: token.SUBROUTINE, Literal: "sub", Line: 2, Position: 1},
+					"stmt_3_2":     {Type: token.DECLARE, Literal: "declare", Line: 3, Position: 2},
+					"stmt_4_2":     {Type: token.SWITCH, Literal: "switch", Line: 4, Position: 2},
+					"stmt_6_3":     {Type: token.SET, Literal: "set", Line: 6, Position: 3},
+					"stmt_7_3":     {Type: token.BREAK, Literal: "break", Line: 7, Position: 3},
+					"stmt_9_3":     {Type: token.SET, Literal: "set", Line: 9, Position: 3},
+					"stmt_10_3":    {Type: token.BREAK, Literal: "break", Line: 10, Position: 3},
+					"stmt_12_3":    {Type: token.SET, Literal: "set", Line: 12, Position: 3},
+					"stmt_13_3":    {Type: token.FALLTHROUGH, Literal: "fallthrough", Line: 13, Position: 3},
+					"stmt_15_3":    {Type: token.SET, Literal: "set", Line: 15, Position: 3},
+					"stmt_16_3":    {Type: token.BREAK, Literal: "break", Line: 16, Position: 3},
+					"branch_4_2_1": {Type: token.SWITCH, Literal: "switch", Line: 4, Position: 2},
+					"branch_4_2_2": {Type: token.SWITCH, Literal: "switch", Line: 4, Position: 2},
+					"branch_4_2_3": {Type: token.SWITCH, Literal: "switch", Line: 4, Position: 2},
+					"branch_4_2_4": {Type: token.SWITCH, Literal: "switch", Line: 4, Position: 2},
+					"branch_5_2":   {Type: token.CASE, Literal: "case", Line: 5, Position: 2},
+					"branch_8_2":   {Type: token.CASE, Literal: "case", Line: 8, Position: 2},
+					"branch_11_2":  {Type: token.CASE, Literal: "case", Line: 11, Position: 2},
+					"branch_14_2":  {Type: token.DEFAULT, Literal: "default", Line: 14, Position: 2},
+				},
+			},
+		},
+	}
+	assertInstrument(t, tests)
+}
+
+func TestInstrumentIfExpression(t *testing.T) {
+	tests := testTables{
+		{
+			name: "if expression instrumenting",
+			input: `
+sub instrument {
+	declare local var.V STRING;
+	set var.V = if(req.http.Foo, "bar", "baz");
+}
+`,
+			expect: `
+sub instrument {
+	coverage.subroutine("sub_2_1");
+	coverage.statement("stmt_3_2");
+	declare local var.V STRING;
+	coverage.statement("stmt_4_2");
+	if (req.http.Foo) {
+		coverage.branch("branch_4_14_true");
+	} else {
+		coverage.branch("branch_4_14_false");
+	}
+	set var.V = if(req.http.Foo, "bar", "baz");
+}
+`,
+			coverage: &shared.Coverage{
+				Subroutines: shared.CoverageMap{
+					"sub_2_1": 0,
+				},
+				Statements: shared.CoverageMap{
+					"stmt_3_2": 0,
+					"stmt_4_2": 0,
+				},
+				Branches: shared.CoverageMap{
+					"branch_4_14_true":  0,
+					"branch_4_14_false": 0,
+				},
+				NodeMap: map[string]token.Token{
+					"sub_2_1":           {Type: token.SUBROUTINE, Literal: "sub", Line: 2, Position: 1},
+					"stmt_3_2":          {Type: token.DECLARE, Literal: "declare", Line: 3, Position: 2},
+					"stmt_4_2":          {Type: token.SET, Literal: "set", Line: 4, Position: 2},
+					"branch_4_14_true":  {Type: token.IF, Literal: "if", Line: 4, Position: 14},
+					"branch_4_14_false": {Type: token.IF, Literal: "if", Line: 4, Position: 14},
+				},
+			},
+		},
+	}
+	assertInstrument(t, tests)
+}

--- a/tester/entity.go
+++ b/tester/entity.go
@@ -61,4 +61,5 @@ type TestFactory struct {
 	Results    []*TestResult
 	Statistics *shared.Counter
 	Logs       []string
+	Coverage   *shared.CoverageReport
 }

--- a/tester/entity.go
+++ b/tester/entity.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ysugimoto/falco/interpreter/function/errors"
 	"github.com/ysugimoto/falco/lexer"
+	"github.com/ysugimoto/falco/tester/shared"
 )
 
 type TestCase struct {
@@ -58,26 +59,6 @@ func (t *TestResult) IsPassed() bool {
 
 type TestFactory struct {
 	Results    []*TestResult
-	Statistics *TestCounter
+	Statistics *shared.Counter
 	Logs       []string
-}
-
-type TestCounter struct {
-	Asserts int `json:"asserts"`
-	Passes  int `json:"passes"`
-	Fails   int `json:"fails"`
-}
-
-func NewTestCounter() *TestCounter {
-	return &TestCounter{}
-}
-
-func (c *TestCounter) Pass() {
-	c.Asserts++
-	c.Passes++
-}
-
-func (c *TestCounter) Fail() {
-	c.Asserts++
-	c.Fails++
 }

--- a/tester/function/coverage.go
+++ b/tester/function/coverage.go
@@ -6,32 +6,11 @@ import (
 	"github.com/ysugimoto/falco/tester/shared"
 )
 
-type CoverageType int8
-
-const (
-	CoverageTypeSubroutine CoverageType = iota
-	CoverageTypeStatement
-	CoverageTypeBranch
-)
-
-func (t CoverageType) String() string {
-	switch t {
-	case CoverageTypeSubroutine:
-		return "subroutine"
-	case CoverageTypeStatement:
-		return "statement"
-	case CoverageTypeBranch:
-		return "branch"
-	default:
-		return ""
-	}
-}
-
 const Coverage_Name = "coverage"
 
 var Coverage_ArgumentTypes = []value.Type{value.StringType}
 
-func Coverage_Validate(t CoverageType, args []value.Value) error {
+func Coverage_Validate(t shared.CoverageType, args []value.Value) error {
 	if len(args) != len(Coverage_ArgumentTypes) {
 		return errors.ArgumentNotEnough(Coverage_Name+"."+t.String(), len(Coverage_ArgumentTypes), args)
 	}
@@ -50,7 +29,7 @@ func Coverage_Validate(t CoverageType, args []value.Value) error {
 
 func Coverage(
 	c *shared.Coverage,
-	t CoverageType,
+	t shared.CoverageType,
 	args ...value.Value,
 ) (value.Value, error) {
 
@@ -60,11 +39,11 @@ func Coverage(
 
 	key := value.Unwrap[*value.String](args[0]).Value
 	switch t {
-	case CoverageTypeSubroutine:
+	case shared.CoverageTypeSubroutine:
 		c.MarkSubroutine(key)
-	case CoverageTypeStatement:
+	case shared.CoverageTypeStatement:
 		c.MarkStatement(key)
-	case CoverageTypeBranch:
+	case shared.CoverageTypeBranch:
 		c.MarkBranch(key)
 	}
 	return value.Null, nil

--- a/tester/function/coverage.go
+++ b/tester/function/coverage.go
@@ -1,0 +1,71 @@
+package function
+
+import (
+	"github.com/ysugimoto/falco/interpreter/function/errors"
+	"github.com/ysugimoto/falco/interpreter/value"
+	"github.com/ysugimoto/falco/tester/shared"
+)
+
+type CoverageType int8
+
+const (
+	CoverageTypeSubroutine CoverageType = iota
+	CoverageTypeStatement
+	CoverageTypeBranch
+)
+
+func (t CoverageType) String() string {
+	switch t {
+	case CoverageTypeSubroutine:
+		return "subroutine"
+	case CoverageTypeStatement:
+		return "statement"
+	case CoverageTypeBranch:
+		return "branch"
+	default:
+		return ""
+	}
+}
+
+const Coverage_Name = "coverage"
+
+var Coverage_ArgumentTypes = []value.Type{value.StringType}
+
+func Coverage_Validate(t CoverageType, args []value.Value) error {
+	if len(args) != len(Coverage_ArgumentTypes) {
+		return errors.ArgumentNotEnough(Coverage_Name+"."+t.String(), len(Coverage_ArgumentTypes), args)
+	}
+	for i := range args {
+		if args[i].Type() != Coverage_ArgumentTypes[i] {
+			return errors.TypeMismatch(
+				Coverage_Name+"."+t.String(),
+				i+1,
+				Coverage_ArgumentTypes[i],
+				args[i].Type(),
+			)
+		}
+	}
+	return nil
+}
+
+func Coverage(
+	c *shared.Coverage,
+	t CoverageType,
+	args ...value.Value,
+) (value.Value, error) {
+
+	if err := Coverage_Validate(t, args); err != nil {
+		return value.Null, errors.NewTestingError("%s", err.Error())
+	}
+
+	key := value.Unwrap[*value.String](args[0]).Value
+	switch t {
+	case CoverageTypeSubroutine:
+		c.MarkSubroutine(key)
+	case CoverageTypeStatement:
+		c.MarkStatement(key)
+	case CoverageTypeBranch:
+		c.MarkBranch(key)
+	}
+	return value.Null, nil
+}

--- a/tester/function/functions.go
+++ b/tester/function/functions.go
@@ -42,7 +42,7 @@ func coverageFunctions(c *shared.Coverage) Functions {
 		"coverage.subroutine": {
 			Scope: allScope,
 			Call: func(ctx *context.Context, args ...value.Value) (value.Value, error) {
-				return Coverage(c, CoverageTypeSubroutine, args...)
+				return Coverage(c, shared.CoverageTypeSubroutine, args...)
 			},
 			CanStatementCall: true,
 			IsIdentArgument: func(i int) bool {
@@ -52,7 +52,7 @@ func coverageFunctions(c *shared.Coverage) Functions {
 		"coverage.statement": {
 			Scope: allScope,
 			Call: func(ctx *context.Context, args ...value.Value) (value.Value, error) {
-				return Coverage(c, CoverageTypeStatement, args...)
+				return Coverage(c, shared.CoverageTypeStatement, args...)
 			},
 			CanStatementCall: true,
 			IsIdentArgument: func(i int) bool {
@@ -62,7 +62,7 @@ func coverageFunctions(c *shared.Coverage) Functions {
 		"coverage.branch": {
 			Scope: allScope,
 			Call: func(ctx *context.Context, args ...value.Value) (value.Value, error) {
-				return Coverage(c, CoverageTypeBranch, args...)
+				return Coverage(c, shared.CoverageTypeBranch, args...)
 			},
 			CanStatementCall: true,
 			IsIdentArgument: func(i int) bool {

--- a/tester/shared/counter.go
+++ b/tester/shared/counter.go
@@ -1,0 +1,21 @@
+package shared
+
+type Counter struct {
+	Asserts int `json:"asserts"`
+	Passes  int `json:"passes"`
+	Fails   int `json:"fails"`
+}
+
+func NewCounter() *Counter {
+	return &Counter{}
+}
+
+func (c *Counter) Pass() {
+	c.Asserts++
+	c.Passes++
+}
+
+func (c *Counter) Fail() {
+	c.Asserts++
+	c.Fails++
+}

--- a/tester/shared/coverage.go
+++ b/tester/shared/coverage.go
@@ -1,31 +1,72 @@
 package shared
 
-import "github.com/ysugimoto/falco/ast"
+import (
+	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/token"
+)
+
+type CoverageType int8
+
+const (
+	CoverageTypeSubroutine CoverageType = iota
+	CoverageTypeStatement
+	CoverageTypeBranch
+)
+
+func (t CoverageType) String() string {
+	switch t {
+	case CoverageTypeSubroutine:
+		return "subroutine"
+	case CoverageTypeStatement:
+		return "statement"
+	case CoverageTypeBranch:
+		return "branch"
+	default:
+		return ""
+	}
+}
+
+type CoverageMap map[string]uint64
 
 type Coverage struct {
-	Subroutines map[string]bool
-	Statements  map[string]bool
-	Branches    map[string]bool
-	NodeMap     map[string]ast.Node
+	Subroutines CoverageMap
+	Statements  CoverageMap
+	Branches    CoverageMap
+	NodeMap     map[string]token.Token
 }
 
 func NewCoverage() *Coverage {
 	return &Coverage{
-		Subroutines: make(map[string]bool),
-		Statements:  make(map[string]bool),
-		Branches:    make(map[string]bool),
-		NodeMap:     make(map[string]ast.Node),
+		Subroutines: make(CoverageMap),
+		Statements:  make(CoverageMap),
+		Branches:    make(CoverageMap),
+		NodeMap:     make(map[string]token.Token),
 	}
 }
 
 func (c *Coverage) MarkSubroutine(key string) {
-	c.Subroutines[key] = true
+	c.Subroutines[key]++
 }
 
 func (c *Coverage) MarkStatement(key string) {
-	c.Statements[key] = true
+	c.Statements[key]++
 }
 
 func (c *Coverage) MarkBranch(key string) {
-	c.Branches[key] = true
+	c.Branches[key]++
+}
+
+func (c *Coverage) SetupSubroutine(key string, node ast.Node) {
+	c.Subroutines[key] = 0
+	c.NodeMap[key] = node.GetMeta().Token
+}
+
+func (c *Coverage) SetupStatement(key string, node ast.Node) {
+	c.Statements[key] = 0
+	c.NodeMap[key] = node.GetMeta().Token
+}
+
+func (c *Coverage) SetupBranch(key string, node ast.Node) {
+	c.Branches[key] = 0
+	c.NodeMap[key] = node.GetMeta().Token
 }

--- a/tester/shared/coverage.go
+++ b/tester/shared/coverage.go
@@ -1,0 +1,31 @@
+package shared
+
+import "github.com/ysugimoto/falco/ast"
+
+type Coverage struct {
+	Subroutines map[string]bool
+	Statements  map[string]bool
+	Branches    map[string]bool
+	NodeMap     map[string]ast.Node
+}
+
+func NewCoverage() *Coverage {
+	return &Coverage{
+		Subroutines: make(map[string]bool),
+		Statements:  make(map[string]bool),
+		Branches:    make(map[string]bool),
+		NodeMap:     make(map[string]ast.Node),
+	}
+}
+
+func (c *Coverage) MarkSubroutine(key string) {
+	c.Subroutines[key] = true
+}
+
+func (c *Coverage) MarkStatement(key string) {
+	c.Statements[key] = true
+}
+
+func (c *Coverage) MarkBranch(key string) {
+	c.Branches[key] = true
+}

--- a/tester/shared/coverage.go
+++ b/tester/shared/coverage.go
@@ -1,6 +1,9 @@
 package shared
 
 import (
+	"math"
+	"sync"
+
 	"github.com/ysugimoto/falco/ast"
 	"github.com/ysugimoto/falco/token"
 )
@@ -26,47 +29,131 @@ func (t CoverageType) String() string {
 	}
 }
 
-type CoverageMap map[string]uint64
-
 type Coverage struct {
-	Subroutines CoverageMap
-	Statements  CoverageMap
-	Branches    CoverageMap
-	NodeMap     map[string]token.Token
+	Subroutines *sync.Map // map[string]uint64
+	Statements  *sync.Map // map[string]uint64
+	Branches    *sync.Map // map[string]uint64
+	NodeMap     *sync.Map // map[string]token.Token
 }
 
 func NewCoverage() *Coverage {
 	return &Coverage{
-		Subroutines: make(CoverageMap),
-		Statements:  make(CoverageMap),
-		Branches:    make(CoverageMap),
-		NodeMap:     make(map[string]token.Token),
+		Subroutines: &sync.Map{},
+		Statements:  &sync.Map{},
+		Branches:    &sync.Map{},
+		NodeMap:     &sync.Map{},
 	}
 }
 
 func (c *Coverage) MarkSubroutine(key string) {
-	c.Subroutines[key]++
+	if v, ok := c.Subroutines.Load(key); ok {
+		c.Subroutines.Swap(key, v.(uint64)+1) // nolint:errcheck
+	}
 }
 
 func (c *Coverage) MarkStatement(key string) {
-	c.Statements[key]++
+	if v, ok := c.Statements.Load(key); ok {
+		c.Statements.Swap(key, v.(uint64)+1) // nolint:errcheck
+	}
 }
 
 func (c *Coverage) MarkBranch(key string) {
-	c.Branches[key]++
+	if v, ok := c.Branches.Load(key); ok {
+		c.Branches.Swap(key, v.(uint64)+1) // nolint:errcheck
+	}
 }
 
 func (c *Coverage) SetupSubroutine(key string, node ast.Node) {
-	c.Subroutines[key] = 0
-	c.NodeMap[key] = node.GetMeta().Token
+	c.Subroutines.LoadOrStore(key, uint64(0))
+	c.NodeMap.LoadOrStore(key, node.GetMeta().Token)
 }
 
 func (c *Coverage) SetupStatement(key string, node ast.Node) {
-	c.Statements[key] = 0
-	c.NodeMap[key] = node.GetMeta().Token
+	c.Statements.LoadOrStore(key, uint64(0))
+	c.NodeMap.LoadOrStore(key, node.GetMeta().Token)
 }
 
 func (c *Coverage) SetupBranch(key string, node ast.Node) {
-	c.Branches[key] = 0
-	c.NodeMap[key] = node.GetMeta().Token
+	c.Branches.LoadOrStore(key, uint64(0))
+	c.NodeMap.LoadOrStore(key, node.GetMeta().Token)
+}
+
+func (c *Coverage) Factory() *CoverageFactory {
+	r := &CoverageFactory{
+		Subroutines: make(CoverageFactoryItem),
+		Statements:  make(CoverageFactoryItem),
+		Branches:    make(CoverageFactoryItem),
+		NodeMap:     make(map[string]token.Token),
+	}
+
+	c.Subroutines.Range(func(key, val any) bool {
+		r.Subroutines[key.(string)] = val.(uint64) // nolint:errcheck
+		return true
+	})
+	c.Statements.Range(func(key, val any) bool {
+		r.Statements[key.(string)] = val.(uint64) // nolint:errcheck
+		return true
+	})
+	c.Branches.Range(func(key, val any) bool {
+		r.Branches[key.(string)] = val.(uint64) // nolint:errcheck
+		return true
+	})
+	c.NodeMap.Range(func(key, val any) bool {
+		r.NodeMap[key.(string)] = val.(token.Token) // nolint:errcheck
+		return true
+	})
+
+	return r
+}
+
+type CoverageFactoryItem map[string]uint64
+
+type CoverageFactory struct {
+	Subroutines CoverageFactoryItem
+	Statements  CoverageFactoryItem
+	Branches    CoverageFactoryItem
+	NodeMap     map[string]token.Token
+}
+
+func (c *CoverageFactory) Report() *CoverageReport {
+	return &CoverageReport{
+		Subroutines: c.calculate(c.Subroutines),
+		Statements:  c.calculate(c.Statements),
+		Branches:    c.calculate(c.Branches),
+		NodeMap:     c.NodeMap,
+	}
+}
+
+func (c *CoverageFactory) calculate(v CoverageFactoryItem) *CoverageReportItem {
+	var executed, total uint64
+	var percent float64
+
+	for _, val := range v {
+		total++
+		if val > 0 {
+			executed++
+		}
+	}
+	if total > 0 {
+		percent = math.Round(float64(executed)/float64(total)*10000) / 100
+	}
+
+	return &CoverageReportItem{
+		Executed: executed,
+		Total:    total,
+		Percent:  percent,
+	}
+}
+
+type CoverageReportItem struct {
+	Executed uint64
+	Total    uint64
+	Percent  float64
+}
+
+type CoverageReport struct {
+	Subroutines *CoverageReportItem
+	Statements  *CoverageReportItem
+	Branches    *CoverageReportItem
+	NodeMap     map[string]token.Token
 }

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -90,11 +90,15 @@ func (t *Tester) Run(main string) (*TestFactory, error) {
 		results = append(results, result)
 	}
 
-	return &TestFactory{
+	factory := &TestFactory{
 		Results:    results,
 		Statistics: t.counter,
 		Logs:       t.debugger.stack,
-	}, nil
+	}
+	if t.coverage != nil {
+		factory.Coverage = t.coverage.Factory().Report()
+	}
+	return factory, nil
 }
 
 // Actually run testing method

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -47,6 +47,7 @@ func New(c *config.TestConfig, opts []icontext.Option) *Tester {
 	}
 	if c.Coverage {
 		t.coverage = shared.NewCoverage()
+		t.interpreterOptions = append(t.interpreterOptions, icontext.WithCoverage(t.coverage))
 	}
 	return t
 }

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ysugimoto/falco/parser"
 	"github.com/ysugimoto/falco/resolver"
 	tf "github.com/ysugimoto/falco/tester/function"
+	"github.com/ysugimoto/falco/tester/shared"
 	"github.com/ysugimoto/falco/tester/syntax"
 	tv "github.com/ysugimoto/falco/tester/variable"
 )
@@ -32,17 +33,22 @@ var (
 type Tester struct {
 	interpreterOptions []icontext.Option
 	config             *config.TestConfig
-	counter            *TestCounter
+	counter            *shared.Counter
 	debugger           *Debugger
+	coverage           *shared.Coverage
 }
 
 func New(c *config.TestConfig, opts []icontext.Option) *Tester {
-	return &Tester{
+	t := &Tester{
 		interpreterOptions: opts,
 		config:             c,
-		counter:            NewTestCounter(),
+		counter:            shared.NewCounter(),
 		debugger:           NewDebugger(),
 	}
+	if c.Coverage {
+		t.coverage = shared.NewCoverage()
+	}
+	return t
 }
 
 // Find test target VCL files
@@ -328,7 +334,7 @@ func (t *Tester) setupInterpreter(defs *tf.Definiions) *interpreter.Interpreter 
 		return nil
 	}
 	variable.Inject(&tv.TestingVariables{})
-	function.Inject(tf.TestingFunctions(i, defs, t.counter))
+	function.Inject(tf.TestingFunctions(i, defs, t.counter, t.coverage))
 
 	return i
 }


### PR DESCRIPTION
This PR implements testing coverage feature that measure test coverage for out testing mechanism.

## Instrumenting

The way of instrumenting - transform the AST for measurement - is based on the istunbul, popular JavaScript library,
we collect the Statements, Branches, and Subroutines (Functions in istunbul) and display when `--coverage` option is provided:

```shell
falco test /path/to/main.vcl --coverage
``` 
## Collect Coverage

Fortunately falco has a feature that specify and inject custom function in the testing runtime, so we define three of coverage related functions.

- `coverage.subroutine(id)`
- `coverage.statement(id)`
- `coverage.branch(id)`

On instrumenting, Interpreter transforms parsed AST and embed above custom functions to suitable place/function.
After the unit testing has run, runtime stores function call times inside and calculate percentage for each coverages, and display after the test result.

![CleanShot 2025-02-24 at 14 07 03@2x](https://github.com/user-attachments/assets/9b7e40c8-e831-4526-8d27-57c8ba024e8f)

Note that this is very basic implementation so we may need more improvement for coverage measurement.

Huge thanks to @nodaguti of the conceptual implementation for this feature in #343 !