### PR TITLE
Fix/objective header get only key name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ lint:
 modernize:
 	go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -test ./...
 
-local: test lint
+local: test lint modernize
 	go build ./cmd/falco
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,6 @@ modernize:
 	go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -test ./...
 
 local: test lint modernize
-	go build ./cmd/falco
 
 clean:
 	rm ./dist/falco-*

--- a/cmd/falco/runner_test.go
+++ b/cmd/falco/runner_test.go
@@ -377,6 +377,12 @@ func TestTester(t *testing.T) {
 			filter: "*regex.test.vcl",
 			passes: 4,
 		},
+		{
+			name:   "header subfield dealing test",
+			main:   "../../examples/testing/subfield-header-dealing/default.vcl",
+			filter: "*default.test.vcl",
+			passes: 10,
+		},
 	}
 
 	for _, tt := range tests {

--- a/examples/testing/subfield-header-dealing/default.test.vcl
+++ b/examples/testing/subfield-header-dealing/default.test.vcl
@@ -1,0 +1,80 @@
+// @scope: recv
+// @suite: SET VARS VALUE
+sub test_recv {
+    set req.http.VARS = "";
+    set req.http.VARS:VALUE = "V";
+    assert.equal(req.http.VARS, "VALUE=V");
+}
+
+// @scope: recv
+// @suite: SET NOT-INITIALIZED VARS VALUE
+sub test_recv {
+    set req.http.VARS:VALUE = "V";
+    assert.equal(req.http.VARS, "VALUE=V");
+}
+
+// @scope: recv
+// @suite: SET MULTIPLE VARS VALUE
+sub test_recv {
+    set req.http.VARS = "";
+    set req.http.VARS:VALUE = "V";
+    set req.http.VARS:VALUE2 = "V2";
+    assert.equal(req.http.VARS, "VALUE=V,VALUE2=V2");
+}
+
+// @scope: recv
+// @suite: SET EMPTY VARS VALUE
+sub test_recv {
+    set req.http.VARS = "";
+    set req.http.VARS:VALUE = "";
+    assert.equal(req.http.VARS, "VALUE");
+}
+
+// @scope: recv
+// @suite: SET MULTIPLE EMPTY VARS VALUE AND SET ACTUAL STRING
+sub test_recv {
+    set req.http.VARS = "";
+    set req.http.VARS:VALUE = "";
+    set req.http.VARS:VALUE2 = "";
+    assert.equal(req.http.VARS, "VALUE,VALUE2");
+
+    set req.http.VARS:VALUE = "V";
+    assert.equal(req.http.VARS, "VALUE2,VALUE=V");
+}
+
+// @scope: recv
+// @suite: UNSET VARS ALL VALUE
+sub test_recv {
+    set req.http.VARS = "";
+    set req.http.VARS:VALUE = "V";
+    unset req.http.VARS:VALUE;
+    assert.is_notset(req.http.VARS);
+}
+
+// @scope: recv
+// @suite: UNSET VARS VALUE
+sub test_recv {
+    set req.http.VARS = "";
+    set req.http.VARS:VALUE = "V";
+    set req.http.VARS:VALUE2 = "V2";
+    unset req.http.VARS:VALUE;
+    assert.equal(req.http.VARS, "VALUE2=V2");
+}
+
+// @scope: recv
+// @suite: OVERRIDE VARS VALUE
+sub test_recv {
+    set req.http.VARS = "";
+    set req.http.VARS:VALUE = "V";
+    set req.http.VARS:VALUE = "O";
+    assert.equal(req.http.VARS, "VALUE=O");
+}
+
+// @scope: recv
+// @suite: SET NULL VALUE
+sub test_recv {
+    set req.http.VARS = "";
+    set req.http.VARS:VALUE = "V";
+    set req.http.VARS:VALUE = req.http.NULL;
+    assert.equal(req.http.VARS, "VALUE");
+}

--- a/interpreter/variable/field.go
+++ b/interpreter/variable/field.go
@@ -95,7 +95,14 @@ func setField(subject, key string, val value.Value, sep string) string {
 			// Fastly truncates values at newlines after quoting the value.
 			sVal, _, _ = strings.Cut(`"`+escaped+`"`, "\n")
 		}
-		kv = fmt.Sprintf("%s=%s", key, sVal)
+
+		if sVal == "" {
+			// If value string is empty, only set key name without equal sign
+			kv = key
+		} else {
+			// Otherwise, set key and value with concatenating equal sign
+			kv = fmt.Sprintf("%s=%s", key, sVal)
+		}
 	}
 
 	if subject == "" {

--- a/interpreter/variable/field_test.go
+++ b/interpreter/variable/field_test.go
@@ -68,6 +68,7 @@ func TestGetField(t *testing.T) {
 		{input: `a=c\,adf,b=asdf`, field: "c", notSet: true},
 		{input: `a=c\,adf,b=asdf`, field: "adf", expect: ""},
 		{input: `a=c\,adf,b=asdf`, field: "b", expect: "asdf"},
+		{input: `a=`, field: "a", expect: ""},
 	}
 
 	for i, tt := range tests {

--- a/interpreter/variable/header_test.go
+++ b/interpreter/variable/header_test.go
@@ -124,6 +124,13 @@ func TestSetResponseHeaderValueEmpty(t *testing.T) {
 	if ret.Value != "VALUE2,VALUE=V" {
 		t.Errorf("Return value unmatch, expect=%s, got=%s", "VALUE2,VALUE=V", ret.Value)
 	}
+
+	// Can unset empty key
+	unsetRequestHeaderValue(req, "VARS:VALUE2")
+	ret = getRequestHeaderValue(req, "VARS")
+	if ret.Value != "VALUE=V" {
+		t.Errorf("Return value unmatch, expect=%s, got=%s", "VALUE=V", ret.Value)
+	}
 }
 
 func TestSetResponseHeaderValue(t *testing.T) {

--- a/interpreter/variable/header_test.go
+++ b/interpreter/variable/header_test.go
@@ -105,6 +105,27 @@ func TestSetRequestHeaderValueOverwrite(t *testing.T) {
 	}
 }
 
+func TestSetResponseHeaderValueEmpty(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+	// Set empty header values
+	setRequestHeaderValue(req, "VARS", &value.String{Value: ""})
+	setRequestHeaderValue(req, "VARS:VALUE", &value.String{Value: ""})
+	setRequestHeaderValue(req, "VARS:VALUE2", &value.String{Value: ""})
+
+	// Each field value does not have equal signs, only present key name
+	ret := getRequestHeaderValue(req, "VARS")
+	if ret.Value != "VALUE,VALUE2" {
+		t.Errorf("Return value unmatch, expect=%s, got=%s", "VALUE,VALUE2", ret.Value)
+	}
+
+	// Overwrite partial key and value
+	setRequestHeaderValue(req, "VARS:VALUE", &value.String{Value: "V"})
+	ret = getRequestHeaderValue(req, "VARS")
+	if ret.Value != "VALUE2,VALUE=V" {
+		t.Errorf("Return value unmatch, expect=%s, got=%s", "VALUE2,VALUE=V", ret.Value)
+	}
+}
+
 func TestSetResponseHeaderValue(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
Fixes #236 

I found we still have a tiny bug for objective header value dealing.
When VCL sets a request header with objective field and empty value, the value should get subfield key name only.

```vcl
// initialize
set req.http.VARS = "";
// add header subfield with empty value
set req.http.VARS:V = "";
// then the header presents key name only.
log req.http.VARS;  #=> V
```

This PR fixes remaining problem and passes all expected tests which are written in #236 (confirmed by adding tests)
The small example on fiddle: https://fiddle.fastly.dev/fiddle/d138836f