### PR TITLE
dedupe test target files

### DIFF
--- a/examples/testing/default/default.vcl
+++ b/examples/testing/default/default.vcl
@@ -38,7 +38,7 @@ sub error_response {
 
 sub vcl_recv {
 
-  #Fastly recv
+  #FASTLY recv
   set req.backend = httpbin_org;
   set req.http.Foo = {" foo bar baz "};
   call custom_logger;

--- a/tester/finder.go
+++ b/tester/finder.go
@@ -49,3 +49,19 @@ func findTestTargetFiles(root, filter string) ([]string, error) {
 	}
 	return f.files, nil
 }
+
+// dedupe testing target files
+func dedupeFiles(files []string) []string {
+	var deduped []string
+	stack := make(map[string]struct{})
+
+	for i := range files {
+		if _, ok := stack[files[i]]; ok {
+			continue
+		}
+		deduped = append(deduped, files[i])
+		stack[files[i]] = struct{}{}
+	}
+
+	return deduped
+}

--- a/tester/finder_test.go
+++ b/tester/finder_test.go
@@ -1,0 +1,25 @@
+package tester
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestDedupleFiles(t *testing.T) {
+	files := []string{
+		"/a/b/c/main.test.vcl",
+		"/a/b/c/main.test.vcl", // duplicated
+		"/a/b/c/main2.test.vcl",
+	}
+
+	deduped := dedupeFiles(files)
+	expect := []string{
+		"/a/b/c/main.test.vcl",
+		"/a/b/c/main2.test.vcl",
+	}
+
+	if diff := cmp.Diff(expect, deduped); diff != "" {
+		t.Errorf("dedupled files mismatch, diff=%s", diff)
+	}
+}

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -70,7 +70,7 @@ func (t *Tester) listTestFiles(main string) ([]string, error) {
 		testFiles = append(testFiles, files...)
 	}
 
-	return testFiles, nil
+	return dedupeFiles(testFiles), nil
 }
 
 // Only expose function for running tests


### PR DESCRIPTION
This PR fixes a problem that finding test target files will be duplicated.

Current implementation finds test target files for each `include_paths` - place of main vcl and additional paths - then falco finds test target file for each paths. Some time it causes duplication:

```
+ tests
  - main.test.vcl
- main.vcl
```

For example, some project has above structure and provide `--include_paths=./tests`, the search paths will be:

- . (place of main.vcl, current directory)
- tests

falco finds `main.test.vcl` from both search paths, and then `main.test.vcl` will be duplicated and run tests multiply.
To prevent this problem, we should dedupe for target files.
