### PR TITLE
implement prefer_ipv6 field in backend declaration

### DIFF
--- a/linter/declaration_linter_test.go
+++ b/linter/declaration_linter_test.go
@@ -57,6 +57,7 @@ backend foo {
   .ssl_check_cert = always;
   .min_tls_version = "1.2";
   .max_tls_version = "1.2";
+  .prefer_ipv6 = true;
   .probe = {
     .dummy = false;
     .initial = 5;

--- a/linter/helper.go
+++ b/linter/helper.go
@@ -33,6 +33,7 @@ var BackendPropertyTypes = map[string]types.Type{
 	"host_header":              types.StringType,
 	"always_use_host_header":   types.BoolType,
 	"bypass_local_route_table": types.BoolType,
+	"prefer_ipv6":              types.BoolType,
 }
 
 var BackendProbePropertyTypes = map[string]types.Type{


### PR DESCRIPTION
Fixes #459 

This PR supports `.prefer_ipv6` field in backend declaration.
This feature comes from Fastly's ipv6 to origin support and if the user enables this feature, this field will be present.
It seems to be enabled in custom VCL so we need to support in linter.