### PR TITLE
Add AES-GCM support to crypto functions

### DIFF
--- a/interpreter/function/builtin/crypto_decrypt_base64.go
+++ b/interpreter/function/builtin/crypto_decrypt_base64.go
@@ -59,6 +59,11 @@ func Crypto_decrypt_base64(ctx *context.Context, args ...value.Value) (value.Val
 
 	decrypted, err := codec.Decrypt(key.Value, iv.Value, buf)
 	if err != nil {
+		// Check if this is a GCM authentication failure
+		if _, ok := err.(*shared.BadDecryptError); ok {
+			ctx.FastlyError = &value.String{Value: "EBADDECRYPT"}
+			return &value.String{Value: ""}, nil
+		}
 		return value.Null, err
 	}
 

--- a/interpreter/function/builtin/crypto_decrypt_hex.go
+++ b/interpreter/function/builtin/crypto_decrypt_hex.go
@@ -59,6 +59,11 @@ func Crypto_decrypt_hex(ctx *context.Context, args ...value.Value) (value.Value,
 
 	decrypted, err := codec.Decrypt(key.Value, iv.Value, buf)
 	if err != nil {
+		// Check if this is a GCM authentication failure
+		if _, ok := err.(*shared.BadDecryptError); ok {
+			ctx.FastlyError = &value.String{Value: "EBADDECRYPT"}
+			return &value.String{Value: ""}, nil
+		}
 		return value.Null, err
 	}
 

--- a/linter/context/identifilers.go
+++ b/linter/context/identifilers.go
@@ -20,6 +20,7 @@ func builtinIdentifiers() map[string]struct{} {
 		// https://developer.fastly.com/reference/vcl/functions/cryptographic/crypto-encrypt-hex/
 		"cbc": {},
 		"ctr": {},
+		"gcm": {},
 
 		// use for crypto.encrypt_xxx function padding argument
 		// https://developer.fastly.com/reference/vcl/functions/cryptographic/crypto-encrypt-hex/


### PR DESCRIPTION
Implements AES-GCM authenticated encryption for `crypto.encrypt_hex`/`base64` and `crypto.decrypt_hex`/`base64` functions.

This was recently added to Fastly VCL.