### PR TITLE
formatter supports custom subroutine parameters

### DIFF
--- a/formatter/declaration_format.go
+++ b/formatter/declaration_format.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/ysugimoto/falco/ast"
 )
@@ -354,7 +355,19 @@ func (f *Formatter) formatSubroutineDeclaration(decl *ast.SubroutineDeclaration)
 	defer bufferPool.Put(buf)
 
 	buf.Reset()
-	buf.WriteString("sub " + decl.Name.String() + " ")
+	buf.WriteString("sub " + decl.Name.String())
+
+	// Format subroutine parameters if exists
+	if len(decl.Parameters) > 0 {
+		args := make([]string, len(decl.Parameters))
+		for i, param := range decl.Parameters {
+			args[i] = param.Type.String() + " " + param.Name.String()
+		}
+		buf.WriteString("(" + strings.Join(args, ", ") + ")")
+	}
+
+	buf.WriteString(" ")
+
 	// Functional Subroutine
 	if decl.ReturnType != nil {
 		buf.WriteString(decl.ReturnType.String() + " ")

--- a/formatter/declaration_format_test.go
+++ b/formatter/declaration_format_test.go
@@ -486,6 +486,24 @@ sub /* before_name */ foo /* after_name */ STRING /* after_type */ {
 }  // subroutine trailing comment
 `,
 		},
+		{
+			name: "with arguments",
+			input: `
+sub bar(STRING var.str, BACKEND var.backend) BACKEND {
+  if (var.str == "ok") {
+    return var.backend;
+  }
+  return default_backend;
+}
+`,
+			expect: `sub bar(STRING var.str, BACKEND var.backend) BACKEND {
+  if (var.str == "ok") {
+    return var.backend;
+  }
+  return default_backend;
+}
+`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/formatter/statement_format.go
+++ b/formatter/statement_format.go
@@ -489,6 +489,19 @@ func (f *Formatter) formatCallStatement(stmt *ast.CallStatement) string {
 
 	buf.Reset()
 	buf.WriteString("call " + stmt.Subroutine.String())
+
+	// Add function arguments if specified
+	if len(stmt.Arguments) > 0 {
+		buf.WriteString("(")
+		length := buf.Len()
+		for i, arg := range stmt.Arguments {
+			buf.WriteString(f.formatExpression(arg).ChunkedString(stmt.Nest, length))
+			if i != len(stmt.Arguments)-1 {
+				buf.WriteString(", ")
+			}
+		}
+		buf.WriteString(")")
+	}
 	buf.WriteString(";")
 
 	return buf.String()

--- a/formatter/statement_format_test.go
+++ b/formatter/statement_format_test.go
@@ -371,6 +371,17 @@ func TestFormatCallStatement(t *testing.T) {
 }
 `,
 		},
+		{
+			name: "with arguments",
+			input: `sub vcl_recv {
+  call  feature_recv(var.foo,var.bar );
+}
+`,
+			expect: `sub vcl_recv {
+  call feature_recv(var.foo, var.bar);
+}
+`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Related https://github.com/ysugimoto/falco/pull/501#issuecomment-3613224675

My apologies that I forgot to review for formatter implementation in #501, so we should support custom subroutine parameters on formatter.

I think we don't need additional formatter options for this, simply added formatting logic 🙃   