### PR TITLE
Improve builtin function tests

### DIFF
--- a/interpreter/function/builtin/accept_language_lookup_test.go
+++ b/interpreter/function/builtin/accept_language_lookup_test.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/ysugimoto/falco/interpreter/context"
 	"github.com/ysugimoto/falco/interpreter/value"
-	// "github.com/ysugimoto/falco/interpreter/context"
-	// "github.com/ysugimoto/falco/interpreter/value"
 )
 
 // Fastly built-in function testing implementation of accept.language_lookup

--- a/interpreter/function/builtin/bin_hex_to_base64_test.go
+++ b/interpreter/function/builtin/bin_hex_to_base64_test.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/ysugimoto/falco/interpreter/context"
 	"github.com/ysugimoto/falco/interpreter/value"
-	// "github.com/ysugimoto/falco/interpreter/context"
-	// "github.com/ysugimoto/falco/interpreter/value"
 )
 
 // Fastly built-in function testing implementation of bin.hex_to_base64

--- a/interpreter/function/builtin/digest_ecdsa_verify_test.go
+++ b/interpreter/function/builtin/digest_ecdsa_verify_test.go
@@ -13,8 +13,6 @@ import (
 	"testing"
 
 	"github.com/ysugimoto/falco/interpreter/value"
-	// "github.com/ysugimoto/falco/interpreter/context"
-	// "github.com/ysugimoto/falco/interpreter/value"
 )
 
 // Fastly built-in function testing implementation of digest.ecdsa_verify

--- a/interpreter/function/builtin/digest_secure_is_equal_test.go
+++ b/interpreter/function/builtin/digest_secure_is_equal_test.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/ysugimoto/falco/interpreter/context"
 	"github.com/ysugimoto/falco/interpreter/value"
-	// "github.com/ysugimoto/falco/interpreter/context"
-	// "github.com/ysugimoto/falco/interpreter/value"
 )
 
 // Fastly built-in function testing implementation of digest.secure_is_equal

