### PR TITLE
Copy ForceQury to add query sign even query string is empty

### DIFF
--- a/cmd/falco/runner_test.go
+++ b/cmd/falco/runner_test.go
@@ -401,6 +401,12 @@ func TestTester(t *testing.T) {
 			filter: "*main.test.vcl",
 			passes: 5,
 		},
+		{
+			name:   "do not omit query sign",
+			main:   "../../examples/testing/query_sign/default.vcl",
+			filter: "*default.test.vcl",
+			passes: 2,
+		},
 	}
 
 	for _, tt := range tests {

--- a/examples/testing/query_sign/default.test.vcl
+++ b/examples/testing/query_sign/default.test.vcl
@@ -1,0 +1,9 @@
+sub test_vcl_recv {
+  testing.call_subroutine("vcl_recv");
+  assert.equal(req.url, "/test?foo=bar");
+}
+
+sub test_empty_query_sign {
+  set req.url = "/test?";
+  assert.equal(req.url, "/test?");
+}

--- a/examples/testing/query_sign/default.vcl
+++ b/examples/testing/query_sign/default.vcl
@@ -1,0 +1,5 @@
+sub vcl_recv {
+  set req.url = "/test";
+  set req.url = req.url "?";
+  set req.url = req.url "foo=bar";
+}

--- a/interpreter/variable/all.go
+++ b/interpreter/variable/all.go
@@ -650,6 +650,8 @@ func (v *AllScopeVariables) Get(s context.Scope, name string) (value.Value, erro
 		u := getRawUrlPath(req.URL)
 		if v := req.URL.RawQuery; v != "" {
 			u += "?" + v
+		} else if req.URL.ForceQuery {
+			u += "?"
 		}
 		if v := req.URL.RawFragment; v != "" {
 			u += "#" + v
@@ -924,6 +926,8 @@ func (v *AllScopeVariables) Set(s context.Scope, name, operator string, val valu
 		u := getRawUrlPath(v.ctx.Request.URL)
 		if query := v.ctx.Request.URL.RawQuery; query != "" {
 			u += "?" + query
+		} else if v.ctx.Request.URL.ForceQuery {
+			u += "?"
 		}
 		if fragment := v.ctx.Request.URL.RawFragment; fragment != "" {
 			u += "#" + fragment
@@ -941,6 +945,7 @@ func (v *AllScopeVariables) Set(s context.Scope, name, operator string, val valu
 		v.ctx.Request.URL.RawPath = parsed.RawPath
 		v.ctx.Request.URL.RawQuery = parsed.RawQuery
 		v.ctx.Request.URL.RawFragment = parsed.RawFragment
+		v.ctx.Request.URL.ForceQuery = parsed.ForceQuery
 		return nil
 	}
 


### PR DESCRIPTION
Fixes #506

From the issue, Fastly should not query sign of "?" even query string is empty like:

```vcl
set req.url = "/foo?";
```

On this case, golang's `*urlURL` struct has `ForceQuery` field to hold the query sign when query string is empty.
This PR copies this boolean field on get/set variable of `req.url` on interpreter and confirm satisfies the cases of the issue.