### PR TITLE
digest_hmac_* : add a 0x prefix

### DIFF
--- a/interpreter/function/builtin/digest_hmac_md5.go
+++ b/interpreter/function/builtin/digest_hmac_md5.go
@@ -44,6 +44,6 @@ func Digest_hmac_md5(ctx *context.Context, args ...value.Value) (value.Value, er
 	mac.Write([]byte(input.Value))
 
 	return &value.String{
-		Value: hex.EncodeToString(mac.Sum(nil)),
+		Value: "0x" + hex.EncodeToString(mac.Sum(nil)),
 	}, nil
 }

--- a/interpreter/function/builtin/digest_hmac_md5_test.go
+++ b/interpreter/function/builtin/digest_hmac_md5_test.go
@@ -27,7 +27,7 @@ func Test_Digest_hmac_md5(t *testing.T) {
 		t.Errorf("Unexpected return type, expect=STRING, got=%s", ret.Type())
 	}
 	v := value.Unwrap[*value.String](ret)
-	expect := "bf8d470185ab817f3c92bb5cef1fd7d5"
+	expect := "0xbf8d470185ab817f3c92bb5cef1fd7d5"
 	if v.Value != expect {
 		t.Errorf("return value unmatch, expect=%s, got=%s", expect, v.Value)
 	}

--- a/interpreter/function/builtin/digest_hmac_sha1.go
+++ b/interpreter/function/builtin/digest_hmac_sha1.go
@@ -44,6 +44,6 @@ func Digest_hmac_sha1(ctx *context.Context, args ...value.Value) (value.Value, e
 	mac.Write([]byte(input.Value))
 
 	return &value.String{
-		Value: hex.EncodeToString(mac.Sum(nil)),
+		Value: "0x" + hex.EncodeToString(mac.Sum(nil)),
 	}, nil
 }

--- a/interpreter/function/builtin/digest_hmac_sha1_test.go
+++ b/interpreter/function/builtin/digest_hmac_sha1_test.go
@@ -27,7 +27,7 @@ func Test_Digest_hmac_sha1(t *testing.T) {
 		t.Errorf("Unexpected return type, expect=STRING, got=%s", ret.Type())
 	}
 	v := value.Unwrap[*value.String](ret)
-	expect := "8513bb355076cce2ae5eb9f399ab5cafdba7c8a2"
+	expect := "0x8513bb355076cce2ae5eb9f399ab5cafdba7c8a2"
 	if v.Value != expect {
 		t.Errorf("return value unmatch, expect=%s, got=%s", expect, v.Value)
 	}

--- a/interpreter/function/builtin/digest_hmac_sha256.go
+++ b/interpreter/function/builtin/digest_hmac_sha256.go
@@ -44,6 +44,6 @@ func Digest_hmac_sha256(ctx *context.Context, args ...value.Value) (value.Value,
 	mac.Write([]byte(input.Value))
 
 	return &value.String{
-		Value: hex.EncodeToString(mac.Sum(nil)),
+		Value: "0x" + hex.EncodeToString(mac.Sum(nil)),
 	}, nil
 }

--- a/interpreter/function/builtin/digest_hmac_sha256_test.go
+++ b/interpreter/function/builtin/digest_hmac_sha256_test.go
@@ -27,7 +27,7 @@ func Test_Digest_hmac_sha256(t *testing.T) {
 		t.Errorf("Unexpected return type, expect=STRING, got=%s", ret.Type())
 	}
 	v := value.Unwrap[*value.String](ret)
-	expect := "9e089ec13af881a8ac227a736c3e7c490ea3b4afca0c5f83dff6393b683a72e3"
+	expect := "0x9e089ec13af881a8ac227a736c3e7c490ea3b4afca0c5f83dff6393b683a72e3"
 	if v.Value != expect {
 		t.Errorf("return value unmatch, expect=%s, got=%s", expect, v.Value)
 	}

--- a/interpreter/function/builtin/digest_hmac_sha256_with_base64_key.go
+++ b/interpreter/function/builtin/digest_hmac_sha256_with_base64_key.go
@@ -52,6 +52,6 @@ func Digest_hmac_sha256_with_base64_key(ctx *context.Context, args ...value.Valu
 	mac.Write([]byte(input.Value))
 
 	return &value.String{
-		Value: hex.EncodeToString(mac.Sum(nil)),
+		Value: "0x" + hex.EncodeToString(mac.Sum(nil)),
 	}, nil
 }

