### PR TITLE
Fix string concatenation with RTIME idents

### DIFF
--- a/interpreter/expression.go
+++ b/interpreter/expression.go
@@ -476,7 +476,6 @@ func (i *Interpreter) ProcessStringConcatInfixExpression(exp *ast.InfixExpressio
 						}
 					}
 				}
-				continue
 			}
 			rv, opErr = operator.Concat(rv, cv)
 			if opErr != nil {

--- a/interpreter/expression_test.go
+++ b/interpreter/expression_test.go
@@ -384,9 +384,20 @@ func TestProcessStringConcat(t *testing.T) {
 			isError: true,
 		},
 		{
-			name:    "RTIME concatenation",
+			name:    "RTIME literal concatenation",
 			vcl:     `sub vcl_recv { set req.http.Foo = "foo" + 6s; }`,
 			isError: true,
+		},
+		{
+			name: "RTIME ident concatenation",
+			vcl: `sub vcl_recv {
+				declare local var.R RTIME;
+				set var.R = 5m;
+				set req.http.Foo = "foo" var.R;
+			}`,
+			assertions: map[string]value.Value{
+				"req.http.Foo": &value.String{Value: "foo300.000"},
+			},
 		},
 		{
 			name: "TIME concatenation",


### PR DESCRIPTION
Trying to concat a string with an RTIME ident (as in the new test case) causes the RTIME to be discarded. This fixes the concatenation logic and adds a test.