### PR TITLE
Make querystring.get not decode query keys

### DIFF
--- a/interpreter/function/builtin/querystring_get.go
+++ b/interpreter/function/builtin/querystring_get.go
@@ -5,6 +5,7 @@ package builtin
 import (
 	"net/url"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/ysugimoto/falco/interpreter/context"
 	"github.com/ysugimoto/falco/interpreter/function/errors"
@@ -38,7 +39,20 @@ func Querystring_get(ctx *context.Context, args ...value.Value) (value.Value, er
 	}
 
 	v := value.Unwrap[*value.String](args[0])
-	name := value.Unwrap[*value.String](args[1])
+	nameValue := value.Unwrap[*value.String](args[1])
+	// Fastly behavior: pct-decode only (no '+' as space) for the argument name.
+	name, err := url.PathUnescape(nameValue.Value)
+	if err != nil {
+		// If URL decoding fails, return not set
+		return value.Null, errors.InvalidHexChar(Querystring_get_Name, 1)
+	}
+	if !utf8.ValidString(name) {
+		return value.Null, errors.UnexpectedByteInShortString(Querystring_get_Name, 1)
+	}
+	// Re-encode using query-component semantics but ensure space encodes as %20 (not '+').
+	// This yields: ' ' -> %20, '+' -> %2B, alnum stays, matching Fastly behavior.
+	name = url.QueryEscape(name)
+	name = strings.ReplaceAll(name, "+", "%20")
 
 	var qs string
 	if idx := strings.Index(v.Value, "?"); idx != -1 {
@@ -50,18 +64,13 @@ func Querystring_get(ctx *context.Context, args ...value.Value) (value.Value, er
 	// ?name= => should return not set, but returns empty string
 	// so we try to parse from RawQuery string, not using url.Value
 	for _, query := range strings.Split(qs, "&") {
-		sp := strings.Split(query, "=")
+		sp := strings.SplitN(query, "=", 2)
 		if len(sp) < 2 || sp[0] == "" {
 			continue
 		}
-		n, err := url.QueryUnescape(sp[0])
-		if err != nil {
-			continue
-		}
-		if n == name.Value {
+		if sp[0] == name && len(sp) >= 2 {
 			return &value.String{Value: sp[1]}, nil
 		}
 	}
-	// includes not set value
 	return &value.String{IsNotSet: true}, nil
 }

--- a/interpreter/function/errors/errors.go
+++ b/interpreter/function/errors/errors.go
@@ -37,6 +37,22 @@ func TypeMismatch(name string, num int, expects, actual value.Type) error {
 	return New(name, "Argument %d expects %s type but %s provided", num, expects, actual)
 }
 
+func CannotConvertToString(name string, num int) error {
+	return New(name, "Argument %d cannot convert to string because the value is literal", num)
+}
+
+// the error given when you querystring.get(req.url, "%ff");
+// fastly error is "Unexpected byte 0x%02X in UTF-8 in short-string"
+func UnexpectedByteInShortString(name string, num int) error {
+	return New(name, "Argument %d, after pct-decoding, is invalid utf-8", num)
+}
+
+// the error given when you querystring.get(req.url, "%eh");
+// fastly error is "Invalid hex char %c (0x%02X) in %%xx escape"
+func InvalidHexChar(name string, num byte) error {
+	return New(name, "Argument %d has invalid pct-encode sequence", num)
+}
+
 // Testing related errors
 type TestingError struct {
 	// Token info will be injected on interpreter


### PR DESCRIPTION
Make querystring.get not pct-decode the query keys as this does not match fastly behavior. But make it pct-decode and re-encode the key argument.

Pass through = in query parameter values instead of truncating values that have =.

Based on tests with fastly fiddle
https://fiddle.fastly.dev/fiddle/ed3feca5