### PR TITLE
fix base64 decode function with single equal characters

### DIFF
--- a/interpreter/function/builtin/digest_base64_decode_test.go
+++ b/interpreter/function/builtin/digest_base64_decode_test.go
@@ -49,6 +49,12 @@ func Test_Digest_base64_decode(t *testing.T) {
 			input:  "YWJjZB==",
 			expect: "abcd",
 		},
+		{
+			// https://github.com/ysugimoto/falco/issues/431
+			name:   "issue-431",
+			input:  "Zm9vYmFyVGVzdAo=",
+			expect: "foobarTest\n",
+		},
 	}
 
 	for _, tt := range tests {

--- a/interpreter/function/builtin/digest_base64url_decode_test.go
+++ b/interpreter/function/builtin/digest_base64url_decode_test.go
@@ -49,6 +49,12 @@ func Test_Digest_base64url_decode(t *testing.T) {
 			input:  "YWJjZB==",
 			expect: "abcd",
 		},
+		{
+			// https://github.com/ysugimoto/falco/issues/431
+			name:   "issue-431",
+			input:  "Zm9vYmFyVGVzdAo=",
+			expect: "foobarTest\n",
+		},
 	}
 
 	for _, tt := range tests {

--- a/interpreter/function/builtin/digest_base64url_nopad_decode_test.go
+++ b/interpreter/function/builtin/digest_base64url_nopad_decode_test.go
@@ -54,6 +54,12 @@ func Test_Digest_base64url_nopad_decode(t *testing.T) {
 			input:  "aGVsbG8=0",
 			expect: "hello4",
 		},
+		{
+			// https://github.com/ysugimoto/falco/issues/431
+			name:   "issue-431",
+			input:  "Zm9vYmFyVGVzdAo=",
+			expect: "foobarTest\n",
+		},
 	}
 
 	for _, tt := range tests {

--- a/interpreter/function/shared/base64_codec.go
+++ b/interpreter/function/shared/base64_codec.go
@@ -45,7 +45,7 @@ func removeInvalidCharactersStd(src string) string {
 			removed.WriteByte(b)
 		case b == 0x3D: // =
 			// If "=" sign found, next byte must also be "="
-			if peek, err := reader.Peek(1); err != nil && peek[0] == 0x3D {
+			if peek, err := reader.Peek(1); err == nil && peek[0] == 0x3D {
 				removed.WriteByte(b)
 				removed.WriteByte(b)
 				// skip next "=" character
@@ -87,7 +87,7 @@ func removeInvalidCharactersUrl(src string) string {
 			removed.WriteByte(b)
 		case b == 0x3D: // =
 			// If "=" sign found, next byte must also be "="
-			if peek, err := r.Peek(1); err != nil && peek[0] == 0x3D {
+			if peek, err := r.Peek(1); err == nil && peek[0] == 0x3D {
 				removed.WriteByte(b)
 				removed.WriteByte(b)
 				// skip next "=" character


### PR DESCRIPTION
fixes #431 

This PR fixes base64[url]_decode builtin function implementation for single equal character in encoded string.
The single equal character includes - probably encodes line-feed character - and then we will panic for null pointer exeption.

This is my rediculous implementation that wrong condition check so I fixed it.