### PR TITLE
support hit_for_pass return state in vcl_fetch directive

### DIFF
--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -579,7 +579,7 @@ func (i *Interpreter) ProcessFetch() error {
 	}
 
 	switch state {
-	case DELIVER, DELIVER_STALE, PASS:
+	case DELIVER, DELIVER_STALE, PASS, HIT_FOR_PASS:
 		i.Debugger.Message(fmt.Sprintf("Move state: %s -> DELIVER", i.ctx.Scope))
 		err = i.ProcessDeliver()
 	case ERROR:

--- a/interpreter/state.go
+++ b/interpreter/state.go
@@ -16,6 +16,7 @@ const (
 	DELIVER_STALE  State = "deliver_stale"
 	LOG            State = "log"
 	END            State = "end"
+	HIT_FOR_PASS   State = "hit_for_pass" // alias for pass
 	INTERNAL_ERROR State = "_internal_error_"
 	BARE_RETURN    State = "_bare_return_"
 )


### PR DESCRIPTION
This PR follows #440 that supports `return(hit_for_pass)` state in `vcl_fetch` directive.
The `hit_for_pass` is an alias for `pass` so add support for the same behavior as `pass`.

