### PR TITLE
enable skipped tests

### DIFF
--- a/interpreter/function/builtin/digest_time_hmac_sha512_test.go
+++ b/interpreter/function/builtin/digest_time_hmac_sha512_test.go
@@ -16,7 +16,7 @@ import (
 // - STRING, INTEGER, INTEGER
 // Reference: https://developer.fastly.com/reference/vcl/functions/cryptographic/digest-time-hmac-sha512/
 func Test_Digest_time_hmac_sha512(t *testing.T) {
-	t.Skip("Test Builtin function digest.time_hmac_sha512 should be impelemented")
+	// t.Skip("Test Builtin function digest.time_hmac_sha512 should be impelemented")
 	secret := base64.StdEncoding.EncodeToString([]byte("12345678901234567890"))
 	ret, err := digest_time_hmac_sha512(
 		time.Date(1970, 1, 1, 0, 0, 59, 0, time.UTC),

--- a/interpreter/function/builtin/uuid_version3_test.go
+++ b/interpreter/function/builtin/uuid_version3_test.go
@@ -17,7 +17,7 @@ import (
 // - STRING, STRING
 // Reference: https://developer.fastly.com/reference/vcl/functions/uuid/uuid-version3/
 func Test_Uuid_version3(t *testing.T) {
-	t.Skip("Test Builtin function uuid.version3 should be impelemented")
+	// t.Skip("Test Builtin function uuid.version3 should be impelemented")
 	tests := []struct {
 		namespace string
 		input     string


### PR DESCRIPTION
This PR enables skipped tests.
I don't know why but some built-in function tests are skipped, they could be enable to run tests.
So I remove `t.Skip()` statements.