### PR TITLE
feat(linter): add hit_for_pass to valid return values for vcl_fetch s…

### DIFF
--- a/linter/statement_linter.go
+++ b/linter/statement_linter.go
@@ -536,7 +536,7 @@ func (l *Linter) lintReturnStatement(stmt *ast.ReturnStatement, ctx *context.Con
 		expects = append(expects, "pass")
 	case context.FETCH:
 		// https://developer.fastly.com/reference/vcl/subroutines/fetch/
-		expects = append(expects, "deliver", "deliver_stale", "pass", "error", "restart")
+		expects = append(expects, "deliver", "deliver_stale", "hit_for_pass", "pass", "error", "restart")
 	case context.ERROR:
 		// https://developer.fastly.com/reference/vcl/subroutines/error/
 		expects = append(expects, "deliver", "deliver_stale", "restart")


### PR DESCRIPTION
…ubroutine

Although it's not very documented, Fastly supports `return(hit_for_pass)` in a `vcl_fetch()` subroutine. It is an alias for `return(pass)`.

It is mentioned briefly at:
https://docs.fastly.com/en/guides/understanding-the-different-pass-action-behaviors

Related: https://github.com/fastly/vscode-fastly-vcl/issues/26