### PR TITLE
remove legacy waf related documentation reference

### DIFF
--- a/cmd/documentation-checker/variables.go
+++ b/cmd/documentation-checker/variables.go
@@ -26,7 +26,8 @@ var fastlyVariableCategoryPageUrls = []string{
 	"/reference/vcl/variables/rate-limiting/",
 	"/reference/vcl/variables/segmented-caching/",
 	"/reference/vcl/variables/server/",
-	"/reference/vcl/variables/waf/",
+	// Note: legacy waf related variables are no longer documented.
+	// "/reference/vcl/variables/waf/",
 }
 
 const predefinedPath = "../../__generator__/predefined.yml"


### PR DESCRIPTION
A documentation for legacy waf related variables is removed on the Fastly docs.

In detail, the legacy waf page https://developer.fastly.com/reference/vcl/variables/waf/ now redirects to https://docs.fastly.com/products/fastly-next-gen-waf#documentation, NGWAF documentation.

Therefore our documentation checker should drop fetching it.