### PR TITLE
implement testing.get_env testing function

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -253,6 +253,7 @@ We describe them following table and examples:
 | testing.mock                 | FUNCTION   | Mock the subroutine with specified subroutine in the testing VCL                             |
 | testing.restore_mock         | FUNCTION   | Restore specific mocked subroutine                                                           |
 | testing.restore_all_mocks    | FUNCTION   | Restore all mocked subroutines                                                               |
+| testing.get_env              | FUNCTION   | Get environment variable value on running machine                                            |
 | assert                       | FUNCTION   | Assert provided expression should be true                                                    |
 | assert.true                  | FUNCTION   | Assert actual value should be true                                                           |
 | assert.false                 | FUNCTION   | Assert actual value should be false                                                          |
@@ -548,6 +549,23 @@ describe add_header_mock {
         // This subroutine no longer uses mocked subroutine
         ...
     }
+}
+```
+
+----
+
+### STRING testing.get_env(STRING name)
+
+Get environment value from `name`.
+This is only enabled on the testing environment and it will be useful for switching test to environment (dev,prod) differences.
+
+```vcl
+sub test_vcl {
+    if (testing.get_env("IS_DEV")) {
+        // skip this test on development environment
+        return;
+    }
+    ...do some assertions
 }
 ```
 

--- a/tester/function/functions.go
+++ b/tester/function/functions.go
@@ -92,7 +92,8 @@ func testingFunctions(i *interpreter.Interpreter, defs *Definiions) Functions {
 			IsIdentArgument: func(i int) bool {
 				return false
 			},
-		}, "testing.fixed_time": {Scope: allScope,
+		},
+		"testing.fixed_time": {Scope: allScope,
 			Call: func(ctx *context.Context, args ...value.Value) (value.Value, error) {
 				unwrapped, err := unwrapIdentArguments(i, args)
 				if err != nil {
@@ -179,6 +180,14 @@ func testingFunctions(i *interpreter.Interpreter, defs *Definiions) Functions {
 			Scope:            allScope,
 			Call:             Testing_inject_variable,
 			CanStatementCall: true,
+			IsIdentArgument: func(i int) bool {
+				return false
+			},
+		},
+		"testing.get_env": {
+			Scope:            allScope,
+			Call:             Testing_get_env,
+			CanStatementCall: false,
 			IsIdentArgument: func(i int) bool {
 				return false
 			},

--- a/tester/function/testing_get_env.go
+++ b/tester/function/testing_get_env.go
@@ -1,0 +1,38 @@
+package function
+
+import (
+	"os"
+
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/function/errors"
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+const Testing_get_env_Name = "testing.get_env"
+
+func Testing_get_env_Validate(args []value.Value) error {
+	if len(args) != 1 {
+		return errors.ArgumentNotEnough(Testing_get_env_Name, 1, args)
+	}
+	if args[0].Type() != value.StringType {
+		return errors.TypeMismatch(Testing_get_env_Name, 1, value.StringType, args[0].Type())
+	}
+	return nil
+}
+
+func Testing_get_env(
+	ctx *context.Context,
+	args ...value.Value,
+) (value.Value, error) {
+
+	if err := Testing_get_env_Validate(args); err != nil {
+		return nil, errors.NewTestingError("%s", err.Error())
+	}
+
+	key := value.Unwrap[*value.String](args[0]).Value
+	env, ok := os.LookupEnv(key)
+	if ok {
+		return &value.String{Value: env}, nil
+	}
+	return &value.String{IsNotSet: true}, nil
+}


### PR DESCRIPTION
This PR adds new testing function that enables to lookup environment variables on the running machine.

```vcl
sub test_vcl {
    if (testing.get_env("IS_DEV")) {
        // skip this test on development environment
        return;
    }
    ...do some assertions
}
```

On the above example, If the machine has environment variable like `IS_DEV=1`, then the test will be skipped.

