### PR TITLE
Fix linting for functions with both positional and variadic args

### DIFF
--- a/linter/statement_linter_test.go
+++ b/linter/statement_linter_test.go
@@ -593,6 +593,7 @@ func TestLintVariadicStringArguments(t *testing.T) {
 		input := `
 	sub foo {
 	  h2.disable_header_compression("Authorization", "Secret");
+	  header.filter_except(req, "Authorization", "Content-Type");
 	}
 	`
 
@@ -609,10 +610,30 @@ func TestLintVariadicStringArguments(t *testing.T) {
 		assertError(t, input)
 	})
 
+	t.Run("empty arguments for functions with both positional and variadic arguments ", func(t *testing.T) {
+		input := `
+	sub foo {
+		header.filter_except(req);
+	}
+	`
+
+		assertError(t, input)
+	})
+
 	t.Run("type error", func(t *testing.T) {
 		input := `
 	sub foo {
 	  h2.disable_header_compression(10);
+	}
+	`
+
+		assertError(t, input)
+	})
+
+	t.Run("type error for function with both positional and variadic arguments", func(t *testing.T) {
+		input := `
+	sub foo {
+		header.filter_except(req, "Authorization", 10);
 	}
 	`
 


### PR DESCRIPTION
Currently, the linter gives errors like the following when calling a function like [header.filter_except()](https://www.fastly.com/documentation/reference/vcl/functions/headers/header-filter-except/) that has both positional and variadic arguments:
```
🔥 [ERROR] Function header.filter_except has 1 arity, but 6 arguments provided (function/arguments)
in custom.vcl at line 321, position 5
 320|    set beresp.http.location = "/test";
 321|    header.filter_except(beresp, "location", "cache-control", "content-encoding", "content-type", "surrogate-key");
         ^^^^^^^^^^^^^^^^^^^^
 322|  }
See reference documentation: https://developer.fastly.com/reference/vcl/functions/headers/header-filter-except/

🔥 1 errors, ❗ 0 warnings, 🔈 28 recommendations.
```

This fixes `lintFunctionArguments()` to correctly parse such function calls. Also, I deleted the `pp.Println("dynamic boolean")` line because that's polluting test output.