### PR TITLE
feat(ast): support inline declarations in declare statements

### DIFF
--- a/ast/codec/statement_decode.go
+++ b/ast/codec/statement_decode.go
@@ -113,6 +113,13 @@ func (c *Decoder) decodeDeclareStatement() (*ast.DeclareStatement, error) {
 		return nil, errors.WithStack(err)
 	}
 
+	// Check if a value is present
+	if isExpressionFrame(c.peekFrame()) {
+		if stmt.Value, err = c.decodeExpression(c.nextFrame()); err != nil {
+			return nil, errors.WithStack(err)
+		}
+	}
+
 	return stmt, nil
 }
 

--- a/ast/codec/statement_encode.go
+++ b/ast/codec/statement_encode.go
@@ -90,6 +90,9 @@ func (c *Encoder) encodeDeclareStatement(stmt *ast.DeclareStatement) *Frame {
 
 	w.Write(c.encodeIdent(stmt.Name).Encode())
 	w.Write(c.encodeIdent(stmt.ValueType).Encode())
+	if stmt.Value != nil {
+		w.Write(c.encodeExpression(stmt.Value).Encode())
+	}
 
 	return &Frame{
 		frameType: DECLARE_STATEMENT,

--- a/ast/codec/statement_test.go
+++ b/ast/codec/statement_test.go
@@ -113,14 +113,35 @@ func TestDeclareStatement(t *testing.T) {
 			name: "basic declare statement",
 			input: `
 sub vcl_recv {
-	call some_function;
+	declare local var.V STRING;
 }`,
 			expect: &ast.SubroutineDeclaration{
 				Name: &ast.Ident{Value: "vcl_recv"},
 				Block: &ast.BlockStatement{
 					Statements: []ast.Statement{
-						&ast.CallStatement{
-							Subroutine: &ast.Ident{Value: "some_function"},
+						&ast.DeclareStatement{
+							Name:      &ast.Ident{Value: "var.V"},
+							ValueType: &ast.Ident{Value: "STRING"},
+							Value:     nil,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "declare statement with value",
+			input: `
+sub vcl_recv {
+	declare local var.V STRING = "hello";
+}`,
+			expect: &ast.SubroutineDeclaration{
+				Name: &ast.Ident{Value: "vcl_recv"},
+				Block: &ast.BlockStatement{
+					Statements: []ast.Statement{
+						&ast.DeclareStatement{
+							Name:      &ast.Ident{Value: "var.V"},
+							ValueType: &ast.Ident{Value: "STRING"},
+							Value:     &ast.String{Value: "hello"},
 						},
 					},
 				},

--- a/ast/declare_statement.go
+++ b/ast/declare_statement.go
@@ -8,6 +8,7 @@ type DeclareStatement struct {
 	*Meta
 	Name      *Ident
 	ValueType *Ident
+	Value     Expression
 }
 
 func (d *DeclareStatement) ID() uint64     { return d.Meta.ID }
@@ -22,7 +23,12 @@ func (d *DeclareStatement) String() string {
 	buf.WriteString(paddingLeft(d.InfixComment(inline)))
 	buf.WriteString(" local")
 	buf.WriteString(padding(d.Name.String()))
-	buf.WriteString(d.ValueType.String() + ";")
+	buf.WriteString(d.ValueType.String())
+	if d.Value != nil {
+		buf.WriteString(" = ")
+		buf.WriteString(d.Value.String())
+	}
+	buf.WriteString(";")
 	buf.WriteString(d.TrailingComment(inline))
 	buf.WriteString("\n")
 

--- a/ast/declare_statement_test.go
+++ b/ast/declare_statement_test.go
@@ -22,4 +22,71 @@ declare /* before_local */ local /* before_name */ var.Foo /* after_name */ STRI
 `
 
 	assert(t, declare.String(), expect)
+
+	// Test with a string value
+	declareWithStringValue := &DeclareStatement{
+		Meta: New(T, 0),
+		Name: &Ident{
+			Meta:  New(T, 0),
+			Value: "var.Foo",
+		},
+		ValueType: &Ident{
+			Meta:  New(T, 0),
+			Value: "STRING",
+		},
+		Value: &String{
+			Meta:  New(T, 0),
+			Value: "hello world",
+		},
+	}
+
+	expectWithStringValue := `declare local var.Foo STRING = "hello world";
+`
+
+	assert(t, declareWithStringValue.String(), expectWithStringValue)
+
+	// Test with a string value and comments
+	declareWithStringValueAndComments := &DeclareStatement{
+		Meta: New(T, 0, comments("// leading comment"), comments("// trailing comment"), comments("/* before_local */")),
+		Name: &Ident{
+			Meta:  New(T, 0, comments("/* before_name */"), comments("/* after_name */")),
+			Value: "var.Foo",
+		},
+		ValueType: &Ident{
+			Meta:  New(T, 0, comments(), comments("/* after_type */")),
+			Value: "STRING",
+		},
+		Value: &String{
+			Meta:  New(T, 0, comments(), comments("/* after_value */")),
+			Value: "hello world",
+		},
+	}
+
+	expectWithStringValueAndComments := `// leading comment
+declare /* before_local */ local /* before_name */ var.Foo /* after_name */ STRING /* after_type */ = "hello world" /* after_value */; // trailing comment
+`
+
+	assert(t, declareWithStringValueAndComments.String(), expectWithStringValueAndComments)
+
+	// Test with an integer value
+	declareWithIntegerValue := &DeclareStatement{
+		Meta: New(T, 0),
+		Name: &Ident{
+			Meta:  New(T, 0),
+			Value: "var.answer",
+		},
+		ValueType: &Ident{
+			Meta:  New(T, 0),
+			Value: "INTEGER",
+		},
+		Value: &Integer{
+			Meta:  New(T, 0),
+			Value: 42,
+		},
+	}
+
+	expectWithIntegerValue := `declare local var.answer INTEGER = 42;
+`
+
+	assert(t, declareWithIntegerValue.String(), expectWithIntegerValue)
 }

--- a/formatter/statement_format.go
+++ b/formatter/statement_format.go
@@ -156,7 +156,7 @@ func (f *Formatter) formatBlockStatement(stmt *ast.BlockStatement) string {
 	return trimMutipleLineFeeds(buf.String())
 }
 
-// Format delclare local varialbe statement
+// Format declare local variable statement
 func (f *Formatter) formatDeclareStatement(stmt *ast.DeclareStatement) string {
 	buf := bufferPool.Get().(*bytes.Buffer) // nolint:errcheck
 	defer bufferPool.Put(buf)
@@ -168,6 +168,10 @@ func (f *Formatter) formatDeclareStatement(stmt *ast.DeclareStatement) string {
 	}
 	buf.WriteString("local " + stmt.Name.String())
 	buf.WriteString(" " + stmt.ValueType.String())
+	if stmt.Value != nil {
+		buf.WriteString(" = ")
+		buf.WriteString(f.formatExpression(stmt.Value).ChunkedString(stmt.Nest, buf.Len()))
+	}
 	buf.WriteString(";")
 
 	return buf.String()

--- a/formatter/statement_format_test.go
+++ b/formatter/statement_format_test.go
@@ -150,6 +150,21 @@ func TestFormatDeclareStatement(t *testing.T) {
 }
 `,
 		},
+		{
+			name: "declare statement with value",
+			input: `sub vcl_recv {
+	// declare leading comment
+	declare /* before_local */ local /* after_local */ var.FOO /* after_name */ STRING /* after_type */ = /* after_equal */ "Hello" /* after_value */; // declare trailing comment
+}
+`,
+			expect: `sub vcl_recv {
+  // declare leading comment
+  declare /* before_local */ local /* after_local */ var.FOO /* after_name */ STRING /* after_type */ = /* after_equal */
+                                                                                                        "Hello"
+                                                                                                        /* after_value */;  // declare trailing comment
+}
+`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/parser/statement_parser_test.go
+++ b/parser/statement_parser_test.go
@@ -5632,6 +5632,293 @@ sub vcl_recv {
 		}
 		assert(t, vcl, expect)
 	})
+
+	t.Run("With string value", func(t *testing.T) {
+		input := `// Subroutine
+sub vcl_recv {
+	// Leading comment
+	declare local var.hello STRING = "world!"; // Trailing comment
+}`
+
+		expect := &ast.VCL{
+			Statements: []ast.Statement{
+				&ast.SubroutineDeclaration{
+					Meta: &ast.Meta{
+						Token: token.Token{
+							Type:     token.SUBROUTINE,
+							Literal:  "sub",
+							Line:     2,
+							Position: 1,
+						},
+						Leading:            comments("// Subroutine"),
+						Trailing:           comments(),
+						Infix:              comments(),
+						Nest:               0,
+						PreviousEmptyLines: 0,
+						EndLine:            5,
+						EndPosition:        1,
+					},
+					Name: &ast.Ident{
+						Meta: &ast.Meta{
+							Token: token.Token{
+								Type:     token.IDENT,
+								Literal:  "vcl_recv",
+								Line:     2,
+								Position: 5,
+							},
+							Leading:            comments(),
+							Trailing:           comments(),
+							Infix:              comments(),
+							Nest:               0,
+							PreviousEmptyLines: 0,
+							EndLine:            2,
+							EndPosition:        12,
+						},
+						Value: "vcl_recv",
+					},
+					Block: &ast.BlockStatement{
+						Meta: &ast.Meta{
+							Token: token.Token{
+								Type:     token.LEFT_BRACE,
+								Literal:  "{",
+								Line:     2,
+								Position: 14,
+							},
+							Leading:            comments(),
+							Trailing:           comments(),
+							Infix:              comments(),
+							Nest:               1,
+							PreviousEmptyLines: 0,
+							EndLine:            5,
+							EndPosition:        1,
+						},
+						Statements: []ast.Statement{
+							&ast.DeclareStatement{
+								Meta: &ast.Meta{
+									Token: token.Token{
+										Type:     token.DECLARE,
+										Literal:  "declare",
+										Line:     4,
+										Position: 2,
+									},
+									Leading:            comments("// Leading comment"),
+									Trailing:           comments("// Trailing comment"),
+									Infix:              comments(),
+									Nest:               1,
+									PreviousEmptyLines: 0,
+									EndLine:            4,
+									EndPosition:        42,
+								},
+								Name: &ast.Ident{
+									Meta: &ast.Meta{
+										Token: token.Token{
+											Type:     token.IDENT,
+											Literal:  "var.hello",
+											Line:     4,
+											Position: 16,
+										},
+										Leading:            comments(),
+										Trailing:           comments(),
+										Infix:              comments(),
+										Nest:               1,
+										PreviousEmptyLines: 0,
+										EndLine:            4,
+										EndPosition:        24,
+									},
+									Value: "var.hello",
+								},
+								ValueType: &ast.Ident{
+									Meta: &ast.Meta{
+										Token: token.Token{
+											Type:     token.IDENT,
+											Literal:  "STRING",
+											Line:     4,
+											Position: 26,
+										},
+										Leading:            comments(),
+										Trailing:           comments(),
+										Infix:              comments(),
+										Nest:               1,
+										PreviousEmptyLines: 0,
+										EndLine:            4,
+										EndPosition:        31,
+									},
+									Value: "STRING",
+								},
+								Value: &ast.String{
+									Meta: &ast.Meta{
+										Token: token.Token{
+											Type:     token.STRING,
+											Literal:  "world!",
+											Line:     4,
+											Position: 35,
+										},
+										Leading:            comments(),
+										Trailing:           comments(),
+										Infix:              comments(),
+										Nest:               1,
+										PreviousEmptyLines: 0,
+										EndLine:            4,
+										EndPosition:        42,
+									},
+									Value: "world!",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		vcl, err := New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Errorf("%+v", err)
+		}
+		assert(t, vcl, expect)
+	})
+
+	t.Run("With integer value", func(t *testing.T) {
+		input := `// Subroutine
+sub vcl_recv {
+	// Leading comment
+	declare local var.answer INTEGER = 42; // Trailing comment
+}`
+
+		expect := &ast.VCL{
+			Statements: []ast.Statement{
+				&ast.SubroutineDeclaration{
+					Meta: &ast.Meta{
+						Token: token.Token{
+							Type:     token.SUBROUTINE,
+							Literal:  "sub",
+							Line:     2,
+							Position: 1,
+						},
+						Leading:            comments("// Subroutine"),
+						Trailing:           comments(),
+						Infix:              comments(),
+						Nest:               0,
+						PreviousEmptyLines: 0,
+						EndLine:            5,
+						EndPosition:        1,
+					},
+					Name: &ast.Ident{
+						Meta: &ast.Meta{
+							Token: token.Token{
+								Type:     token.IDENT,
+								Literal:  "vcl_recv",
+								Line:     2,
+								Position: 5,
+							},
+							Leading:            comments(),
+							Trailing:           comments(),
+							Infix:              comments(),
+							Nest:               0,
+							PreviousEmptyLines: 0,
+							EndLine:            2,
+							EndPosition:        12,
+						},
+						Value: "vcl_recv",
+					},
+					Block: &ast.BlockStatement{
+						Meta: &ast.Meta{
+							Token: token.Token{
+								Type:     token.LEFT_BRACE,
+								Literal:  "{",
+								Line:     2,
+								Position: 14,
+							},
+							Leading:            comments(),
+							Trailing:           comments(),
+							Infix:              comments(),
+							Nest:               1,
+							PreviousEmptyLines: 0,
+							EndLine:            5,
+							EndPosition:        1,
+						},
+						Statements: []ast.Statement{
+							&ast.DeclareStatement{
+								Meta: &ast.Meta{
+									Token: token.Token{
+										Type:     token.DECLARE,
+										Literal:  "declare",
+										Line:     4,
+										Position: 2,
+									},
+									Leading:            comments("// Leading comment"),
+									Trailing:           comments("// Trailing comment"),
+									Infix:              comments(),
+									Nest:               1,
+									PreviousEmptyLines: 0,
+									EndLine:            4,
+									EndPosition:        38,
+								},
+								Name: &ast.Ident{
+									Meta: &ast.Meta{
+										Token: token.Token{
+											Type:     token.IDENT,
+											Literal:  "var.answer",
+											Line:     4,
+											Position: 16,
+										},
+										Leading:            comments(),
+										Trailing:           comments(),
+										Infix:              comments(),
+										Nest:               1,
+										PreviousEmptyLines: 0,
+										EndLine:            4,
+										EndPosition:        25,
+									},
+									Value: "var.answer",
+								},
+								ValueType: &ast.Ident{
+									Meta: &ast.Meta{
+										Token: token.Token{
+											Type:     token.IDENT,
+											Literal:  "INTEGER",
+											Line:     4,
+											Position: 27,
+										},
+										Leading:            comments(),
+										Trailing:           comments(),
+										Infix:              comments(),
+										Nest:               1,
+										PreviousEmptyLines: 0,
+										EndLine:            4,
+										EndPosition:        33,
+									},
+									Value: "INTEGER",
+								},
+								Value: &ast.Integer{
+									Meta: &ast.Meta{
+										Token: token.Token{
+											Type:     token.INT,
+											Literal:  "42",
+											Line:     4,
+											Position: 37,
+										},
+										Leading:            comments(),
+										Trailing:           comments(),
+										Infix:              comments(),
+										Nest:               1,
+										PreviousEmptyLines: 0,
+										EndLine:            4,
+										EndPosition:        38,
+									},
+									Value: 42,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		vcl, err := New(lexer.NewFromString(input)).ParseVCL()
+		if err != nil {
+			t.Errorf("%+v", err)
+		}
+		assert(t, vcl, expect)
+	})
+
 	t.Run("Full comments", func(t *testing.T) {
 		input := `// Subroutine
 sub vcl_recv {
@@ -6728,8 +7015,8 @@ sub vcl_recv {
 									Right: &ast.String{
 										Meta: &ast.Meta{
 											Token: token.Token{
-												Type: token.STRING,
-												Literal: "	timestamp:",
+												Type:     token.STRING,
+												Literal:  "	timestamp:",
 												Line:     5,
 												Position: 31,
 											},
@@ -6741,7 +7028,7 @@ sub vcl_recv {
 											EndLine:            5,
 											EndPosition:        45,
 										},
-										Value: "	timestamp:",
+										Value:      "	timestamp:",
 										LongString: true,
 									},
 									Left: &ast.InfixExpression{


### PR DESCRIPTION
Fastly now supports declarations with inline assignments: https://fiddle.fastly.dev/fiddle/0583d2c4

- Add optional value assignment to DeclareStatement
- Update parser to handle expressions after the type declaration
- Implement encoding/decoding support for the new value field
- Update string representation and formatting for declare statements with values
- Add comprehensive tests for the new functionality