### PR TITLE
Add `-w` shorthand flag for Unit Testing watch mode

### DIFF
--- a/cmd/falco/help.go
+++ b/cmd/falco/help.go
@@ -165,7 +165,7 @@ Flags:
     -request           : Override request config
     --max_backends     : Override max backends limitation
     --max_acls         : Override max acls limitation
-    --watch            : Watch VCL file changes and run test
+    -w, --watch        : Watch VCL file changes and run test
     --coverage         : Report code coverage
 
 Local testing example:

--- a/config/config.go
+++ b/config/config.go
@@ -67,7 +67,7 @@ type TestConfig struct {
 	Filter       string   `cli:"f,filter" default:"*.test.vcl"`
 	IncludePaths []string // Copy from root field
 	OverrideHost string   `yaml:"host" cli:"host"`
-	Watch        bool     `cli:"watch"`        // Enable only in CLI option
+	Watch        bool     `cli:"w,watch"`      // Enable only in CLI option
 	Coverage     bool     `cli:"coverage"`     // Enable only in CLI option
 	CoverageOut  string   `cli:"coverage-out"` // Enable only in CLI option
 


### PR DESCRIPTION
## description

The [falco docs](https://github.com/ysugimoto/falco/blob/main/docs/configuration.md) mentioned that Unit Testing watch mode could be enabled with both `--watch` and `-w` flags, but `-w` didn’t work. So, I added support for the flag, which I think could improve usability.