### PR TITLE
fix object response handling, mainly error scope

### DIFF
--- a/cmd/falco/runner_test.go
+++ b/cmd/falco/runner_test.go
@@ -383,6 +383,12 @@ func TestTester(t *testing.T) {
 			filter: "*default.test.vcl",
 			passes: 10,
 		},
+		{
+			name:   "synthetic vs obj.resoonse",
+			main:   "../../examples/testing/synthetic_response/default.vcl",
+			filter: "*default.test.vcl",
+			passes: 2,
+		},
 	}
 
 	for _, tt := range tests {

--- a/examples/testing/synthetic_response/default.test.vcl
+++ b/examples/testing/synthetic_response/default.test.vcl
@@ -1,0 +1,7 @@
+// @scope: error
+sub test_vcl {
+  testing.call_subroutine("vcl_error");
+  assert.equal(testing.synthetic_body, "No dice.");
+  // obj.response could not set after the syntheic response has called.
+  assert.is_notset(obj.response);
+}

--- a/examples/testing/synthetic_response/default.vcl
+++ b/examples/testing/synthetic_response/default.vcl
@@ -1,0 +1,4 @@
+sub vcl_error {
+  synthetic "No dice.";
+  set obj.response = "OK";
+}

--- a/interpreter/context/context.go
+++ b/interpreter/context/context.go
@@ -178,6 +178,12 @@ type Context struct {
 	// Marker that return request is purge request.
 	IsPurgeRequest bool
 
+	// Flag for a synthetic response has been set.
+	// It means that some VCL will set response phase like `set obj.response = "xxx"`
+	// but we should ignore when synthetic response has already set.
+	// Note that obj.response is deprecated after HTTP/1.1 but VCL still supports this spec.
+	HasSyntheticResponse bool
+
 	OverrideVariables map[string]value.Value
 }
 
@@ -268,7 +274,7 @@ func New(options ...Option) *Context {
 		ObjectGrace:                         &value.RTime{},
 		ObjectTTL:                           &value.RTime{},
 		ObjectStatus:                        &value.Integer{Value: 500},
-		ObjectResponse:                      &value.String{Value: "error"},
+		ObjectResponse:                      &value.String{IsNotSet: true},
 		ReturnState:                         &value.String{IsNotSet: true},
 		IsLocallyGenerated:                  &value.Boolean{},
 		BackendRequestMaxReuseIdleTime:      &value.RTime{},

--- a/interpreter/statement.go
+++ b/interpreter/statement.go
@@ -445,6 +445,7 @@ func (i *Interpreter) ProcessSyntheticStatement(stmt *ast.SyntheticStatement) er
 		return exception.Runtime(&stmt.GetMeta().Token, "%s", err.Error())
 	}
 	i.ctx.Object.Body = nopSeekCloser(strings.NewReader(v.Value))
+	i.ctx.HasSyntheticResponse = true
 	return nil
 }
 
@@ -458,6 +459,7 @@ func (i *Interpreter) ProcessSyntheticBase64Statement(stmt *ast.SyntheticBase64S
 		return exception.Runtime(&stmt.GetMeta().Token, "%s", err.Error())
 	}
 	i.ctx.Object.Body = nopSeekCloser(strings.NewReader(v.Value))
+	i.ctx.HasSyntheticResponse = true
 	return nil
 }
 

--- a/interpreter/variable/hit.go
+++ b/interpreter/variable/hit.go
@@ -1,11 +1,7 @@
 package variable
 
 import (
-	"io"
-	"strings"
 	"time"
-
-	"net/http"
 
 	"github.com/pkg/errors"
 	"github.com/ysugimoto/falco/interpreter/context"
@@ -108,10 +104,16 @@ func (v *HitScopeVariables) Set(s context.Scope, name, operator string, val valu
 		}
 		return nil
 	case OBJ_RESPONSE:
+		// If synthetic response has already been set, ignore this assignment.
+		if v.ctx.HasSyntheticResponse {
+			return nil
+		}
+
 		if err := doAssign(v.ctx.ObjectResponse, operator, val); err != nil {
 			return errors.WithStack(err)
 		}
-		v.ctx.Object.Body = io.NopCloser(strings.NewReader(v.ctx.ObjectResponse.Value))
+		// obj.response indicates response header line, meand status text in http.Response
+		v.ctx.Object.Status = v.ctx.ObjectResponse.Value
 		return nil
 	case OBJ_STATUS:
 		i := &value.Integer{Value: 0}
@@ -119,7 +121,6 @@ func (v *HitScopeVariables) Set(s context.Scope, name, operator string, val valu
 			return errors.WithStack(err)
 		}
 		v.ctx.Object.StatusCode = int(i.Value)
-		v.ctx.Object.Status = http.StatusText(int(i.Value))
 		return nil
 	case OBJ_TTL:
 		if err := doAssign(v.ctx.ObjectTTL, operator, val); err != nil {

--- a/tester/variable/testing.go
+++ b/tester/variable/testing.go
@@ -25,17 +25,16 @@ func (v *TestingVariables) Get(ctx *context.Context, scope context.Scope, name s
 	case TESTING_STATE:
 		return &value.String{Value: strings.ToUpper(ctx.ReturnState.Value)}, nil
 	case TESTING_SYNTHETIC_BODY:
-		if b, err := io.ReadAll(ctx.Object.Body); err == nil {
+		b, err := io.ReadAll(ctx.Object.Body)
+		if err == nil {
 			// Just assuming that seeking it back to the start is fine. Nothing
 			// else _should_ have left this in a weird state.
 			if seeker, ok := ctx.Object.Body.(io.Seeker); ok {
 				if _, err := seeker.Seek(0, io.SeekStart); err != nil {
 					return nil, err
 				}
-				return &value.String{Value: string(b)}, nil
-			} else {
-				return nil, errors.New("cannot assert ctx.Object.Body to io.Seeker")
 			}
+			return &value.String{Value: string(b)}, nil
 		} else {
 			return nil, err
 		}
@@ -52,5 +51,5 @@ func (v *TestingVariables) Set(
 	val value.Value,
 ) error {
 
-	return errors.New("Not Found")
+	return errors.New("Testing variables are read-only")
 }


### PR DESCRIPTION
This PR fixes #480 that follows the Fastly spec of object response handling.

## Object response handling

`obj.*` variables are enabled - mainly `error` scope - on the VCL, we should take care of `synthetic` and `obj.response` variable behavior.

When a `synthetic` statement has called, the VCL will prepare for sending error response, and the `obj.response` variable will set the *Response Phase*. The these statement/variable has a difference about the response.

1. If `synthetic` statement has called before the `obj.response`, the `obj.response` will be ignored.

```vcl
sub vcl_error {
  synthetic "No dice.";
  set obj.response = "OK";
}
```

The `set obj.response = OK` statement will be ignoreed because synthetic statement has been called before, the runtime should prepare the response body with the statement value, so Response Phase will not affect.

2. If `synthetic` statement has called after the `obj.response`, the `obj.response` is enabled (but actually be ignored on the client)

```vcl
sub vcl_error {
  set obj.response = "OK";
  synthetic "No dice.";
}
```

Then the response will be:

```
HTTP/1.1 400 OK
[some headers...]

No dice.
```

However, `400 OK` is illigal so client will ignore the status text.

This PR follows the both spec but i'm not sure how a client should treat the case 2.

And also This PR fixes `testing.synthetic_body` access on the testing.