--- a/interpreter/function/builtin/digest_time_hmac_sha512_test.go
+++ b/interpreter/function/builtin/digest_time_hmac_sha512_test.go
@@ -16,7 +16,6 @@ import (
 // - STRING, INTEGER, INTEGER
 // Reference: https://developer.fastly.com/reference/vcl/functions/cryptographic/digest-time-hmac-sha512/
 func Test_Digest_time_hmac_sha512(t *testing.T) {
-	// t.Skip("Test Builtin function digest.time_hmac_sha512 should be impelemented")
 	secret := base64.StdEncoding.EncodeToString([]byte("12345678901234567890"))
 	ret, err := digest_time_hmac_sha512(
 		time.Date(1970, 1, 1, 0, 0, 59, 0, time.UTC),

--- a/interpreter/function/builtin/early_hints_test.go
+++ b/interpreter/function/builtin/early_hints_test.go
@@ -4,8 +4,6 @@ package builtin
 
 import (
 	"testing"
-	// "github.com/ysugimoto/falco/interpreter/context"
-	// "github.com/ysugimoto/falco/interpreter/value"
 )
 
 // Fastly built-in function testing implementation of early_hints

--- a/interpreter/function/builtin/fastly_try_select_shield_test.go
+++ b/interpreter/function/builtin/fastly_try_select_shield_test.go
@@ -4,8 +4,6 @@ package builtin
 
 import (
 	"testing"
-	// "github.com/ysugimoto/falco/interpreter/context"
-	// "github.com/ysugimoto/falco/interpreter/value"
 )
 
 // Fastly built-in function testing implementation of fastly.try_select_shield

--- a/interpreter/function/builtin/header_get_test.go
+++ b/interpreter/function/builtin/header_get_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ysugimoto/falco/ast"
 	"github.com/ysugimoto/falco/interpreter/context"
 	"github.com/ysugimoto/falco/interpreter/value"
-	// "github.com/ysugimoto/falco/interpreter/value"
 )
 
 // Fastly built-in function testing implementation of header.get

--- a/interpreter/function/builtin/ratelimit_check_rate_test.go
+++ b/interpreter/function/builtin/ratelimit_check_rate_test.go
@@ -4,8 +4,6 @@ package builtin
 
 import (
 	"testing"
-	// "github.com/ysugimoto/falco/interpreter/context"
-	// "github.com/ysugimoto/falco/interpreter/value"
 )
 
 // Fastly built-in function testing implementation of ratelimit.check_rate

--- a/interpreter/function/builtin/ratelimit_check_rates_test.go
+++ b/interpreter/function/builtin/ratelimit_check_rates_test.go
@@ -4,8 +4,6 @@ package builtin
 
 import (
 	"testing"
-	// "github.com/ysugimoto/falco/interpreter/context"
-	// "github.com/ysugimoto/falco/interpreter/value"
 )
 
 // Fastly built-in function testing implementation of ratelimit.check_rates

--- a/interpreter/function/builtin/ratelimit_penaltybox_add_test.go
+++ b/interpreter/function/builtin/ratelimit_penaltybox_add_test.go
@@ -4,8 +4,6 @@ package builtin
 
 import (
 	"testing"
-	// "github.com/ysugimoto/falco/interpreter/context"
-	// "github.com/ysugimoto/falco/interpreter/value"
 )
 
 // Fastly built-in function testing implementation of ratelimit.penaltybox_add

--- a/interpreter/function/builtin/ratelimit_penaltybox_has_test.go
+++ b/interpreter/function/builtin/ratelimit_penaltybox_has_test.go
@@ -4,8 +4,6 @@ package builtin
 
 import (
 	"testing"
-	// "github.com/ysugimoto/falco/interpreter/context"
-	// "github.com/ysugimoto/falco/interpreter/value"
 )
 
 // Fastly built-in function testing implementation of ratelimit.penaltybox_has

--- a/interpreter/function/builtin/ratelimit_ratecounter_increment_test.go
+++ b/interpreter/function/builtin/ratelimit_ratecounter_increment_test.go
@@ -4,8 +4,6 @@ package builtin
 
 import (
 	"testing"
-	// "github.com/ysugimoto/falco/interpreter/context"
-	// "github.com/ysugimoto/falco/interpreter/value"
 )
 
 // Fastly built-in function testing implementation of ratelimit.ratecounter_increment

--- a/interpreter/function/builtin/resp_tarpit_test.go
+++ b/interpreter/function/builtin/resp_tarpit_test.go
@@ -4,8 +4,6 @@ package builtin
 
 import (
 	"testing"
-	// "github.com/ysugimoto/falco/interpreter/context"
-	// "github.com/ysugimoto/falco/interpreter/value"
 )
 
 // Fastly built-in function testing implementation of resp.tarpit

--- a/interpreter/function/builtin/setcookie_delete_by_name_test.go
+++ b/interpreter/function/builtin/setcookie_delete_by_name_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/ysugimoto/falco/interpreter/context"
 	"github.com/ysugimoto/falco/interpreter/value"
-	// "github.com/ysugimoto/falco/interpreter/context"
-	// "github.com/ysugimoto/falco/interpreter/value"
 )
 
 // Fastly built-in function testing implementation of setcookie.delete_by_name

--- a/interpreter/function/builtin/std_count.go
+++ b/interpreter/function/builtin/std_count.go
@@ -45,6 +45,8 @@ func Std_count(ctx *context.Context, args ...value.Value) (value.Value, error) {
 		return &value.Integer{Value: int64(len(ctx.BackendRequest.Header))}, nil
 	case "beresp.headers":
 		return &value.Integer{Value: int64(len(ctx.BackendResponse.Header))}, nil
+	case "obj.headers":
+		return &value.Integer{Value: int64(len(ctx.Object.Header))}, nil
 	case "resp.headers":
 		return &value.Integer{Value: int64(len(ctx.Response.Header))}, nil
 	default:

--- a/interpreter/function/builtin/std_count_test.go
+++ b/interpreter/function/builtin/std_count_test.go
@@ -3,9 +3,12 @@
 package builtin
 
 import (
+	"net/http"
 	"testing"
-	// "github.com/ysugimoto/falco/interpreter/context"
-	// "github.com/ysugimoto/falco/interpreter/value"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/value"
 )
 
 // Fastly built-in function testing implementation of std.count
@@ -13,5 +16,84 @@ import (
 // - ID
 // Reference: https://developer.fastly.com/reference/vcl/functions/miscellaneous/std-count/
 func Test_Std_count(t *testing.T) {
-	t.Skip("Test Builtin function std.count should be impelemented")
+	tests := []struct {
+		name    string
+		ident   string
+		expect  int64
+		isError bool
+	}{
+		{
+			name:   "Request Header",
+			ident:  "req.headers",
+			expect: 1,
+		},
+		{
+			name:   "Backend Request Header",
+			ident:  "bereq.headers",
+			expect: 2,
+		},
+		{
+			name:   "Backend Response Header",
+			ident:  "beresp.headers",
+			expect: 3,
+		},
+		{
+			name:   "Object Header",
+			ident:  "obj.headers",
+			expect: 4,
+		},
+		{
+			name:   "Response Header",
+			ident:  "resp.headers",
+			expect: 5,
+		},
+		{
+			name:    "Unexpected",
+			ident:   "req.foobar",
+			isError: true,
+		},
+	}
+
+	ctx := &context.Context{
+		Request: &http.Request{Header: http.Header{
+			"Header-1": {"1"},
+		}},
+		BackendRequest: &http.Request{Header: http.Header{
+			"Header-1": {"1"},
+			"Header-2": {"2"},
+		}},
+		BackendResponse: &http.Response{Header: http.Header{
+			"Header-1": {"1"},
+			"Header-2": {"2"},
+			"Header-3": {"3"},
+		}},
+		Object: &http.Response{Header: http.Header{
+			"Header-1": {"1"},
+			"Header-2": {"2"},
+			"Header-3": {"3"},
+			"Header-4": {"4"},
+		}},
+		Response: &http.Response{Header: http.Header{
+			"Header-1": {"1"},
+			"Header-2": {"2"},
+			"Header-3": {"3"},
+			"Header-4": {"4"},
+			"Header-5": {"5"},
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := Std_count(ctx, &value.Ident{Value: tt.ident})
+			if err != nil {
+				if !tt.isError {
+					t.Errorf("Unexpected error: %s", err)
+				}
+				return
+			}
+			if diff := cmp.Diff(&value.Integer{Value: tt.expect}, v); diff != "" {
+				t.Errorf("Return value mismatch, diff=%s", diff)
+			}
+		})
+	}
 }

--- a/interpreter/function/builtin/time_interval_elapsed_ratio_test.go
+++ b/interpreter/function/builtin/time_interval_elapsed_ratio_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/ysugimoto/falco/interpreter/context"
 	"github.com/ysugimoto/falco/interpreter/value"
-	// "github.com/ysugimoto/falco/interpreter/context"
-	// "github.com/ysugimoto/falco/interpreter/value"
 )
 
 // Fastly built-in function testing implementation of time.interval_elapsed_ratio

--- a/interpreter/function/builtin/uuid_version3_test.go
+++ b/interpreter/function/builtin/uuid_version3_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/ysugimoto/falco/interpreter/context"
 	"github.com/ysugimoto/falco/interpreter/value"
-	// "github.com/ysugimoto/falco/interpreter/context"
-	// "github.com/ysugimoto/falco/interpreter/value"
 )
 
 // Fastly built-in function testing implementation of uuid.version3
@@ -17,7 +15,6 @@ import (
 // - STRING, STRING
 // Reference: https://developer.fastly.com/reference/vcl/functions/uuid/uuid-version3/
 func Test_Uuid_version3(t *testing.T) {
-	// t.Skip("Test Builtin function uuid.version3 should be impelemented")
 	tests := []struct {
 		namespace string
 		input     string

--- a/interpreter/function/builtin/uuid_version4_test.go
+++ b/interpreter/function/builtin/uuid_version4_test.go
@@ -4,8 +4,6 @@ package builtin
 
 import (
 	"testing"
-	// "github.com/ysugimoto/falco/interpreter/context"
-	// "github.com/ysugimoto/falco/interpreter/value"
 )
 
 // Fastly built-in function testing implementation of uuid.version4

--- a/interpreter/function/builtin/uuid_version7_test.go
+++ b/interpreter/function/builtin/uuid_version7_test.go
@@ -4,8 +4,6 @@ package builtin
 
 import (
 	"testing"
-	// "github.com/ysugimoto/falco/interpreter/context"
-	// "github.com/ysugimoto/falco/interpreter/value"
 )
 
 // Fastly built-in function testing implementation of uuid.version7


### PR DESCRIPTION
This PR improves built-in function testings.

- remove unnecessary commented out imports event tests are skipped
- add `std.count` function tests

Changesets are slightly large but most changes are removing comments.