### PR TITLE
Add `assert.is_json()` function

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -311,6 +311,7 @@ We describe them following table and examples:
 | assert                       | FUNCTION   | Assert provided expression should be true                                                    |
 | assert.true                  | FUNCTION   | Assert actual value should be true                                                           |
 | assert.false                 | FUNCTION   | Assert actual value should be false                                                          |
+| assert.is_json               | FUNCTION   | Assert actual string should be valid JSON                                                    |
 | assert.is_notset             | FUNCTION   | Assert actual value should be NotSet                                                         |
 | assert.equal                 | FUNCTION   | Assert actual value should be equal to expected value (alias of assert.strict_equal)         |
 | assert.not_equal             | FUNCTION   | Assert actual value should not be equal to expected value (alias of assert.not_strict_equal) |
@@ -710,6 +711,28 @@ sub test_vcl {
 
     // Fail because experssion value is not BOOL false
     assert.false(req.http.Foo);
+}
+```
+
+----
+
+### assert.is_json(STRING actual [, STRING message])
+
+Assert actual string should be valid JSON.
+
+```vcl
+sub test_vcl {
+    declare local var.testing STRING;
+
+    set var.testing = "[1,2,3]";
+
+    // Pass because value contains valid JSON array.
+    assert.is_json(var.testing);
+
+    set var.testing = "[1,2,3,]";
+
+    // Fail because value contains array with trailing comma.
+    assert.is_json(var.testing);
 }
 ```
 

--- a/tester/function/assert_is_json.go
+++ b/tester/function/assert_is_json.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const Assert_is_json_Name = "testing.get_log"
+const Assert_is_json_Name = "assert.is_json"
 
 func Assert_is_json_Validate(args []value.Value) error {
 	if len(args) < 1 || len(args) > 2 {
@@ -23,7 +23,7 @@ func Assert_is_json_Validate(args []value.Value) error {
 
 	if len(args) == 2 {
 		if args[1].Type() != value.StringType {
-			return errors.TypeMismatch(Assert_ends_with_Name, 2, value.StringType, args[1].Type())
+			return errors.TypeMismatch(Assert_is_json_Name, 2, value.StringType, args[1].Type())
 		}
 	}
 	return nil
@@ -41,7 +41,7 @@ func Assert_is_json(
 	// Check custom message
 	var message string
 	if len(args) == 2 {
-		message = value.Unwrap[*value.String](args[2]).Value
+		message = value.Unwrap[*value.String](args[1]).Value
 	} else {
 		message = "Value should be JSON"
 	}
@@ -49,7 +49,7 @@ func Assert_is_json(
 	msg := value.Unwrap[*value.String](args[0])
 	valid := &value.Boolean{Value: json.Valid([]byte(msg.Value))}
 	if !valid.Value {
-		return valid, errors.NewAssertionError(valid, message)
+		return valid, errors.NewAssertionError(args[0], message)
 	}
 	return valid, nil
 }

--- a/tester/function/assert_is_json.go
+++ b/tester/function/assert_is_json.go
@@ -1,0 +1,55 @@
+package function
+
+import (
+	"encoding/json"
+
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/function/errors"
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+const Assert_is_json_Name = "testing.get_log"
+
+func Assert_is_json_Validate(args []value.Value) error {
+	if len(args) < 1 || len(args) > 2 {
+		return errors.ArgumentNotInRange(Assert_is_json_Name, 1, 2, args)
+	}
+
+	if args[0].Type() != value.StringType {
+		return errors.TypeMismatch(
+			Assert_is_json_Name, 1, value.StringType, args[0].Type(),
+		)
+	}
+
+	if len(args) == 2 {
+		if args[1].Type() != value.StringType {
+			return errors.TypeMismatch(Assert_ends_with_Name, 2, value.StringType, args[1].Type())
+		}
+	}
+	return nil
+}
+
+func Assert_is_json(
+	ctx *context.Context,
+	args ...value.Value,
+) (value.Value, error) {
+
+	if err := Assert_is_json_Validate(args); err != nil {
+		return nil, errors.NewTestingError(err.Error())
+	}
+
+	// Check custom message
+	var message string
+	if len(args) == 2 {
+		message = value.Unwrap[*value.String](args[2]).Value
+	} else {
+		message = "Value should be JSON"
+	}
+
+	msg := value.Unwrap[*value.String](args[0])
+	valid := &value.Boolean{Value: json.Valid([]byte(msg.Value))}
+	if !valid.Value {
+		return valid, errors.NewAssertionError(valid, message)
+	}
+	return valid, nil
+}

--- a/tester/function/assert_is_json_test.go
+++ b/tester/function/assert_is_json_test.go
@@ -19,6 +19,21 @@ func TestAssertIsJSON(t *testing.T) {
 	}{
 		{
 			args: []value.Value{
+				&value.Boolean{Value: false},
+			},
+			expect: nil,
+			err:    &errors.TestingError{},
+		},
+		{
+			args: []value.Value{
+				&value.String{Value: "[]"},
+				&value.Boolean{Value: false},
+			},
+			expect: nil,
+			err:    &errors.TestingError{},
+		},
+		{
+			args: []value.Value{
 				&value.String{Value: "[]"},
 			},
 			expect: &value.Boolean{Value: true},
@@ -32,16 +47,23 @@ func TestAssertIsJSON(t *testing.T) {
 		{
 			args: []value.Value{
 				&value.String{Value: "[1,2"},
+				&value.String{Value: "custom_message"},
 			},
 			expect: &value.Boolean{Value: false},
-			err:    &errors.AssertionError{},
+			err: &errors.AssertionError{
+				Actual:  &value.String{Value: "[1,2"},
+				Message: "custom_message",
+			},
 		},
 		{
 			args: []value.Value{
 				&value.String{Value: `{"foo: "bar"}`},
 			},
 			expect: &value.Boolean{Value: false},
