### PR TITLE
ability to check origin host header

### DIFF
--- a/cmd/falco/runner_test.go
+++ b/cmd/falco/runner_test.go
@@ -384,10 +384,22 @@ func TestTester(t *testing.T) {
 			passes: 10,
 		},
 		{
-			name:   "synthetic vs obj.resoonse",
+			name:   "synthetic vs obj.response",
 			main:   "../../examples/testing/synthetic_response/default.vcl",
 			filter: "*default.test.vcl",
 			passes: 2,
+		},
+		{
+			name:   "rate limiting",
+			main:   "../../examples/testing/rate_limiting/main.vcl",
+			filter: "*main.test.vcl",
+			passes: 1,
+		},
+		{
+			name:   "origin host header",
+			main:   "../../examples/testing/origin_host_header/main.vcl",
+			filter: "*main.test.vcl",
+			passes: 5,
 		},
 	}
 

--- a/examples/testing/origin_host_header/main.test.vcl
+++ b/examples/testing/origin_host_header/main.test.vcl
@@ -1,0 +1,23 @@
+sub test_recv {
+  assert.equal(testing.origin_host_header, "localhost");
+}
+
+sub test_example {
+  set req.backend = example;
+  assert.equal(testing.origin_host_header, "localhost");
+}
+
+sub test_override_example {
+  set req.backend = override_example;
+  assert.equal(testing.origin_host_header, "example.com");
+}
+
+sub test_dynamic_example {
+  set req.backend = dynamic_example;
+  assert.equal(testing.origin_host_header, "localhost");
+}
+
+sub test_dynamic_override_example {
+  set req.backend = dynamic_override_example;
+  assert.equal(testing.origin_host_header, "dynamic.example.com");
+}

--- a/examples/testing/origin_host_header/main.vcl
+++ b/examples/testing/origin_host_header/main.vcl
@@ -1,0 +1,23 @@
+backend example {
+  .host = "example.com";
+  .port = "443";
+}
+
+backend override_example {
+  .host = "example.com";
+  .port = "443";
+  .always_use_host_header = true;
+}
+
+backend dynamic_example {
+  .dynamic = true;
+  .host = "example.com";
+  .port = "443";
+}
+
+backend dynamic_override_example {
+  .dynamic = true;
+  .host = "example.com";
+  .port = "443";
+  .host_header = "dynamic.example.com";
+}

--- a/examples/testing/rate_limiting/main.test.vcl
+++ b/examples/testing/rate_limiting/main.test.vcl
@@ -1,5 +1,5 @@
 sub test_recv {
-  testing.set_access_rate(100);
+  testing.fixed_access_rate(100);
   testing.call_subroutine("vcl_recv");
   assert.equal(req.http.Rate-Limit-Exceeded, "1");
 }

--- a/interpreter/transport.go
+++ b/interpreter/transport.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gobwas/glob"
+	"github.com/k0kubun/pp"
 	"github.com/pkg/errors"
 	"github.com/ysugimoto/falco/ast"
 	"github.com/ysugimoto/falco/config"
@@ -98,13 +99,6 @@ func (i *Interpreter) createBackendRequest(ctx *icontext.Context, backend *value
 		}
 	}
 
