### PR TITLE
improve set statement value expression

### DIFF
--- a/interpreter/helper.go
+++ b/interpreter/helper.go
@@ -1,9 +1,11 @@
 package interpreter
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/interpreter/value"
 )
 
 func findProcessMark(comments ast.Comments) (string, bool) {
@@ -20,4 +22,22 @@ func findProcessMark(comments ast.Comments) (string, bool) {
 type series struct {
 	Operator   string
 	Expression ast.Expression
+}
+
+func isValidStatementExpression(left value.Type, exp ast.Expression) error {
+	switch t := exp.(type) {
+	case *ast.PrefixExpression:
+		if t.Operator == "!" {
+			return fmt.Errorf("could not specify bang operator in first expression")
+		}
+	case *ast.InfixExpression:
+		if t.Operator != "+" {
+			return fmt.Errorf("could not specify %s operator in statement", t.Operator)
+		}
+	case *ast.GroupedExpression:
+		if left != value.BooleanType {
+			return fmt.Errorf("could not specify grouped expression excepting boolean statement")
+		}
+	}
+	return nil
 }

--- a/linter/helper.go
+++ b/linter/helper.go
@@ -164,13 +164,15 @@ func isValidConditionExpression(cond ast.Expression) error {
 //
 // declare local var.Foo BOOL;
 // declare local var.Bar STRING;
-// set var.Bar = "foo" "bar";                      // -> valid, string concatenation operator can use
-// set var.Foo = (req.http.Host == "example.com"); // -> valid, equal operator cau use inside grouped expression set statement
-// set var.Foo = !false;                           // -> invalid, could not use in set statement
-// set var.Foo = req.http.Host == "example.com";   // -> invalid, equal operator could not use in set statement
+// set var.Bar = "foo" "bar";                         // -> valid, string concatenation operator can use
+// set var.Foo = (req.http.Host == "example.com");    // -> valid, equal operator cau use inside grouped expression set statement
+// set var.Bar = (req.http.Host == "example.com");    // -> invalid, expression must be an string
+// set var.Foo = !false;                              // -> invalid, could not use in set statement
+// set var.Bar = !tls.client.certificate.is_cert_bad; // -> invalid, expression must be an string
+// set var.Foo = req.http.Host == "example.com";      // -> invalid, equal operator could not use in set statement
 //
 // So we'd check validity following function.
-func isValidStatementExpression(exp ast.Expression) error {
+func isValidStatementExpression(leftType types.Type, exp ast.Expression) error {
 	switch t := exp.(type) {
 	case *ast.PrefixExpression:
 		if t.Operator == "!" {
@@ -179,6 +181,10 @@ func isValidStatementExpression(exp ast.Expression) error {
 	case *ast.InfixExpression:
 		if t.Operator != "+" {
 			return fmt.Errorf("could not specify %s operator in statement", t.Operator)
+		}
+	case *ast.GroupedExpression:
+		if leftType != types.BoolType {
+			return fmt.Errorf("could not specify grouped expression excepting boolean statement")
 		}
 	}
 	return nil

--- a/linter/statement_linter.go
+++ b/linter/statement_linter.go
@@ -135,7 +135,7 @@ func (l *Linter) lintSetStatement(stmt *ast.SetStatement, ctx *context.Context) 
 		l.Error(err)
 	}
 
-	if err := isValidStatementExpression(stmt.Value); err != nil {
+	if err := isValidStatementExpression(left, stmt.Value); err != nil {
 		err := &LintError{
 			Severity: ERROR,
 			Token:    stmt.Value.GetMeta().Token,
@@ -377,7 +377,7 @@ func (l *Linter) lintAddStatement(stmt *ast.AddStatement, ctx *context.Context) 
 		}
 	}
 
-	if err := isValidStatementExpression(stmt.Value); err != nil {
+	if err := isValidStatementExpression(left, stmt.Value); err != nil {
 		err := &LintError{
 			Severity: ERROR,
 			Token:    stmt.Value.GetMeta().Token,

--- a/linter/statement_linter_test.go
+++ b/linter/statement_linter_test.go
@@ -783,3 +783,23 @@ sub foo {
 		assertErrorWithSeverity(t, input, WARNING)
 	}
 }
+
+func TestGroupedExpressionInStatement(t *testing.T) {
+	tests := []string{
+		`
+sub vcl_recv {
+  #FASTLY recv
+  set req.http.foo = (req.http.bar == "example.com");
+}`,
+		`
+sub vcl_recv {
+  #FASTLY recv
+  set req.http.foo = req.http.bar (req.http.baz == "example.com");
+}`,
+	}
+
+	for _, input := range tests {
+		assertError(t, input)
+	}
+
+}


### PR DESCRIPTION
Fixes #268 

This PR improves linting and evaliation for set statement expression.
In value of set statement, grouped expression is invalid for assinment to string value like:

```
set req.http.Value = (req.http.Foo = "example.com"); // invalid
```

However, it is valid to assignment to boolean value:

```
declare local var.B BOOL;
set var.B = (req.http.Foo = "example.com"); // valid
```

This is strange but we should follow the Fastly spec.
