### PR TITLE
fix: resolve missing default transport settings in HTTPS by cloning http.DefaultTransport

### DIFF
--- a/interpreter/transport.go
+++ b/interpreter/transport.go
@@ -168,12 +168,18 @@ func (i *Interpreter) sendBackendRequest(backend *value.Backend) (*http.Response
 
 	client := http.DefaultClient
 	if req.URL.Scheme == HTTPS_SCHEME {
+		defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+		if !ok {
+			return nil, errors.WithStack(errors.New("cannot clone http.DefaultTransport"))
+		}
+
+		transport := defaultTransport.Clone()
+		transport.TLSClientConfig = &tls.Config{
+			ServerName: req.URL.Hostname(),
+		}
+
 		client = &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{
-					ServerName: req.URL.Hostname(),
-				},
-			},
+			Transport: transport,
 		}
 	}
 	resp, err := client.Do(req)


### PR DESCRIPTION
## Description

This pull request fixes the issue where using Transport without setting its all fields misses important default behaviors. 

Specifically, it does not automatically use proxy settings from the HTTP_PROXY and HTTPS_PROXY environment variables. 

* ref. https://pkg.go.dev/net/http#ProxyFromEnvironment

By including these defaults, network requests can correctly go through proxies, matching the behavior of the default transport.

## Related Articles

* (Japanese) [\[Go\] 前方互換性を保ちながらhttp.DefaultTransportからチューニングしたhttp.Transportをつくる - My External Storage](https://budougumi0617.github.io/2021/09/13/how_to_copy_default_transport/)
  * > しかし上記のような宣言ではMaxIdleConnsPerHostフィールド以外のフィールドがゼロ値になってしまうため、よくない宣言だ。(...)  Cloneメソッドを利用するのが正しい設定のコピーの仕方だろう。この方法ならば、中身が変わったときでもメンテ無しで追従できる。 この手法を利用しているのが、Google APIのGoクライアントだ。 
* (Japanese) [【Go】http.Client に独自ルート証明書を追加する #Go - Qiita](https://qiita.com/frozenbonito/items/bb615e09dcee3175ef5a#httptransport-%E3%81%AF%E3%83%87%E3%83%95%E3%82%A9%E3%83%AB%E3%83%88%E5%80%A4%E3%82%92%E3%82%B3%E3%83%94%E3%83%BC%E3%81%97%E3%81%9F%E3%82%82%E3%81%AE%E3%82%92%E4%BD%BF%E3%81%86)
  * > 次のように http.Transport を適当に初期化して TLSClientConfig のみを設定してしまうと、http.Transport のその他のフィールドが全てゼロ値になってしまいます。 (...) デフォルトの設定を使いつつ TLSClientConfig のみを変更したい場合は http.Transport の `Clone()` メソッドを使用して http.DefaultTransport をコピーしたものを使用すると良いでしょう。

## Related Code Example

* https://github.com/googleapis/google-api-go-client/blob/e878018a6c2edbbb3f798506f468d29acc17ebc6/transport/http/dial.go#L309-L318
* https://github.com/elastic/elastic-transport-go/blob/e839b606fc84a49cc09e18fb3d8b735a0f245ba0/elastictransport/elastictransport.go#L154-L158