### PR TITLE
fix synthetic response and obj.response relevants

### DIFF
--- a/examples/testing/synthetic_response/default.test.vcl
+++ b/examples/testing/synthetic_response/default.test.vcl
@@ -2,6 +2,5 @@
 sub test_vcl {
   testing.call_subroutine("vcl_error");
   assert.equal(testing.synthetic_body, "No dice.");
-  // obj.response could not set after the syntheic response has called.
-  assert.is_notset(obj.response);
+  assert.equal(obj.response, "Overwritten");
 }

--- a/examples/testing/synthetic_response/default.vcl
+++ b/examples/testing/synthetic_response/default.vcl
@@ -1,4 +1,4 @@
 sub vcl_error {
   synthetic "No dice.";
-  set obj.response = "OK";
+  set obj.response = "Overwritten";
 }

--- a/interpreter/context/context.go
+++ b/interpreter/context/context.go
@@ -182,12 +182,6 @@ type Context struct {
 	// Marker that return request is purge request.
 	IsPurgeRequest bool
 
-	// Flag for a synthetic response has been set.
-	// It means that some VCL will set response phase like `set obj.response = "xxx"`
-	// but we should ignore when synthetic response has already set.
-	// Note that obj.response is deprecated after HTTP/1.1 but VCL still supports this spec.
-	HasSyntheticResponse bool
-
 	OverrideVariables map[string]value.Value
 }
 

--- a/interpreter/handler.go
+++ b/interpreter/handler.go
@@ -81,14 +81,15 @@ func (i *Interpreter) sendProcessResponse(w http.ResponseWriter) {
 }
 
 func (i *Interpreter) sendResponse(w http.ResponseWriter) {
-	h := w.Header()
-	for key, val := range i.ctx.Response.Header {
-		for i := range val {
-			h.Add(key, val[i])
-		}
-	}
-	w.WriteHeader(i.ctx.Response.StatusCode)
-	io.Copy(w, i.ctx.Response.Body) // nolint:errcheck
+	// We have to use (*http.Response).Write(io.Writer)
+	// in order to write custom status text which is set via obj.response variable.
+	//
+	// Typically, on handling HTTP, http.ResponseWriter interface is enough to respond regular HTTP specs
+	// but could not set custom status text on the status line.
+	//
+	// Fortunately (*http.Response).Write(io.Writer) method will support to output custom status text
+	// so we need to send HTTP response via this method.
+	i.ctx.Response.Write(w) // nolint:errcheck
 }
 
 func (i *Interpreter) sendPurgeRequestResponse(w http.ResponseWriter, err error) {

--- a/interpreter/statement.go
+++ b/interpreter/statement.go
@@ -445,7 +445,6 @@ func (i *Interpreter) ProcessSyntheticStatement(stmt *ast.SyntheticStatement) er
 		return exception.Runtime(&stmt.GetMeta().Token, "%s", err.Error())
 	}
 	i.ctx.Object.Body = nopSeekCloser(strings.NewReader(v.Value))
-	i.ctx.HasSyntheticResponse = true
 	return nil
 }
 
@@ -459,7 +458,6 @@ func (i *Interpreter) ProcessSyntheticBase64Statement(stmt *ast.SyntheticBase64S
 		return exception.Runtime(&stmt.GetMeta().Token, "%s", err.Error())
 	}
 	i.ctx.Object.Body = nopSeekCloser(strings.NewReader(v.Value))
-	i.ctx.HasSyntheticResponse = true
 	return nil
 }
 

--- a/interpreter/variable/error.go
+++ b/interpreter/variable/error.go
@@ -211,11 +211,6 @@ func (v *ErrorScopeVariables) Set(s context.Scope, name, operator string, val va
 		}
 		return nil
 	case OBJ_RESPONSE:
-		// If synthetic response has already been set, ignore this assignment.
-		if v.ctx.HasSyntheticResponse {
-			return nil
-		}
-
 		if err := doAssign(v.ctx.ObjectResponse, operator, val); err != nil {
 			return errors.WithStack(err)
 		}

--- a/interpreter/variable/hit.go
+++ b/interpreter/variable/hit.go
@@ -106,11 +106,6 @@ func (v *HitScopeVariables) Set(s context.Scope, name, operator string, val valu
 		}
 		return nil
 	case OBJ_RESPONSE:
-		// If synthetic response has already been set, ignore this assignment.
-		if v.ctx.HasSyntheticResponse {
-			return nil
-		}
-
 		if err := doAssign(v.ctx.ObjectResponse, operator, val); err != nil {
 			return errors.WithStack(err)
 		}


### PR DESCRIPTION
Fixes #493

Once I fixed error handling related feature of `synthetic` statement and `obj.response` variable but I misunderstood position of affection to the HTTP response:

- `synthetic`: Response body
- `obj.response`: Status text of HTTP response status line `e.g HTTP/1.1 200 [obj.response value]`

Therefore, these values will not affect each other, VCL could set both values independently.
This PR fixes above spec and follows Fastly spec and add another tiny fix.

The Fastly default response headers like `Date`, `X-Cache`, etc... could unset on the `vcl_deliver` subroutine so falco should set these default headers before calling `vcl_deliver` subroutine. Before this fix, default headers always present on proxy response. it should be adjust with Faslty behavior also.

@jedisct1 I'm happy if you can review slightly even caused by my implementation, not necessary!