-			err:    &errors.AssertionError{},
+			err: &errors.AssertionError{
+				Actual:  &value.String{Value: `{"foo: "bar"}`},
+				Message: "Value should be JSON",
+			},
 		},
 	}
 
@@ -53,10 +75,9 @@ func TestAssertIsJSON(t *testing.T) {
 		if diff := cmp.Diff(
 			tests[i].err,
 			err,
-			cmpopts.IgnoreFields(errors.AssertionError{}, "Message", "Actual"),
 			cmpopts.IgnoreFields(errors.TestingError{}, "Message"),
 		); diff != "" {
-			t.Errorf("AssertIsJSON()[%d] error: diff=%s", i, diff)
+			t.Errorf("Assert_is_json()[%d] error: diff=%s", i, diff)
 		}
 	}
 }

--- a/tester/function/assert_is_json_test.go
+++ b/tester/function/assert_is_json_test.go
@@ -1,0 +1,62 @@
+package function
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/function/errors"
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+func TestAssertIsJSON(t *testing.T) {
+
+	tests := []struct {
+		args   []value.Value
+		err    error
+		expect *value.Boolean
+	}{
+		{
+			args: []value.Value{
+				&value.String{Value: "[]"},
+			},
+			expect: &value.Boolean{Value: true},
+		},
+		{
+			args: []value.Value{
+				&value.String{Value: `{"foo": "bar"}`},
+			},
+			expect: &value.Boolean{Value: true},
+		},
+		{
+			args: []value.Value{
+				&value.String{Value: "[1,2"},
+			},
+			expect: &value.Boolean{Value: false},
+			err:    &errors.AssertionError{},
+		},
+		{
+			args: []value.Value{
+				&value.String{Value: `{"foo: "bar"}`},
+			},
+			expect: &value.Boolean{Value: false},
+			err:    &errors.AssertionError{},
+		},
+	}
+
+	for i := range tests {
+		_, err := Assert_is_json(
+			&context.Context{},
+			tests[i].args...,
+		)
+		if diff := cmp.Diff(
+			tests[i].err,
+			err,
+			cmpopts.IgnoreFields(errors.AssertionError{}, "Message", "Actual"),
+			cmpopts.IgnoreFields(errors.TestingError{}, "Message"),
+		); diff != "" {
+			t.Errorf("AssertIsJSON()[%d] error: diff=%s", i, diff)
+		}
+	}
+}

--- a/tester/function/functions.go
+++ b/tester/function/functions.go
@@ -358,6 +358,26 @@ func assertionFunctions(i *interpreter.Interpreter, c *shared.Counter) Functions
 				return false
 			},
 		},
+		"assert.is_json": {
+			Scope: allScope,
+			Call: func(ctx *context.Context, args ...value.Value) (value.Value, error) {
+				unwrapped, err := unwrapIdentArguments(i, args)
+				if err != nil {
+					return value.Null, errors.WithStack(err)
+				}
+				v, err := Assert_is_json(ctx, unwrapped...)
+				if err != nil {
+					c.Fail()
+				} else {
+					c.Pass()
+				}
+				return v, err
+			},
+			CanStatementCall: true,
+			IsIdentArgument: func(i int) bool {
+				return false
+			},
+		},
 		"assert.is_notset": {
 			Scope: allScope,
 			Call: func(ctx *context.Context, args ...value.Value) (value.Value, error) {


### PR DESCRIPTION
This adds a simple `assert.is_json()` function to the `tester` package, mainly to facilitate testing logging code: https://github.com/ysugimoto/falco/issues/249#issuecomment-1916123360

@richardmarshall did the implementation, I just stripped out other changes (though I think `testing.get_log()` is still valuable), resolved conflicts, and made some minor fixes.