### PR TITLE
Implement skipping test feature

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -173,9 +173,34 @@ falco recognizes `@scope` annotation for execution scope.
 `@scope: deliver` means the testing should run on `DELIVER` scope.
 You can specify multiply by separating commas like `@scope: hit,pass`.
 
+```vcl
+// @scope: recv,fetch,pass
+sub some_test_suite {
+    ...
+}
+```
+
 ### Suite Name
 
 You can specify the test suite name with `@suite` annotation value. Otherwise, the suite name will be set as the subroutine name.
+
+```vcl
+// @suite: test suite name here
+sub some_test_suite {
+    ...
+}
+```
+
+### Skipping Test
+
+You can skip test case by adding `@skip` annotation comment. falco recognizes this annotation and skip testing.
+
+```vcl
+// @skip
+sub some_test_suite {
+    ...
+}
+```
 
 ### Testing preparation
 

--- a/tester/entity.go
+++ b/tester/entity.go
@@ -14,6 +14,7 @@ type TestCase struct {
 	Error error
 	Scope string
 	Time  int64 // msec order
+	Skip  bool
 }
 
 func (t *TestCase) MarshalJSON() ([]byte, error) {

--- a/tester/metadata.go
+++ b/tester/metadata.go
@@ -1,0 +1,86 @@
+package tester
+
+import (
+	"strings"
+
+	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/interpreter/context"
+)
+
+// Define test metadata.
+// This struct fields are filled from annotation comments
+type Metadata struct {
+	Name   string
+	Scopes []context.Scope
+	Skip   bool
+}
+
+// Find test metadata from annotation comment
+func getTestMetadata(sub *ast.SubroutineDeclaration) *Metadata {
+	metadata := &Metadata{
+		Name:   sub.Name.Value,
+		Scopes: []context.Scope{},
+		Skip:   false,
+	}
+
+	comments := sub.GetMeta().Leading
+	for i := range comments {
+		l := strings.TrimLeft(comments[i].Value, " */#")
+		if !strings.HasPrefix(l, "@") {
+			continue
+		}
+		// If @suite annotation found, use it as suite name
+		if strings.HasPrefix(l, "@suite:") {
+			metadata.Name = strings.TrimSpace(strings.TrimPrefix(l, "@suite:"))
+			continue
+		}
+
+		// If @skip annotation found. mark as skipped test
+		if strings.HasPrefix(l, "@skip") {
+			metadata.Skip = true
+		}
+
+		var Scopes []string
+		if strings.HasPrefix(l, "@scope:") {
+			Scopes = strings.Split(strings.TrimPrefix(l, "@scope:"), ",")
+		} else {
+			Scopes = strings.Split(strings.TrimPrefix(l, "@"), ",")
+		}
+		for _, scope := range Scopes {
+			s := context.ScopeByString(strings.TrimSpace(scope))
+			if s != context.UnknownScope {
+				metadata.Scopes = append(metadata.Scopes, s)
+			}
+		}
+	}
+
+	// If test scope is found, return metadata
+	if len(metadata.Scopes) > 0 {
+		return metadata
+	}
+
+	// If we could not determine scope from annotation, try to find from subroutine name.
+	switch {
+	case strings.HasSuffix(sub.Name.Value, "_recv"):
+		metadata.Scopes = append(metadata.Scopes, context.RecvScope)
+	case strings.HasSuffix(sub.Name.Value, "_hash"):
+		metadata.Scopes = append(metadata.Scopes, context.HashScope)
+	case strings.HasSuffix(sub.Name.Value, "_miss"):
+		metadata.Scopes = append(metadata.Scopes, context.MissScope)
+	case strings.HasSuffix(sub.Name.Value, "_pass"):
+		metadata.Scopes = append(metadata.Scopes, context.PassScope)
+	case strings.HasSuffix(sub.Name.Value, "_fetch"):
+		metadata.Scopes = append(metadata.Scopes, context.FetchScope)
+	case strings.HasSuffix(sub.Name.Value, "_deliver"):
+		metadata.Scopes = append(metadata.Scopes, context.DeliverScope)
+	case strings.HasSuffix(sub.Name.Value, "_error"):
+		metadata.Scopes = append(metadata.Scopes, context.ErrorScope)
+	case strings.HasSuffix(sub.Name.Value, "_log"):
+		metadata.Scopes = append(metadata.Scopes, context.LogScope)
+	default:
+		// Set RECV scope as default
+		metadata.Scopes = append(metadata.Scopes, context.RecvScope)
+	}
+
+	return metadata
+}

--- a/tester/metadata_test.go
+++ b/tester/metadata_test.go
@@ -1,0 +1,95 @@
+package tester
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/lexer"
+	"github.com/ysugimoto/falco/parser"
+)
+
+func TestGetMetadata(t *testing.T) {
+	tests := []struct {
+		name   string
+		vcl    string
+		expect *Metadata
+	}{
+		{
+			name: "basic metadata",
+			vcl: `
+// @suite: basic metadata test
+// @scope: recv
+sub test_subroutine {}
+`,
+			expect: &Metadata{
+				Name:   "basic metadata test",
+				Scopes: []context.Scope{context.RecvScope},
+			},
+		},
+		{
+			name: "use subroutine name when suite annotation is not found",
+			vcl: `
+// @scope: recv
+sub test_subroutine {}
+`,
+			expect: &Metadata{
+				Name:   "test_subroutine",
+				Scopes: []context.Scope{context.RecvScope},
+			},
+		},
+		{
+			name: "default scope is Recv when scope annotation is not found",
+			vcl: `
+// @suite: metadata test
+sub test_subroutine {}
+`,
+			expect: &Metadata{
+				Name:   "metadata test",
+				Scopes: []context.Scope{context.RecvScope},
+			},
+		},
+		{
+			name: "multiple scopes",
+			vcl: `
+// @suite: metadata test
+// @scope: fetch,pass,log
+sub test_subroutine {}
+`,
+			expect: &Metadata{
+				Name:   "metadata test",
+				Scopes: []context.Scope{context.FetchScope, context.PassScope, context.LogScope},
+			},
+		},
+		{
+			name: "skipped",
+			vcl: `
+// @suite: metadata test
+// @scope: recv
+// @skip
+sub test_subroutine {}
+`,
+			expect: &Metadata{
+				Name:   "metadata test",
+				Scopes: []context.Scope{context.RecvScope},
+				Skip:   true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vcl, err := parser.New(lexer.NewFromString(tt.vcl)).ParseVCL()
+			if err != nil {
+				t.Errorf("VCL parser error: %s", err)
+				return
+			}
+			sub := vcl.Statements[0].(*ast.SubroutineDeclaration)
+			actual := getTestMetadata(sub)
+			if diff := cmp.Diff(tt.expect, actual); diff != "" {
+				t.Errorf("Parsed metadata mismatch, diff=%s", diff)
+			}
+		})
+	}
+}

--- a/tester/shared/counter.go
+++ b/tester/shared/counter.go
@@ -4,6 +4,7 @@ type Counter struct {
 	Asserts int `json:"asserts"`
 	Passes  int `json:"passes"`
 	Fails   int `json:"fails"`
+	Skips   int `json:"skips"`
 }
 
 func NewCounter() *Counter {
@@ -18,4 +19,8 @@ func (c *Counter) Pass() {
 func (c *Counter) Fail() {
 	c.Asserts++
 	c.Fails++
+}
+
+func (c *Counter) Skip() {
+	c.Skips++
 }


### PR DESCRIPTION
This PR implements skipping test case by adding `@skip` annotation on the leading comment of testing subroutine.

### Use Case

From some reason, user want to skip some test case in the test file. Now user can apply annotation to skip test case:

```vcl
// @suite: skipping test
// @scope: recv
// @skip <- apply this annotation to skip this test case
sub test_subroutine {
  ...
}
```