### PR TITLE
implement max call stack for calling subroutine recursively

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ request.json
 *.pem
 bench.*.txt
 issue-*
+*.prof

--- a/interpreter/exception/exception.go
+++ b/interpreter/exception/exception.go
@@ -65,7 +65,8 @@ func MaxCallStackExceeded(t *token.Token, stacks []*ast.SubroutineDeclaration) *
 	message := make([]string, len(stacks))
 	for i := range stacks {
 		message[i] = fmt.Sprintf(
-			"%s:%d",
+			"%s in %s:%d",
+			stacks[i].Name.Value,
 			stacks[i].GetMeta().Token.File,
 			stacks[i].GetMeta().Token.Line,
 		)

--- a/interpreter/exception/exception.go
+++ b/interpreter/exception/exception.go
@@ -2,7 +2,9 @@ package exception
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/ysugimoto/falco/ast"
 	"github.com/ysugimoto/falco/token"
 )
 
@@ -56,5 +58,25 @@ func System(format string, args ...interface{}) *Exception {
 	return &Exception{
 		Type:    SystemType,
 		Message: fmt.Sprintf(format, args...),
+	}
+}
+
+func MaxCallStackExceeded(t *token.Token, stacks []*ast.SubroutineDeclaration) *Exception {
+	message := make([]string, len(stacks))
+	for i := range stacks {
+		message[i] = fmt.Sprintf(
+			"%s:%d",
+			stacks[i].GetMeta().Token.File,
+			stacks[i].GetMeta().Token.Line,
+		)
+	}
+
+	return &Exception{
+		Type:  RuntimeType,
+		Token: t,
+		Message: fmt.Sprintf(
+			"max call stack exceeded. Call stack:\n%s",
+			strings.Join(message, "\n"),
+		),
 	}
 }

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -32,6 +32,7 @@ type Interpreter struct {
 	ctx           *context.Context
 	process       *process.Process
 	cache         *cache.Cache
+	callStack     []*ast.SubroutineDeclaration
 	Debugger      Debugger
 	IdentResolver func(v string) value.Value
 
@@ -42,6 +43,7 @@ func New(options ...context.Option) *Interpreter {
 	return &Interpreter{
 		options:      options,
 		cache:        cache.New(),
+		callStack:    []*ast.SubroutineDeclaration{},
 		localVars:    variable.LocalVariables{},
 		Debugger:     DefaultDebugger{},
 		TestingState: NONE,


### PR DESCRIPTION
Fixes #293 

Count and store the subroutine call stack inside interpreter and raise an error when our specific call stack exceeded.
Now we speficied max call stack as `100`.