### PR TITLE
Fix string concatenation with functional calls

### DIFF
--- a/interpreter/expression.go
+++ b/interpreter/expression.go
@@ -414,7 +414,8 @@ func (i *Interpreter) ProcessStringConcatInfixExpression(exp *ast.InfixExpressio
 				return value.Null, errors.WithStack(err)
 			}
 		case *ast.FunctionCallExpression:
-			if cv.Type() != value.StringType {
+			// Fiddle: https://fiddle.fastly.dev/fiddle/e71a005f
+			if cv.Type() == value.BackendType || cv.Type() == value.AclType {
 				return value.Null, exception.Runtime(
 					&s.Expression.GetMeta().Token,
 					"Cannot use %s type for string concatenation",

--- a/interpreter/expression_test.go
+++ b/interpreter/expression_test.go
@@ -407,8 +407,57 @@ func TestProcessStringConcat(t *testing.T) {
 			},
 		},
 		{
-			name:    "FunctionCall expression concatenation with not string",
-			vcl:     `sub vcl_recv { set req.http.Foo = "foo" + std.atoi("foo"); }`,
+			name: "FunctionCall expression concatenation with integer",
+			vcl:  `sub vcl_recv { set req.http.Foo = "foo" + std.atoi("10"); }`,
+			assertions: map[string]value.Value{
+				"req.http.Foo": &value.String{Value: "foo10"},
+			},
+		},
+		{
+			name: "FunctionCall expression concatenation with boolean",
+			vcl:  `sub vcl_recv { set req.http.Foo = "foo" + math.is_finite(1.0); }`,
+			assertions: map[string]value.Value{
+				"req.http.Foo": &value.String{Value: "foo1"},
+			},
+		},
+		{
+			name: "FunctionCall expression concatenation with float",
+			vcl:  `sub vcl_recv { set req.http.Foo = "foo" + math.exp(1.0); }`,
+			assertions: map[string]value.Value{
+				"req.http.Foo": &value.String{Value: "foo2.718"},
+			},
+		},
+		{
+			name: "FunctionCall expression concatenation with IP",
+			vcl:  `sub vcl_recv { set req.http.Foo = "foo" + std.str2ip("192.0.2.1", "192.0.2.2"); }`,
+			assertions: map[string]value.Value{
+				"req.http.Foo": &value.String{Value: "foo192.0.2.1"},
+			},
+		},
+		{
+			name: "FunctionCall expression concatenation with time",
+			vcl:  `sub vcl_recv { set req.http.Foo = "foo" + std.time("Mon, 02 Jan 2006 22:04:05 GMT", now); }`,
+			assertions: map[string]value.Value{
+				"req.http.Foo": &value.String{Value: "fooMon, 02 Jan 2006 22:04:05 GMT"},
+			},
+		},
+		{
+			name: "FunctionCall expression concatenation with ACL",
+			vcl: `
+			acl empty{}
+			table ext ACL { "ext": empty, }
+			sub vcl_recv {
+				set req.http.Foo = "foo" + table.lookup_acl(ext, req.url.ext, empty);
+			}`,
+			isError: true,
+		},
+		{
+			name: "FunctionCall expression concatenation with backend",
+			vcl: `
+			table t BACKEND { "test": F_origin_0, }
+			sub vcl_recv {
+				set req.http.Foo = "foo" + table.lookup_backend(t, "test2", req.backend);
+			}`,
 			isError: true,
 		},
 		{


### PR DESCRIPTION
This relaxes the restriction on concatenating strings with functional call expressions to allow all functions except those returning `ACL` or `BACKEND` types. Fiddle: https://fiddle.fastly.dev/fiddle/e71a005f