### PR TITLE
implement wildcard support for unset statement

### DIFF
--- a/interpreter/variable/header.go
+++ b/interpreter/variable/header.go
@@ -86,6 +86,19 @@ func setResponseHeaderValue(r *http.Response, name string, val value.Value) {
 }
 
 func unsetRequestHeaderValue(r *http.Request, name string) {
+	// If unset header name ends with "*", remove all matched headers
+	if strings.HasSuffix(name, "*") {
+		// Note that the wildcard does not work for header subfield
+		// ref: https://fiddle.fastly.dev/fiddle/288403c5
+		name = strings.TrimSuffix(name, "*")
+		for key := range r.Header {
+			if strings.HasPrefix(key, name) {
+				r.Header.Del(key)
+			}
+		}
+		return
+	}
+
 	name, key, found := strings.Cut(name, ":")
 	if !found {
 		r.Header.Del(name)
@@ -148,6 +161,19 @@ func removeCookieByName(r *http.Request, cookieName string) {
 }
 
 func unsetResponseHeaderValue(r *http.Response, name string) {
+	// If unset header name ends with "*", remove all matched headers
+	if strings.HasSuffix(name, "*") {
+		// Note that the wildcard does not work for header subfield
+		// ref: https://fiddle.fastly.dev/fiddle/288403c5
+		name = strings.TrimSuffix(name, "*")
+		for key := range r.Header {
+			if strings.HasPrefix(key, name) {
+				r.Header.Del(key)
+			}
+		}
+		return
+	}
+
 	name, key, found := strings.Cut(name, ":")
 	if !found {
 		r.Header.Del(name)

--- a/interpreter/variable/header_test.go
+++ b/interpreter/variable/header_test.go
@@ -204,6 +204,50 @@ func TestUnsetRequestHeaderValue(t *testing.T) {
 	}
 }
 
+func TestUnsetRequestHeaderValueWildcard(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		expects map[string]value.Value
+	}{
+		{
+			name: "unset simple wildcard fields",
+			key:  "X-*",
+			expects: map[string]value.Value{
+				"X-SomeHeader-1": &value.String{IsNotSet: true},
+				"X-SomeHeader-2": &value.String{IsNotSet: true},
+			},
+		},
+		{
+			name: "subfiled wildcard does not be delete",
+			key:  "VARS:VALUE*",
+			expects: map[string]value.Value{
+				"VARS:VALUE1": &value.String{Value: "foo"},
+				"VARS:VALUE2": &value.String{Value: "bar"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+			req.Header.Set("X-SomeHeader-1", "foo")
+			req.Header.Set("X-SomeHeader-2", "bar")
+			setRequestHeaderValue(req, "VARS:VALUE1", &value.String{Value: "foo"})
+			setRequestHeaderValue(req, "VARS:VALUE2", &value.String{Value: "bar"})
+
+			unsetRequestHeaderValue(req, tt.key)
+
+			for key, val := range tt.expects {
+				ret := getRequestHeaderValue(req, key)
+				if diff := cmp.Diff(ret, val); diff != "" {
+					t.Errorf("Unset result mismatch, diff=%s", diff)
+				}
+			}
+		})
+	}
+}
+
 func TestUnsetResponseHeaderValue(t *testing.T) {
 	tests := []struct {
 		name string
@@ -226,6 +270,51 @@ func TestUnsetResponseHeaderValue(t *testing.T) {
 		if diff := cmp.Diff(ret, &value.String{IsNotSet: true}); diff != "" {
 			t.Errorf("Unset value still not empty, diff=%s", diff)
 		}
+	}
+}
+
+func TestUnsetResponseHeaderValueWildcard(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		expects map[string]value.Value
+	}{
+		{
+			name: "unset simple wildcard fields",
+			key:  "X-*",
+			expects: map[string]value.Value{
+				"X-SomeHeader-1": &value.String{IsNotSet: true},
+				"X-SomeHeader-2": &value.String{IsNotSet: true},
+			},
+		},
+		{
+			name: "subfiled wildcard does not be delete",
+			key:  "VARS:VALUE*",
+			expects: map[string]value.Value{
+				"VARS:VALUE1": &value.String{Value: "foo"},
+				"VARS:VALUE2": &value.String{Value: "bar"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			header := http.Header{}
+			header.Set("X-SomeHeader-1", "foo")
+			header.Set("X-SomeHeader-2", "bar")
+			resp := &http.Response{Header: header}
+			setResponseHeaderValue(resp, "VARS:VALUE1", &value.String{Value: "foo"})
+			setResponseHeaderValue(resp, "VARS:VALUE2", &value.String{Value: "bar"})
+
+			unsetResponseHeaderValue(resp, tt.key)
+
+			for key, val := range tt.expects {
+				ret := getResponseHeaderValue(resp, key)
+				if diff := cmp.Diff(ret, val); diff != "" {
+					t.Errorf("Unset result mismatch, diff=%s", diff)
+				}
+			}
+		})
 	}
 }
 

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -368,9 +368,10 @@ func (l *Lexer) NextToken() token.Token {
 				return t
 			}
 
-			// Read more neighbor digit, dot, hyphen and colon character
-			// in order to lex digit contained identifier like "version4", "req.http.Cookie:session" string
-			for l.char == '-' || l.char == '.' || l.char == ':' || isDigit(l.char) {
+			// Read more neighbor digit, dot, hyphen, asterisk and colon character
+			// in order to lex digit contained identifier like "version4", "req.http.Cookie:session" string.
+			// For asterisk ('*'), support wildcard prefix match for unset/remove statement.
+			for l.char == '-' || l.char == '.' || l.char == ':' || l.char == '*' || isDigit(l.char) {
 				literal += string(l.char)
 				l.readChar()
 				literal += l.readIdentifier()

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -74,6 +74,7 @@ sub vcl_recv {
 		error 750;
 	}
 
+	unset req.http.X-*;
 	add req.http.Cookie:session = uuid.version4();
 	esi;
 	log syslog "foo";
@@ -424,6 +425,12 @@ aabbccddIieEffggHHhEXAMPLEPUBLICKEY
 		{Type: token.LF, Literal: "\n"},
 		{Type: token.RIGHT_BRACE, Literal: "}"},
 		{Type: token.LF, Literal: "\n"},
+		{Type: token.LF, Literal: "\n"},
+
+		// wildcard unset
+		{Type: token.UNSET, Literal: "unset"},
+		{Type: token.IDENT, Literal: "req.http.X-*"},
+		{Type: token.SEMICOLON, Literal: ";"},
 		{Type: token.LF, Literal: "\n"},
 
 		{Type: token.ADD, Literal: "add"},

--- a/linter/helper_test.go
+++ b/linter/helper_test.go
@@ -1,0 +1,60 @@
+package linter
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestIsValidVariableNameWithWildcard(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect bool
+	}{
+		{
+			name:   "valid",
+			input:  "req.http.Foo",
+			expect: true,
+		},
+		{
+			name:   "valid with wildcard",
+			input:  "req.http.X-*",
+			expect: true,
+		},
+		{
+			name:   "valid with wildcard with subfield",
+			input:  "req.http.VARS:VAL*",
+			expect: true,
+		},
+		{
+			name:   "invalid character included",
+			input:  "req.http&Foo",
+			expect: false,
+		},
+		{
+			name:   "invalid with wildcard",
+			input:  "req.http.X-*Bar",
+			expect: false,
+		},
+		{
+			name:   "invalid with first name of wildcard",
+			input:  "req.http.*",
+			expect: false,
+		},
+		{
+			name:   "invalid for wildcard present after the colon",
+			input:  "req.http.VARS:*",
+			expect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := isValidVariableNameWithWildcard(tt.input)
+			if diff := cmp.Diff(tt.expect, actual); diff != "" {
+				t.Errorf("function result mismatch, diff=%s", diff)
+			}
+		})
+	}
+}

--- a/linter/statement_linter.go
+++ b/linter/statement_linter.go
@@ -194,7 +194,7 @@ PASS:
 }
 
 func (l *Linter) lintUnsetStatement(stmt *ast.UnsetStatement, ctx *context.Context) types.Type {
-	if !isValidVariableName(stmt.Ident.Value) {
+	if !isValidVariableNameWithWildcard(stmt.Ident.Value) {
 		l.Error(InvalidName(stmt.Ident.GetMeta(), stmt.Ident.Value, "unset").Match(UNSET_STATEMENT_SYNTAX))
 	}
 
@@ -215,7 +215,7 @@ func (l *Linter) lintUnsetStatement(stmt *ast.UnsetStatement, ctx *context.Conte
 }
 
 func (l *Linter) lintRemoveStatement(stmt *ast.RemoveStatement, ctx *context.Context) types.Type {
-	if !isValidVariableName(stmt.Ident.Value) {
+	if !isValidVariableNameWithWildcard(stmt.Ident.Value) {
 		l.Error(InvalidName(stmt.Ident.GetMeta(), stmt.Ident.Value, "remove").Match(REMOVE_STATEMENT_SYNTAX))
 	}
 

--- a/linter/statement_linter_test.go
+++ b/linter/statement_linter_test.go
@@ -129,6 +129,15 @@ sub foo {
 
 		assertError(t, input)
 	})
+
+	t.Run("invalid ident with wildcard", func(t *testing.T) {
+		input := `
+sub foo {
+	set req.http.X-* = "foo";
+}`
+
+		assertError(t, input)
+	})
 }
 
 func TestLintUnsetStatement(t *testing.T) {
@@ -165,6 +174,22 @@ sub foo {
 	unset req.backend;
 }`
 
+		assertError(t, input)
+	})
+
+	t.Run("valid with wildcard", func(t *testing.T) {
+		input := `
+sub foo {
+	unset req.http.X-*;
+}`
+		assertNoError(t, input)
+	})
+
+	t.Run("invalid with wildcard position", func(t *testing.T) {
+		input := `
+sub foo {
+	unset req.http.X-*-Bar;
+}`
 		assertError(t, input)
 	})
 }


### PR DESCRIPTION
This PR implements wildcard support for `unset` statement. The syntax is somethink like folliwing:

```vcl
unset req.http.V-*;
```

This behavior is documented at [fastly docs](https://www.fastly.com/documentation/reference/vcl/statements/unset/) but is not described properly.

1. Cannot delete all headers like `unset req.http.*`
2. Cannot specify as glob pattern like `unset req.http.X-*-Value`, wildcard character must be the end of ID
3. Cannot specify after the subfield like `unset req.http.VARS:*`
4. Wildcard does not work for header subfield like `unset req.http.VARS:V*` - Fastly won't delete subfield like `req.http.VARS:VALUE1`

The actual behavior is based on [Fastly Fiddle](https://fiddle.fastly.dev/fiddle/288403c5)