### PR TITLE
use log statement for testing printing

### DIFF
--- a/dap/debugger.go
+++ b/dap/debugger.go
@@ -68,6 +68,10 @@ func (d *Debugger) Message(msg string) {
 	d.printFunc(msg)
 }
 
+func (d *Debugger) Log(stmt *ast.LogStatement, value string) {
+	d.printFunc(value)
+}
+
 func (d *Debugger) waitForNewState() interpreter.DebugState {
 	d.mode = <-d.stateCh
 

--- a/debugger/debugger.go
+++ b/debugger/debugger.go
@@ -48,6 +48,10 @@ func (d *Debugger) Message(msg string) {
 	d.message.Append(messageview.Runtime, "%s", msg)
 }
 
+func (d *Debugger) Log(stmt *ast.LogStatement, value string) {
+	d.message.Append(messageview.Runtime, "%s", value)
+}
+
 func (d *Debugger) breakPoint(t token.Token) interpreter.DebugState {
 	d.code.SetFile(t.File, t.Line)
 	d.app.Draw()

--- a/interpreter/debugger.go
+++ b/interpreter/debugger.go
@@ -19,6 +19,7 @@ const (
 type Debugger interface {
 	Run(ast.Node) DebugState
 	Message(string)
+	Log(*ast.LogStatement, string)
 }
 
 // Default debugger, simply output message to stdout
@@ -29,4 +30,7 @@ func (d DefaultDebugger) Run(node ast.Node) DebugState {
 }
 func (d DefaultDebugger) Message(msg string) {
 	fmt.Fprintln(os.Stderr, msg)
+}
+func (d DefaultDebugger) Log(stmt *ast.LogStatement, value string) {
+	fmt.Fprintln(os.Stderr, value)
 }

--- a/interpreter/statement.go
+++ b/interpreter/statement.go
@@ -429,7 +429,7 @@ func (i *Interpreter) ProcessLogStatement(stmt *ast.LogStatement) error {
 	}
 
 	i.process.Logs = append(i.process.Logs, process.NewLog(stmt, i.ctx.Scope, line))
-	i.Debugger.Message(line)
+	i.Debugger.Log(stmt, line)
 	return nil
 }
 

--- a/interpreter/testing.go
+++ b/interpreter/testing.go
@@ -28,7 +28,11 @@ func (i *Interpreter) TestProcessInit(r *http.Request) error {
 				Properties: []*ast.BackendProperty{
 					{
 						Key:   &ast.Ident{Value: "host"},
-						Value: &ast.String{Value: "http://localhost:3124"},
+						Value: &ast.String{Value: "localhost"},
+					},
+					{
+						Key:   &ast.Ident{Value: "port"},
+						Value: &ast.String{Value: "80"},
 					},
 				},
 			},

--- a/tester/debugger.go
+++ b/tester/debugger.go
@@ -1,6 +1,9 @@
 package tester
 
 import (
+	"fmt"
+	"path/filepath"
+
 	"github.com/ysugimoto/falco/ast"
 	"github.com/ysugimoto/falco/interpreter"
 )
@@ -18,5 +21,14 @@ func (d *Debugger) Run(node ast.Node) interpreter.DebugState {
 }
 
 func (d *Debugger) Message(msg string) {
+	// Discard message
+}
+
+func (d *Debugger) Log(stmt *ast.LogStatement, value string) {
+	token := stmt.GetMeta().Token
+	msg := fmt.Sprintf(
+		"%s (%s %d:%d)",
+		value, filepath.Base(token.File), token.Line, token.Position,
+	)
 	d.stack = append(d.stack, msg)
 }

--- a/tester/entity.go
+++ b/tester/entity.go
@@ -15,20 +15,25 @@ type TestCase struct {
 	Scope string
 	Time  int64 // msec order
 	Skip  bool
+	Logs  []string
 }
 
 func (t *TestCase) MarshalJSON() ([]byte, error) {
 	v := struct {
-		Name  string `json:"name"`
-		Error string `json:"error,omitempty"`
-		Group string `json:"group,omitempty"`
-		Scope string `json:"scope"`
-		Time  int64  `json:"elapsed_time"`
+		Name  string   `json:"name"`
+		Error string   `json:"error,omitempty"`
+		Group string   `json:"group,omitempty"`
+		Scope string   `json:"scope"`
+		Time  int64    `json:"elapsed_time"`
+		Skip  bool     `json:"skip"`
+		Logs  []string `json:"logs"`
 	}{
 		Name:  t.Name,
 		Group: t.Group,
 		Scope: t.Scope,
 		Time:  t.Time,
+		Skip:  t.Skip,
+		Logs:  t.Logs,
 	}
 	if t.Error != nil {
 		switch e := t.Error.(type) {
@@ -61,6 +66,5 @@ func (t *TestResult) IsPassed() bool {
 type TestFactory struct {
 	Results    []*TestResult
 	Statistics *shared.Counter
-	Logs       []string
 	Coverage   *shared.CoverageFactory
 }

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -34,7 +34,6 @@ type Tester struct {
 	interpreterOptions []context.Option
 	config             *config.TestConfig
 	counter            *shared.Counter
-	debugger           *Debugger
 	coverage           *shared.Coverage
 }
 
@@ -43,7 +42,6 @@ func New(c *config.TestConfig, opts []context.Option) *Tester {
 		interpreterOptions: opts,
 		config:             c,
 		counter:            shared.NewCounter(),
-		debugger:           NewDebugger(),
 	}
 	if c.Coverage {
 		t.coverage = shared.NewCoverage()
@@ -93,7 +91,6 @@ func (t *Tester) Run(main string) (*TestFactory, error) {
 	factory := &TestFactory{
 		Results:    results,
 		Statistics: t.counter,
-		Logs:       t.debugger.stack,
 	}
 	if t.coverage != nil {
 		factory.Coverage = t.coverage.Factory()
@@ -155,6 +152,10 @@ func (t *Tester) run(testFile string) (*TestResult, error) {
 				}
 				metadata := getTestMetadata(st)
 				for _, s := range metadata.Scopes {
+					// Attach new debugger for each test suite
+					d := NewDebugger()
+					i.Debugger = d
+
 					// Skip this testsuite when marked as @skip or @tag matched
 					if metadata.Skip || metadata.MatchTags(t.config.Tags) {
 						cases = append(cases, &TestCase{
@@ -173,6 +174,7 @@ func (t *Tester) run(testFile string) (*TestResult, error) {
 						Error: errors.Cause(err),
 						Scope: s.String(),
 						Time:  time.Since(start).Milliseconds(),
+						Logs:  d.stack,
 					})
 					if err != nil {
 						t.counter.Fail()
@@ -229,6 +231,10 @@ func (t *Tester) runDescribedTests(
 	for _, sub := range d.Subroutines {
 		metadata := getTestMetadata(sub)
 		for _, s := range metadata.Scopes {
+			// Attach new debugger for each test suite
+			debugger := NewDebugger()
+			i.Debugger = debugger
+
 			// Skip this testsuite when marked as @skip or @tag matched
 			if metadata.Skip || metadata.MatchTags(t.config.Tags) {
 				cases = append(cases, &TestCase{
@@ -260,6 +266,7 @@ func (t *Tester) runDescribedTests(
 				Error: errors.Cause(err),
 				Scope: s.String(),
 				Time:  time.Since(start).Milliseconds(),
+				Logs:  debugger.stack,
 			})
 			if err != nil {
 				t.counter.Fail()
@@ -285,7 +292,7 @@ func (t *Tester) runDescribedTests(
 // Set up interprete for each test subroutines
 func (t *Tester) setupInterpreter(defs *tf.Definiions) *interpreter.Interpreter {
 	i := interpreter.New(t.interpreterOptions...)
-	i.Debugger = t.debugger
+	i.Debugger = NewDebugger() // store the default debugger
 	i.IdentResolver = func(val string) value.Value {
 		if v, ok := defs.Backends[val]; ok {
 			return v


### PR DESCRIPTION
On the testing, falco does not have mechanism for debugging output like `print`, `console.log` so it makes user harder to confirm the state of variables in both of main and tesing VCL.

To solve this problem, we will use `log` statement for debug printing on the testing.
When user write `log` statement in main VCL of testing VCL, falco stores the statement output and display them with testing results, see following screenshot:

![CleanShot 2025-06-03 at 03 32 01@2x](https://github.com/user-attachments/assets/59cc58d5-cc4f-48c1-a799-d0915cb8e234)

We hope this feature is useful for the user who writes unit tests.