### PR TITLE
Fix/table lookup xxx functions

### DIFF
--- a/interpreter/function/builtin/table_lookup.go
+++ b/interpreter/function/builtin/table_lookup.go
@@ -47,21 +47,23 @@ func Table_lookup(ctx *context.Context, args ...value.Value) (value.Value, error
 
 	table, ok := ctx.Tables[id]
 	if !ok {
-		return &value.String{IsNotSet: true}, errors.New(Table_lookup_Name,
+		return defaultValue, errors.New(Table_lookup_Name,
 			"table %d does not exist", id,
 		)
 	}
 
 	for _, prop := range table.Properties {
-		if prop.Key.Value == key {
-			v, ok := prop.Value.(*ast.String)
-			if !ok {
-				return &value.String{IsNotSet: true}, errors.New(Table_lookup_Name,
-					"table %s value could not cast to STRING type", id,
-				)
-			}
-			return &value.String{Value: v.Value}, nil
+		if prop.Key.Value != key {
+			continue
 		}
+
+		v, ok := prop.Value.(*ast.String)
+		if !ok {
+			return defaultValue, errors.New(Table_lookup_Name,
+				"table %s value could not cast to STRING type", id,
+			)
+		}
+		return &value.String{Value: v.Value}, nil
 	}
-	return defaultValue, nil
+	return defaultValue.Copy(), nil
 }

--- a/interpreter/function/builtin/table_lookup_backend_test.go
+++ b/interpreter/function/builtin/table_lookup_backend_test.go
@@ -4,8 +4,11 @@ package builtin
 
 import (
 	"testing"
-	// "github.com/ysugimoto/falco/interpreter/context"
-	// "github.com/ysugimoto/falco/interpreter/value"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/value"
 )
 
 // Fastly built-in function testing implementation of table.lookup_backend
@@ -13,5 +16,61 @@ import (
 // - TABLE, STRING, BACKEND
 // Reference: https://developer.fastly.com/reference/vcl/functions/table/table-lookup-backend/
 func Test_Table_lookup_backend(t *testing.T) {
-	t.Skip("table.lookup_backend only has difference for table value type")
+	table := map[string]*ast.TableDeclaration{
+		"example": {
+			ValueType: &ast.Ident{Value: "BACKEND"},
+			Properties: []*ast.TableProperty{
+				{
+					Key: &ast.String{Value: "foo"},
+					Value: &ast.Ident{
+						Value: "bar",
+					},
+				},
+			},
+		},
+	}
+	backend := map[string]*value.Backend{
+		"bar": {
+			Value: &ast.BackendDeclaration{
+				Name: &ast.Ident{Value: "bar"},
+			},
+		},
+		"default": {
+			Value: &ast.BackendDeclaration{
+				Name: &ast.Ident{Value: "default"},
+			},
+		},
+	}
+
+	tests := []struct {
+		input   string
+		key     string
+		expect  value.Value
+		isError bool
+	}{
+		{input: "doesnotexist", key: "foo", expect: backend["default"], isError: true},
+		{input: "example", key: "foo", expect: backend["bar"]},
+		{input: "example", key: "other", expect: backend["default"]},
+	}
+
+	for i, tt := range tests {
+		args := []value.Value{
+			&value.Ident{Value: tt.input},
+			&value.String{Value: tt.key},
+			backend["default"],
+		}
+		ret, err := Table_lookup_backend(&context.Context{Tables: table, Backends: backend}, args...)
+		if err != nil {
+			if !tt.isError {
+				t.Errorf("[%d] Unexpected error: %s", i, err)
+			}
+			continue
+		}
+		if ret.Type() != value.BackendType {
+			t.Errorf("[%d] Unexpected return type, expect=BACKEND, got=%s", i, ret.Type())
+		}
+		if diff := cmp.Diff(tt.expect, ret); diff != "" {
+			t.Errorf("[%d] Return value unmatch, diff=%s", i, diff)
+		}
+	}
 }

--- a/interpreter/function/builtin/table_lookup_bool.go
+++ b/interpreter/function/builtin/table_lookup_bool.go
@@ -37,30 +37,32 @@ func Table_lookup_bool(ctx *context.Context, args ...value.Value) (value.Value, 
 
 	id := value.Unwrap[*value.Ident](args[0]).Value
 	key := value.Unwrap[*value.String](args[1]).Value
-	defaultValue := value.Unwrap[*value.Boolean](args[2]).Value
+	defaultValue := value.Unwrap[*value.Boolean](args[2])
 
 	table, ok := ctx.Tables[id]
 	if !ok {
-		return &value.Boolean{Value: defaultValue}, errors.New(Table_lookup_bool_Name,
+		return defaultValue, errors.New(Table_lookup_bool_Name,
 			"table %d does not exist", id,
 		)
 	}
 	if table.ValueType == nil || table.ValueType.Value != "BOOL" {
-		return &value.Boolean{Value: defaultValue}, errors.New(Table_lookup_bool_Name,
+		return defaultValue, errors.New(Table_lookup_bool_Name,
 			"table %d value type is not BOOL", id,
 		)
 	}
 
 	for _, prop := range table.Properties {
-		if prop.Key.Value == key {
-			v, ok := prop.Value.(*ast.Boolean)
-			if !ok {
-				return &value.Boolean{Value: defaultValue}, errors.New(Table_lookup_bool_Name,
-					"table %s value could not cast to BOOL type", id,
-				)
-			}
-			return &value.Boolean{Value: v.Value}, nil
+		if prop.Key.Value != key {
+			continue
 		}
+
+		v, ok := prop.Value.(*ast.Boolean)
+		if !ok {
+			return defaultValue, errors.New(Table_lookup_bool_Name,
+				"table %s value could not cast to BOOL type", id,
+			)
+		}
+		return &value.Boolean{Value: v.Value}, nil
 	}
-	return &value.Boolean{Value: defaultValue}, nil
+	return defaultValue.Copy(), nil
 }

--- a/interpreter/function/builtin/table_lookup_bool_test.go
+++ b/interpreter/function/builtin/table_lookup_bool_test.go
@@ -4,8 +4,12 @@ package builtin
 
 import (
 	"testing"
-	// "github.com/ysugimoto/falco/interpreter/context"
-	// "github.com/ysugimoto/falco/interpreter/value"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/value"
+	"github.com/ysugimoto/falco/token"
 )
 
 // Fastly built-in function testing implementation of table.lookup_bool
@@ -13,5 +17,52 @@ import (
 // - TABLE, STRING, BOOL
 // Reference: https://developer.fastly.com/reference/vcl/functions/table/table-lookup-bool/
 func Test_Table_lookup_bool(t *testing.T) {
-	t.Skip("table.lookup_bool only has difference for table value type")
+	table := map[string]*ast.TableDeclaration{
+		"example": {
+			ValueType: &ast.Ident{Value: "BOOL"},
+			Properties: []*ast.TableProperty{
+				{
+					Key: &ast.String{Value: "foo"},
+					Value: &ast.Boolean{
+						Value: true,
+						Meta: &ast.Meta{
+							Token: token.Token{Offset: 0},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		input   string
+		key     string
+		expect  value.Value
+		isError bool
+	}{
+		{input: "doesnotexist", key: "foo", expect: &value.Boolean{}, isError: true},
+		{input: "example", key: "foo", expect: &value.Boolean{Value: true}},
+		{input: "example", key: "other", expect: &value.Boolean{Value: false}},
+	}
+
+	for i, tt := range tests {
+		args := []value.Value{
+			&value.Ident{Value: tt.input},
+			&value.String{Value: tt.key},
+			&value.Boolean{Value: false},
+		}
+		ret, err := Table_lookup_bool(&context.Context{Tables: table}, args...)
+		if err != nil {
+			if !tt.isError {
+				t.Errorf("[%d] Unexpected error: %s", i, err)
+			}
+			continue
+		}
+		if ret.Type() != value.BooleanType {
+			t.Errorf("[%d] Unexpected return type, expect=BOOL, got=%s", i, ret.Type())
+		}
+		if diff := cmp.Diff(tt.expect, ret); diff != "" {
+			t.Errorf("[%d] Return value unmatch, diff=%s", i, diff)
+		}
+	}
 }

--- a/interpreter/function/builtin/table_lookup_float.go
+++ b/interpreter/function/builtin/table_lookup_float.go
@@ -37,30 +37,32 @@ func Table_lookup_float(ctx *context.Context, args ...value.Value) (value.Value,
 
 	id := value.Unwrap[*value.Ident](args[0]).Value
 	key := value.Unwrap[*value.String](args[1]).Value
-	defaultValue := value.Unwrap[*value.Float](args[2]).Value
+	defaultValue := value.Unwrap[*value.Float](args[2])
 
 	table, ok := ctx.Tables[id]
 	if !ok {
-		return &value.Float{Value: defaultValue}, errors.New(Table_lookup_float_Name,
+		return defaultValue, errors.New(Table_lookup_float_Name,
 			"table %d does not exist", id,
 		)
 	}
 	if table.ValueType == nil || table.ValueType.Value != "FLOAT" {
-		return &value.Float{Value: defaultValue}, errors.New(Table_lookup_float_Name,
+		return defaultValue, errors.New(Table_lookup_float_Name,
 			"table %d value type is not FLOAT", id,
 		)
 	}
 
 	for _, prop := range table.Properties {
-		if prop.Key.Value == key {
-			v, ok := prop.Value.(*ast.Float)
-			if !ok {
-				return &value.Float{Value: defaultValue}, errors.New(Table_lookup_float_Name,
-					"table %s value could not cast to FLOAT type", id,
-				)
-			}
-			return &value.Float{Value: v.Value}, nil
+		if prop.Key.Value != key {
+			continue
 		}
+
+		v, ok := prop.Value.(*ast.Float)
+		if !ok {
+			return defaultValue, errors.New(Table_lookup_float_Name,
+				"table %s value could not cast to FLOAT type", id,
+			)
+		}
+		return &value.Float{Value: v.Value}, nil
 	}
-	return &value.Float{Value: defaultValue}, nil
+	return defaultValue.Copy(), nil
 }

--- a/interpreter/function/builtin/table_lookup_integer.go
+++ b/interpreter/function/builtin/table_lookup_integer.go
@@ -37,30 +37,31 @@ func Table_lookup_integer(ctx *context.Context, args ...value.Value) (value.Valu
 
 	id := value.Unwrap[*value.Ident](args[0]).Value
 	key := value.Unwrap[*value.String](args[1]).Value
-	defaultValue := value.Unwrap[*value.Integer](args[2]).Value
+	defaultValue := value.Unwrap[*value.Integer](args[2])
 
 	table, ok := ctx.Tables[id]
 	if !ok {
-		return &value.Integer{Value: defaultValue}, errors.New(Table_lookup_integer_Name,
+		return defaultValue, errors.New(Table_lookup_integer_Name,
 			"table %d does not exist", id,
 		)
 	}
 	if table.ValueType == nil || table.ValueType.Value != "INTEGER" {
-		return &value.Integer{Value: defaultValue}, errors.New(Table_lookup_integer_Name,
+		return defaultValue, errors.New(Table_lookup_integer_Name,
 			"table %d value type is not INTEGER", id,
 		)
 	}
 
 	for _, prop := range table.Properties {
-		if prop.Key.Value == key {
-			v, ok := prop.Value.(*ast.Integer)
-			if !ok {
-				return &value.Integer{Value: defaultValue}, errors.New(Table_lookup_integer_Name,
-					"table %s value could not cast to INTEGER type", id,
-				)
-			}
-			return &value.Integer{Value: v.Value}, nil
+		if prop.Key.Value != key {
+			continue
 		}
+		v, ok := prop.Value.(*ast.Integer)
+		if !ok {
+			return defaultValue, errors.New(Table_lookup_integer_Name,
+				"table %s value could not cast to INTEGER type", id,
+			)
+		}
+		return &value.Integer{Value: v.Value}, nil
 	}
-	return &value.Integer{Value: defaultValue}, nil
+	return defaultValue.Copy(), nil
 }

--- a/interpreter/function/builtin/table_lookup_integer_test.go
+++ b/interpreter/function/builtin/table_lookup_integer_test.go
@@ -4,6 +4,12 @@ package builtin
 
 import (
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/value"
+	"github.com/ysugimoto/falco/token"
 	// "github.com/ysugimoto/falco/interpreter/context"
 	// "github.com/ysugimoto/falco/interpreter/value"
 )
@@ -13,5 +19,52 @@ import (
 // - TABLE, STRING, INTEGER
 // Reference: https://developer.fastly.com/reference/vcl/functions/table/table-lookup-integer/
 func Test_Table_lookup_integer(t *testing.T) {
-	t.Skip("table.lookup_integer only has difference for table value type")
+	table := map[string]*ast.TableDeclaration{
+		"example": {
+			ValueType: &ast.Ident{Value: "INTEGER"},
+			Properties: []*ast.TableProperty{
+				{
+					Key: &ast.String{Value: "foo"},
+					Value: &ast.Integer{
+						Value: 10,
+						Meta: &ast.Meta{
+							Token: token.Token{Offset: 0},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		input   string
+		key     string
+		expect  value.Value
+		isError bool
+	}{
+		{input: "doesnotexist", key: "foo", isError: true},
+		{input: "example", key: "foo", expect: &value.Integer{Value: 10}},
+		{input: "example", key: "other", expect: &value.Integer{Value: 1}},
+	}
+
+	for i, tt := range tests {
+		args := []value.Value{
+			&value.Ident{Value: tt.input},
+			&value.String{Value: tt.key},
+			&value.Integer{Value: 1},
+		}
+		ret, err := Table_lookup_integer(&context.Context{Tables: table}, args...)
+		if err != nil {
+			if !tt.isError {
+				t.Errorf("[%d] Unexpected error: %s", i, err)
+			}
+			continue
+		}
+		if ret.Type() != value.IntegerType {
+			t.Errorf("[%d] Unexpected return type, expect=INTEGER, got=%s", i, ret.Type())
+		}
+		if diff := cmp.Diff(tt.expect, ret); diff != "" {
+			t.Errorf("[%d] Return value unmatch, diff=%s", i, diff)
+		}
+	}
 }

--- a/interpreter/function/builtin/table_lookup_integer_test.go
+++ b/interpreter/function/builtin/table_lookup_integer_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/ysugimoto/falco/interpreter/context"
 	"github.com/ysugimoto/falco/interpreter/value"
 	"github.com/ysugimoto/falco/token"
-	// "github.com/ysugimoto/falco/interpreter/context"
-	// "github.com/ysugimoto/falco/interpreter/value"
 )
 
 // Fastly built-in function testing implementation of table.lookup_integer

--- a/interpreter/function/builtin/table_lookup_rtime.go
+++ b/interpreter/function/builtin/table_lookup_rtime.go
@@ -40,44 +40,46 @@ func Table_lookup_rtime(ctx *context.Context, args ...value.Value) (value.Value,
 
 	id := value.Unwrap[*value.Ident](args[0]).Value
 	key := value.Unwrap[*value.String](args[1]).Value
-	defaultValue := value.Unwrap[*value.RTime](args[2]).Value
+	defaultValue := value.Unwrap[*value.RTime](args[2])
 
 	table, ok := ctx.Tables[id]
 	if !ok {
-		return &value.RTime{Value: defaultValue}, errors.New(Table_lookup_rtime_Name,
+		return defaultValue, errors.New(Table_lookup_rtime_Name,
 			"table %d does not exist", id,
 		)
 	}
 	if table.ValueType == nil || table.ValueType.Value != "RTIME" {
-		return &value.RTime{Value: defaultValue}, errors.New(Table_lookup_rtime_Name,
+		return defaultValue, errors.New(Table_lookup_rtime_Name,
 			"table %d value type is not RTIME", id,
 		)
 	}
 
 	for _, prop := range table.Properties {
-		if prop.Key.Value == key {
-			v, ok := prop.Value.(*ast.RTime)
-			if !ok {
-				return &value.RTime{Value: defaultValue}, errors.New(Table_lookup_rtime_Name,
-					"table %s value could not cast to RTIME type", id,
-				)
-			}
-
-			var val time.Duration
-			switch {
-			case strings.HasSuffix(v.Value, "d"):
-				num := strings.TrimSuffix(v.Value, "d")
-				val, _ = time.ParseDuration(num + "h")
-				val *= 24
-			case strings.HasSuffix(v.Value, "y"):
-				num := strings.TrimSuffix(v.Value, "y")
-				val, _ = time.ParseDuration(num + "h")
-				val *= 24 * 365
-			default:
-				val, _ = time.ParseDuration(v.Value)
-			}
-			return &value.RTime{Value: val}, nil
+		if prop.Key.Value != key {
+			continue
 		}
+
+		v, ok := prop.Value.(*ast.RTime)
+		if !ok {
+			return defaultValue, errors.New(Table_lookup_rtime_Name,
+				"table %s value could not cast to RTIME type", id,
+			)
+		}
+
+		var val time.Duration
+		switch {
+		case strings.HasSuffix(v.Value, "d"):
+			num := strings.TrimSuffix(v.Value, "d")
+			val, _ = time.ParseDuration(num + "h")
+			val *= 24
+		case strings.HasSuffix(v.Value, "y"):
+			num := strings.TrimSuffix(v.Value, "y")
+			val, _ = time.ParseDuration(num + "h")
+			val *= 24 * 365
+		default:
+			val, _ = time.ParseDuration(v.Value)
+		}
+		return &value.RTime{Value: val}, nil
 	}
-	return &value.RTime{Value: defaultValue}, nil
+	return defaultValue.Copy(), nil
 }

--- a/parser/declaration_parser.go
+++ b/parser/declaration_parser.go
@@ -436,8 +436,6 @@ func (p *Parser) ParseTableProperty() (*ast.TableProperty, error) {
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
-	case token.ACL, token.BACKEND:
-		prop.Value = p.ParseIdent()
 	case token.TRUE, token.FALSE:
 		prop.Value = p.ParseBoolean()
 	case token.FLOAT:


### PR DESCRIPTION
This PR fixes `table.lookup_xxx` functions.
For table value types of `ACL` and `BACKEND`, the value will be parsed as IDENT so we need to check as IDENT and lookup defined table in VCL.

Additionally, we forget to write tests for each functions so write them for ensure exact work.