### PR TITLE
Add VCL_ prefix at scope string in test result printing

### DIFF
--- a/cmd/falco/main.go
+++ b/cmd/falco/main.go
@@ -443,7 +443,7 @@ func runTest(runner *Runner, rslv resolver.Resolver) error {
 				prefix = c.Group + " › "
 			}
 			if c.Error != nil {
-				writeln(redBold, "%s● [%s] %s%s\n", indent(1), c.Scope, prefix, c.Name)
+				writeln(redBold, "%s● [VCL_%s] %s%s\n", indent(1), c.Scope, prefix, c.Name)
 				writeln(red, "%s%s", indent(2), c.Error.Error())
 				switch e := c.Error.(type) {
 				case *ife.AssertionError:
@@ -457,7 +457,7 @@ func runTest(runner *Runner, rslv resolver.Resolver) error {
 				writeln(white, "")
 				failedCount++
 			} else {
-				writeln(green, "%s✓ [%s] %s%s", indent(1), c.Scope, prefix, c.Name)
+				writeln(green, "%s✓ [VCL_%s] %s%s", indent(1), c.Scope, prefix, c.Name)
 				passedCount++
 			}
 		}


### PR DESCRIPTION
Related #434 

This PR adds `VCL_` prefix at scope string in displaying test result
From the issue, `[ERROR]` string recognizes like error in GHA console and it's confusing for the user.

So we add prefix like `[VCL_ERROR]` to avoid confusion.