--- a/interpreter/function/builtin/digest_hmac_sha256_with_base64_key_test.go
+++ b/interpreter/function/builtin/digest_hmac_sha256_with_base64_key_test.go
@@ -25,27 +25,27 @@ func Test_Digest_hmac_sha256_with_base64_key(t *testing.T) {
 		{
 			keyHex:  "5d694a15baddf0f503fec7e65ba434d3",
 			message: "st=1678885238~exp=1679749238~acl=/*",
-			expect:  "6a2915695030d8b83ae5c9c12d521a9f84d192398bb949e7b98f6efcc5bceb65",
+			expect:  "0x6a2915695030d8b83ae5c9c12d521a9f84d192398bb949e7b98f6efcc5bceb65",
 		},
 		{
 			keyHex:  "ed90b9a043b6659d36acf36d5aeaec96",
 			message: "st=1678885238~exp=1679749238~acl=/*",
-			expect:  "5569ac4c81d200e56ce25ace987c8ea6194539a7c4eba3b32493d44081ced2f0",
+			expect:  "0x5569ac4c81d200e56ce25ace987c8ea6194539a7c4eba3b32493d44081ced2f0",
 		},
 		{
 			keyHex:  "ed90b9a043b6650036acf36d5aeaec96",
 			message: "st=1678885238~exp=1679749238~acl=/*",
-			expect:  "eddcfce5527bf76c5e2d2b777904f3545f2249b5f080cf0f41d8b980ade703c7",
+			expect:  "0xeddcfce5527bf76c5e2d2b777904f3545f2249b5f080cf0f41d8b980ade703c7",
 		},
 		{
 			keyHex:  "5d694a00baddf0f503fec7e65ba434d3",
 			message: "st=1678885238~exp=1679749238~acl=/*",
-			expect:  "9309c89a4741fcac74592a7f3156d07402f168a2d829e25fb53798ad0c55788e",
+			expect:  "0x9309c89a4741fcac74592a7f3156d07402f168a2d829e25fb53798ad0c55788e",
 		},
 		{
 			keyHex:  "00694a15baddf0f503fec7e65ba434d3",
 			message: "st=1678885238~exp=1679749238~acl=/*",
-			expect:  "7cef7427845f419d1c9aea350723909e994ebd7ea0dd70deac68f2cef9250064",
+			expect:  "0x7cef7427845f419d1c9aea350723909e994ebd7ea0dd70deac68f2cef9250064",
 		},
 	}
 

--- a/interpreter/function/builtin/digest_hmac_sha512.go
+++ b/interpreter/function/builtin/digest_hmac_sha512.go
@@ -44,6 +44,6 @@ func Digest_hmac_sha512(ctx *context.Context, args ...value.Value) (value.Value,
 	mac.Write([]byte(input.Value))
 
 	return &value.String{
-		Value: hex.EncodeToString(mac.Sum(nil)),
+		Value: "0x" + hex.EncodeToString(mac.Sum(nil)),
 	}, nil
 }

--- a/interpreter/function/builtin/digest_hmac_sha512_test.go
+++ b/interpreter/function/builtin/digest_hmac_sha512_test.go
@@ -27,7 +27,7 @@ func Test_Digest_hmac_sha512(t *testing.T) {
 		t.Errorf("Unexpected return type, expect=STRING, got=%s", ret.Type())
 	}
 	v := value.Unwrap[*value.String](ret)
-	expect := "03ad77c817f32669cccf38dac915d4e55a16833b1ca685979a9df521a05235978090043c3da402dad365ed39ac05af4864a804451861f4b4df7680834c6d4f95"
+	expect := "0x03ad77c817f32669cccf38dac915d4e55a16833b1ca685979a9df521a05235978090043c3da402dad365ed39ac05af4864a804451861f4b4df7680834c6d4f95"
 	if v.Value != expect {
 		t.Errorf("return value unmatch, expect=%s, got=%s", expect, v.Value)
 	}


### PR DESCRIPTION
For some reason, in Fastly VCL, the digest_hmac_* functions return a hex representation of the hash, prefixed with `0x`.

Do the same thing in Falco.