### PR TITLE
fix: Order snippets by ascending priority

### DIFF
--- a/snippets/fetch.go
+++ b/snippets/fetch.go
@@ -264,7 +264,7 @@ func fetchVCLSnippets(fetcher Fetcher) (
 
 	// Sort by priority
 	sort.Slice(snippets, func(i, j int) bool {
-		return snippets[i].Priority > snippets[j].Priority
+		return snippets[i].Priority < snippets[j].Priority
 	})
 
 	scoped := make(map[string][]SnippetItem)


### PR DESCRIPTION
Sort snippets by Priority ascending, not descending, to match documentation: “Priority determines execution order. Lower numbers execute first.” https://www.fastly.com/documentation/reference/api/vcl-services/snippet/