-	var alwaysHost bool
-	if v, err := i.getBackendProperty(backend.Value.Properties, "always_use_host_header"); err != nil {
-		return nil, errors.WithStack(err)
-	} else if v != nil {
-		alwaysHost = value.Unwrap[*value.Boolean](v).Value
-	}
-
 	if port == "" {
 		if scheme == HTTPS_SCHEME {
 			port = "443"
@@ -130,10 +124,39 @@ func (i *Interpreter) createBackendRequest(ctx *icontext.Context, backend *value
 	req.Header = i.ctx.Request.Header.Clone()
 	setupFastlyHeaders(req)
 
-	if alwaysHost {
-		req.Header.Set("Host", host)
+	hostHeader, err := i.getOriginHostHeader(backend, host)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	} else if hostHeader != nil {
+		req.Header.Set("Host", *hostHeader)
 	}
 	return req, nil
+}
+
+func (i *Interpreter) getOriginHostHeader(backend *value.Backend, defaultHost string) (*string, error) {
+	// Check backend is dynamic
+	if v, err := i.getBackendProperty(backend.Value.Properties, "dynamic"); err != nil {
+		pp.Println("dynamic get error")
+		return nil, errors.WithStack(err)
+	} else if v != nil && v.Type() == value.BooleanType {
+		pp.Println("dynamic boolean")
+		// If backend is dynamic, lookup .host_header field value
+		if vv, err := i.getBackendProperty(backend.Value.Properties, "host_header"); err != nil {
+			return nil, errors.WithStack(err)
+		} else if vv != nil && vv.Type() == value.StringType {
+			return &value.Unwrap[*value.String](vv).Value, nil
+		}
+	}
+
+	// Otherwise, check .always_use_host_header is defined
+	if v, err := i.getBackendProperty(backend.Value.Properties, "always_use_host_header"); err != nil {
+		return nil, errors.WithStack(err)
+	} else if v != nil && v.Type() == value.BooleanType {
+		if value.Unwrap[*value.Boolean](v).Value {
+			return &defaultHost, nil
+		}
+	}
+	return nil, nil
 }
 
 func (i *Interpreter) sendBackendRequest(backend *value.Backend) (*http.Response, error) {

--- a/tester/variable/testing.go
+++ b/tester/variable/testing.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/ysugimoto/falco/ast"
 	"github.com/ysugimoto/falco/interpreter/context"
 	"github.com/ysugimoto/falco/interpreter/value"
 	iv "github.com/ysugimoto/falco/interpreter/variable"
@@ -12,8 +13,9 @@ import (
 
 // Dedicated for testing variables
 const (
-	TESTING_STATE          = "testing.state"
-	TESTING_SYNTHETIC_BODY = "testing.synthetic_body"
+	TESTING_STATE              = "testing.state"
+	TESTING_SYNTHETIC_BODY     = "testing.synthetic_body"
+	TESTING_ORIGIN_HOST_HEADER = "testing.origin_host_header"
 )
 
 type TestingVariables struct {
@@ -38,6 +40,22 @@ func (v *TestingVariables) Get(ctx *context.Context, scope context.Scope, name s
 		} else {
 			return nil, err
 		}
+	case TESTING_ORIGIN_HOST_HEADER:
+		if ctx.Backend == nil {
+			return nil, errors.New("backend is not determined")
+		}
+		// Attempt to get dynamic backend host header
+		if v := getDynamicBackendHostHeader(ctx.Backend); v != "" {
+			return &value.String{Value: v}, nil
+		}
+		// Attempt to get static backend host header
+		if v := getStaticBackendHostHeader(ctx.Backend); v != "" {
+			return &value.String{Value: v}, nil
+		}
+		// Return received host header on the CDN as default
+		return &value.String{
+			Value: ctx.Request.Header.Get("Host"),
+		}, nil
 	}
 
 	return nil, errors.New("Not Found")
@@ -52,4 +70,61 @@ func (v *TestingVariables) Set(
 ) error {
 
 	return errors.New("Testing variables are read-only")
+}
+
+// Get override host header for dynamic backend
+func getDynamicBackendHostHeader(backend *value.Backend) string {
+	// For dynamic backend, `.dynamic = true;` property should be found and value should be true
+	prop := getBackendProperty(backend, "dynamic")
+	if prop == nil {
+		return ""
+	}
+	if b, ok := prop.(*ast.Boolean); !ok || !b.Value {
+		return ""
+	}
+
+	// Get override host header from ".host_header" field value
+	prop = getBackendProperty(backend, "host_header")
+	if prop == nil {
+		return ""
+	}
+	str, ok := prop.(*ast.String)
+	if !ok {
+		return ""
+	}
+	return str.Value
+}
+
+// Get override host header for static backend
+func getStaticBackendHostHeader(backend *value.Backend) string {
+	// Lookup `.always_use_host_header = true;` property and override when value is true
+	prop := getBackendProperty(backend, "always_use_host_header")
+	if prop == nil {
+		return ""
+	}
+	if b, ok := prop.(*ast.Boolean); !ok || !b.Value {
+		return ""
+	}
+
+	// Get override host header from ".host" field value
+	prop = getBackendProperty(backend, "host")
+	if prop == nil {
+		return ""
+	}
+	str, ok := prop.(*ast.String)
+	if !ok {
+		return ""
+	}
+	return str.Value
+}
+
+func getBackendProperty(backend *value.Backend, key string) ast.Expression {
+	for _, v := range backend.Value.Properties {
+		if v.Key.Value != key {
+			continue
+		}
+		return v.Value
+	}
+
+	return nil
 }


### PR DESCRIPTION
Fixes #484 

This PR equips ability to check actual `Host` header to send to origin.
In case of testing, sometimes the user would like to check the `Host` header is origin's one by adding `.always_use_host_header = true;` field in `backend` declaration.

This PR implements new testing variable `testing.origin_host_header`, which can get actual `Host` header value for sending origin.

Note that this variable is calculated from `backend` configuration so it isn't actual behavior of Fastly, I'm not sure what is the best timing to add the header value - undocumented on Fastly.