### PR TITLE
Fully implement and fix `fastly.try_select_shield()`

### DIFF
--- a/interpreter/director.go
+++ b/interpreter/director.go
@@ -19,15 +19,6 @@ import (
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
-const (
-	DIRECTORTYPE_RANDOM   = "random"
-	DIRECTORTYPE_FALLBACK = "fallback"
-	DIRECTORTYPE_HASH     = "hash"
-	DIRECTORTYPE_CLIENT   = "client"
-	DIRECTORTYPE_CHASH    = "chash"
-	DIRECTORTYPE_SHIELD   = "shield"
-)
-
 var (
 	ErrQuorumWeightNotReached = errors.New("Quorum weight not reached")
 	ErrAllBackendsFailed      = errors.New("All backend failed")
@@ -74,7 +65,7 @@ func (i *Interpreter) getDirectorConfigBackend(o *ast.DirectorBackendObject) (*v
 func (i *Interpreter) setDirectorConfigProperty(conf *value.DirectorConfig, prop *ast.DirectorProperty) error {
 	switch prop.Key.Value {
 	case "quorum":
-		if conf.Type == DIRECTORTYPE_FALLBACK {
+		if conf.Type == value.DIRECTORTYPE_FALLBACK {
 			return exception.Runtime(
 				&prop.GetMeta().Token,
 				".quorum field must not be present in fallback director type",
@@ -95,7 +86,7 @@ func (i *Interpreter) setDirectorConfigProperty(conf *value.DirectorConfig, prop
 		conf.Quorum = int(left.Value)
 		return nil
 	case "retries":
-		if conf.Type != DIRECTORTYPE_RANDOM {
+		if conf.Type != value.DIRECTORTYPE_RANDOM {
 			return exception.Runtime(
 				&prop.GetMeta().Token,
 				".retries field must be present only in random director type",
@@ -108,7 +99,7 @@ func (i *Interpreter) setDirectorConfigProperty(conf *value.DirectorConfig, prop
 		}
 		return nil
 	case "key":
-		if conf.Type != DIRECTORTYPE_CHASH {
+		if conf.Type != value.DIRECTORTYPE_CHASH {
 			return exception.Runtime(
 				&prop.GetMeta().Token,
 				".key field must be present only in chash director type",
@@ -123,7 +114,7 @@ func (i *Interpreter) setDirectorConfigProperty(conf *value.DirectorConfig, prop
 		}
 		return nil
 	case "seed":
-		if conf.Type != DIRECTORTYPE_CHASH {
+		if conf.Type != value.DIRECTORTYPE_CHASH {
 			return exception.Runtime(
 				&prop.GetMeta().Token,
 				".seed field must be present only in chash director type",
@@ -136,7 +127,7 @@ func (i *Interpreter) setDirectorConfigProperty(conf *value.DirectorConfig, prop
 		}
 		return nil
 	case "vnodes_per_node":
-		if conf.Type != DIRECTORTYPE_CHASH {
+		if conf.Type != value.DIRECTORTYPE_CHASH {
 			return exception.Runtime(
 				&prop.GetMeta().Token,
 				".vnodes_per_node field must be present only in chash director type",
@@ -163,12 +154,12 @@ func (i *Interpreter) getDirectorConfig(d *ast.DirectorDeclaration) (*value.Dire
 
 	// Validate director type
 	switch d.DirectorType.Value {
-	case DIRECTORTYPE_RANDOM,
-		DIRECTORTYPE_FALLBACK,
-		DIRECTORTYPE_HASH,
-		DIRECTORTYPE_CLIENT,
-		DIRECTORTYPE_CHASH,
-		DIRECTORTYPE_SHIELD:
+	case value.DIRECTORTYPE_RANDOM,
+		value.DIRECTORTYPE_FALLBACK,
+		value.DIRECTORTYPE_HASH,
+		value.DIRECTORTYPE_CLIENT,
+		value.DIRECTORTYPE_CHASH,
+		value.DIRECTORTYPE_SHIELD:
 		conf.Type = d.DirectorType.Value
 	default:
 		return nil, exception.Runtime(
@@ -188,7 +179,7 @@ func (i *Interpreter) getDirectorConfig(d *ast.DirectorDeclaration) (*value.Dire
 			}
 			// Validate reqired properties
 			switch conf.Type {
-			case DIRECTORTYPE_RANDOM, DIRECTORTYPE_HASH, DIRECTORTYPE_CLIENT:
+			case value.DIRECTORTYPE_RANDOM, value.DIRECTORTYPE_HASH, value.DIRECTORTYPE_CLIENT:
 				if backend.Weight == 0 {
 					return nil, exception.Runtime(
 						&t.GetMeta().Token,
@@ -219,7 +210,7 @@ func (i *Interpreter) getDirectorConfig(d *ast.DirectorDeclaration) (*value.Dire
 		}
 	}
 
-	if len(conf.Backends) == 0 && d.DirectorType.Value != DIRECTORTYPE_SHIELD {
+	if len(conf.Backends) == 0 && d.DirectorType.Value != value.DIRECTORTYPE_SHIELD {
 		return nil, exception.Runtime(
 			&d.GetMeta().Token,
 			"At least one backend must be specified in director '%s'",
@@ -235,15 +226,15 @@ func (i *Interpreter) createDirectorRequest(ctx *context.Context, dc *value.Dire
 	var err error
 
 	switch dc.Type {
-	case DIRECTORTYPE_RANDOM:
+	case value.DIRECTORTYPE_RANDOM:
 		backend, err = i.directorBackendRandom(dc)
-	case DIRECTORTYPE_FALLBACK:
+	case value.DIRECTORTYPE_FALLBACK:
 		backend, err = i.directorBackendFallback(dc)
-	case DIRECTORTYPE_HASH:
+	case value.DIRECTORTYPE_HASH:
 		backend, err = i.directorBackendHash(dc)
-	case DIRECTORTYPE_CLIENT:
+	case value.DIRECTORTYPE_CLIENT:
 		backend, err = i.directorBackendClient(dc)
-	case DIRECTORTYPE_CHASH:
+	case value.DIRECTORTYPE_CHASH:
 		backend, err = i.directorBackendConsistentHash(dc)
 	default:
 		return nil, exception.System("Unexpected director type '%s' provided", dc.Type)

--- a/interpreter/function/builtin/fastly_try_select_shield.go
+++ b/interpreter/function/builtin/fastly_try_select_shield.go
@@ -3,8 +3,6 @@
 package builtin
 
 import (
-	"strings"
-
 	"github.com/ysugimoto/falco/interpreter/context"
 	"github.com/ysugimoto/falco/interpreter/function/errors"
 	"github.com/ysugimoto/falco/interpreter/value"
@@ -37,16 +35,18 @@ func Fastly_try_select_shield(ctx *context.Context, args ...value.Value) (value.
 	}
 
 	shield := value.Unwrap[*value.Backend](args[0])
-	fallback := value.Unwrap[*value.Backend](args[0])
+	fallback := value.Unwrap[*value.Backend](args[1])
 
 	// If first argument is not a shield director, return fallback
 	if shield.Director == nil {
 		return fallback, nil
 	}
-	if !strings.EqualFold(shield.Director.Type, "shield") {
+	if shield.Director.Type != value.DIRECTORTYPE_SHIELD {
+		return fallback, nil
+	}
+	if shield.Healthy == nil || !shield.Healthy.Load() {
 		return fallback, nil
 	}
 
-	// Note that our interpreter could not consider about director/backend is healthy.
 	return shield, nil
 }

--- a/interpreter/value/director.go
+++ b/interpreter/value/director.go
@@ -16,3 +16,12 @@ type DirectorConfigBackend struct {
 	Id      string
 	Weight  int
 }
+
+const (
+	DIRECTORTYPE_RANDOM   = "random"
+	DIRECTORTYPE_FALLBACK = "fallback"
+	DIRECTORTYPE_HASH     = "hash"
+	DIRECTORTYPE_CLIENT   = "client"
+	DIRECTORTYPE_CHASH    = "chash"
+	DIRECTORTYPE_SHIELD   = "shield"
+)


### PR DESCRIPTION
This completes the implementation of [fastly.try_select_shield()](https://www.fastly.com/documentation/reference/vcl/functions/miscellaneous/fastly-try-select-shield/) and fixes a minor bug with the fallback logic. I also added tests.