### PR TITLE
docs: fix typos across documentation and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Migrate golangci-lint v2 [#520](https://github.com/ysugimoto/falco/pull/520) (@ysugimoto)
 - Adjust modernize notification for go1.25 [#519](https://github.com/ysugimoto/falco/pull/519) (@ysugimoto)
 - Sync linter rules doc [#518](https://github.com/ysugimoto/falco/pull/518) (@ysugimoto)
-- Add documentation for more remote reosurce and caching [#517](https://github.com/ysugimoto/falco/pull/517) (@ysugimoto)
+- Add documentation for more remote resource and caching [#517](https://github.com/ysugimoto/falco/pull/517) (@ysugimoto)
 
 
 ## v2.0.0
@@ -21,10 +21,10 @@
 ## v1.21.0
 
 - Add functionality for setting backend health during testing [#511](https://github.com/ysugimoto/falco/pull/511) (@emylincon)
-- Fix synthetic response and obj.response relevants [#509](https://github.com/ysugimoto/falco/pull/509) (@ysugimoto)
+- Fix synthetic response and obj.response relevant [#509](https://github.com/ysugimoto/falco/pull/509) (@ysugimoto)
 - Ability to check origin host header [#492](https://github.com/ysugimoto/falco/pull/492) (@ysugimoto)
 - Add contributor [#508](https://github.com/ysugimoto/falco/pull/508) (@ysugimoto)
-- Copy ForceQury to add query sign even query string is empty [#507](https://github.com/ysugimoto/falco/pull/507) (@ysugimoto)
+- Copy ForceQuery to add query sign even query string is empty [#507](https://github.com/ysugimoto/falco/pull/507) (@ysugimoto)
 - Add table.lookup_regex function + extensive tests [#504](https://github.com/ysugimoto/falco/pull/504) (@jedisct1)
 - Remove legacy waf related documentation reference [#502](https://github.com/ysugimoto/falco/pull/502) (@ysugimoto)
 - Support parameters in custom subs [#501](https://github.com/ysugimoto/falco/pull/501) (@jedisct1)
@@ -72,7 +72,7 @@
 - Implement wildcard support for unset statement [#449](https://github.com/ysugimoto/falco/pull/449) (@ysugimoto)
 - Implement skipping test feature [#448](https://github.com/ysugimoto/falco/pull/448) (@ysugimoto)
 - Fix objective header get only key name [#446](https://github.com/ysugimoto/falco/pull/446) (@ysugimoto)
-- Use modarnize package [#445](https://github.com/ysugimoto/falco/pull/445) (@ysugimoto)
+- Use modernize package [#445](https://github.com/ysugimoto/falco/pull/445) (@ysugimoto)
 
 ## v1.16.0
 
@@ -110,12 +110,12 @@
 
 ## v1.14.0
 
-- use pcre regexp for assetion function [#416](https://github.com/ysugimoto/falco/pull/416) (@ysugimoto)
+- use pcre regexp for assertion function [#416](https://github.com/ysugimoto/falco/pull/416) (@ysugimoto)
 - Display coverage table [#415](https://github.com/ysugimoto/falco/pull/415) (@ysugimoto)
 - Implement test coverage measurement [#414](https://github.com/ysugimoto/falco/pull/414) (@ysugimoto)
 - Improve and new feature for parser package [#413](https://github.com/ysugimoto/falco/pull/413) (@ysugimoto)
 - Reset regex captured group when matched [#412](https://github.com/ysugimoto/falco/pull/412) (@ysugimoto)
-- remove goling linter-settings [#411](https://github.com/ysugimoto/falco/pull/411) (@ysugimoto)
+- remove golang linter-settings [#411](https://github.com/ysugimoto/falco/pull/411) (@ysugimoto)
 - fix objective header set like foo:bar [#410](https://github.com/ysugimoto/falco/pull/410) (@ysugimoto)
 - use pcre regular expression in interpreter [#409](https://github.com/ysugimoto/falco/pull/409) (@ysugimoto)
 
@@ -181,7 +181,7 @@
 - correct typo in SortDeclaration default tag [#342](https://github.com/ysugimoto/falco/pull/342) (@acme)
 - adjust default TrailingCommentWidth to 1 [#341](https://github.com/ysugimoto/falco/pull/341) (@acme)
 - update timezone in test [#340](https://github.com/ysugimoto/falco/pull/340) (@acme)
-- add `--genearted` option and add vcl_pipe related linter rule [#339](https://github.com/ysugimoto/falco/pull/339) (@ysugimoto)
+- add `--generated` option and add vcl_pipe related linter rule [#339](https://github.com/ysugimoto/falco/pull/339) (@ysugimoto)
 - support Fastly generated specific syntaxes [#338](https://github.com/ysugimoto/falco/pull/338) (@ysugimoto)
 
 ## v1.9.1
@@ -232,7 +232,7 @@
 - Save/restore current subroutine locals when processing call statement [#254](https://github.com/ysugimoto/falco/pull/254) (@richardmarshall)
 - Handle % string escapes [#256](https://github.com/ysugimoto/falco/pull/256) (@richardmarshall)
 - testing.call_subroutine ignores invalid subroutine name [#259](https://github.com/ysugimoto/falco/pull/259) (@akrainiouk)
-- fixed double decoding in urldecod [#261](https://github.com/ysugimoto/falco/pull/261) (@akrainiouk)
+- fixed double decoding in urldecode [#261](https://github.com/ysugimoto/falco/pull/261) (@akrainiouk)
 - req.url: fixed consistency with Fastly implementation [#262](https://github.com/ysugimoto/falco/pull/262) (@akrainiouk)
 - fix base64 decode related builtin function [#263](https://github.com/ysugimoto/falco/pull/263) (@ysugimoto)
 - Fixed parsing of += operator [#266](https://github.com/ysugimoto/falco/pull/266) (@akrainiouk)
@@ -241,7 +241,7 @@
 - follow new fastly documentation [#271](https://github.com/ysugimoto/falco/pull/271) (@ysugimoto)
 - special dealing for req.hash addition assignment [#275](https://github.com/ysugimoto/falco/pull/275) (@ysugimoto)
 - Prioritize cache object [#277](https://github.com/ysugimoto/falco/pull/277) (@richardmarshall)
-- fix exprression comment parsing [#278](https://github.com/ysugimoto/falco/pull/278) (@ysugimoto)
+- fix expression comment parsing [#278](https://github.com/ysugimoto/falco/pull/278) (@ysugimoto)
 - Setup req.http.host in ProcessInit [#279](https://github.com/ysugimoto/falco/pull/279) (@richardmarshall)
 - Record test runtime errors [#280](https://github.com/ysugimoto/falco/pull/280) (@richardmarshall)
 
@@ -289,7 +289,7 @@
 ## v1.1.1
 
 - Feature/add equal fold assertion [#195](https://github.com/ysugimoto/falco/pull/195) (@ysugimoto)
-- add shield director type for origin-sheileding [#197](https://github.com/ysugimoto/falco/pull/197) (@ysugimoto)
+- add shield director type for origin-shielding [#197](https://github.com/ysugimoto/falco/pull/197) (@ysugimoto)
 - Implement STRING to ACL regex comparison [#200](https://github.com/ysugimoto/falco/pull/200) (@MasonM)
 - Fix type of client.geo.ip_override [#201](https://github.com/ysugimoto/falco/pull/201) (@MasonM)
 
@@ -315,7 +315,7 @@ New features for the major version.
 
 ## v0.23.2
 
-- fix up output methods on runne [#161](https://github.com/ysugimoto/falco/pull/161) (@ysugimoto)
+- fix up output methods on runner [#161](https://github.com/ysugimoto/falco/pull/161) (@ysugimoto)
 
 ## v0.23.1
 
@@ -348,7 +348,7 @@ New features for the major version.
 
 ## v0.19.1
 
-- supress output [#123](https://github.com/ysugimoto/falco/pull/123) (@ysugimoto)
+- suppress output [#123](https://github.com/ysugimoto/falco/pull/123) (@ysugimoto)
 
 ## v0.19.0
 
@@ -363,11 +363,11 @@ New features for the major version.
 ## v0.17.0
 
 - Sanitize invalid chars in backend name before adding them as snippets [#106](https://github.com/ysugimoto/falco/pull/106) (@davinci26)
-- Add more implicit conversion fuzy types [#107](https://github.com/ysugimoto/falco/pull/107) (@davinci26)
+- Add more implicit conversion fuzzy types [#107](https://github.com/ysugimoto/falco/pull/107) (@davinci26)
 - lint protected HTTP headers [#108](https://github.com/ysugimoto/falco/pull/108) (@ysugimoto)
 - Fix error with ast.GOTO and Encoder [#109](https://github.com/ysugimoto/falco/pull/109) (@davinci26)
 - display actual line and position even identity is not found in context [#112](https://github.com/ysugimoto/falco/pull/112) (@ysugimoto)
-- treat obective access in req.http contains semicolon character [#113](https://github.com/ysugimoto/falco/pull/113) (@ysugimoto)
+- treat objective access in req.http contains semicolon character [#113](https://github.com/ysugimoto/falco/pull/113) (@ysugimoto)
 - fix panic error for getting remote snippet [#115](https://github.com/ysugimoto/falco/pull/115) (@ysugimoto)
 - correct parser for reserved word [#117](https://github.com/ysugimoto/falco/pull/117) (@ysugimoto)
 
@@ -415,7 +415,7 @@ New features for the major version.
 
 ## v0.9.2
 
-- Support platform of `alipne`, `darwin-arm64` [#55](https://github.com/ysugimoto/falco/pull/55) (@ysugimoto)
+- Support platform of `alpine`, `darwin-arm64` [#55](https://github.com/ysugimoto/falco/pull/55) (@ysugimoto)
 
 ## v0.9.1
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,7 +36,7 @@ format:
   align_declaration_property: false
   else_if: false
   always_next_line_else_if:  false
-  return_statement_parentheis: false
+  return_statement_parenthesis: false
   sort_declaration: false
   align_trailing_comment: false
   comment_style: none
@@ -88,9 +88,9 @@ All configurations of configuration files and CLI arguments are described follow
 | linter.verbose                          | String              | error       | -v, -vv            | Verbose level, `warning` or `info` is valid                                                                                           |
 | linter.rules                            | Object              | null        | -                  | Override linter rules                                                                                                                 |
 | linter.rules.[rule_name]                | String              | -           | -                  | Override linter error level for the rule name, see [rules](https://github.com/ysugimoto/falco/blob/develop/docs/rules.md)             |
-| linter.enforce_subroutine_scopes        | Object              | null        | -                  | Coerce subroutine scope for specified list of subroutine names. will be usefull for Fastly managed snippet that cannot be modified.   |
+| linter.enforce_subroutine_scopes        | Object              | null        | -                  | Coerce subroutine scope for specified list of subroutine names. will be useful for Fastly managed snippet that cannot be modified.   |
 | linter.enforce_subroutine_scopes.[name] | Array<String>       | []          | -                  | `name` is subroutine name and specify acceptable scope as an array.                                                                   |
-| linter.ignore_subroutines               | Array<String>       | []          | -                  | Ignore subroutine linting for specified list of subroutine names. will be usefull for Fastly managed snippet that cannot be modified. |
+| linter.ignore_subroutines               | Array<String>       | []          | -                  | Ignore subroutine linting for specified list of subroutine names. will be useful for Fastly managed snippet that cannot be modified. |
 | linter.generated                        | Boolean             | false       | --generated        | Lint VCL as **generated** VCL. generated means that VCL comes from `show VCL` data in Fastly management console.                      |
 | simulator                               | Object              | null        | -                  | Simulator configuration object                                                                                                        |
 | simulator.port                          | Integer             | 3124        | -p, --port         | Simulator server listen port                                                                                                          |

--- a/docs/console.md
+++ b/docs/console.md
@@ -32,7 +32,7 @@ Run console with fetch scope example:
 
 In console, some control commands that start with `\` are enabled.
 
-| Command            | Desctiption                                                  |
+| Command            | Description                                                  |
 |:------------------:|:-------------------------------------------------------------|
 | \s, \scope [scope] | Change input evaluation scope (recv, fetch, deliver, etc...) |
 | \h, \help          | Show this help                                               |
@@ -40,8 +40,8 @@ In console, some control commands that start with `\` are enabled.
 
 ## Console Behavior
 
-The console does single-line code evaluatation and must be valid of VCL syntax.
-And some predefined variables depends on the scope, then you can change artibrary scope by typing the `\s` command:
+The console does single-line code evaluation and must be valid of VCL syntax.
+And some predefined variables depends on the scope, then you can change arbitrary scope by typing the `\s` command:
 
 ```shell
 @RECV>> \s FETCH
@@ -64,5 +64,5 @@ If you want to see the variable value, type variable as expression:
 
 Falco evaluates expression and display value with its type.
 
-Note that console runtime uses interpreter, therefore the result depends on the intepreter implementation.
+Note that console runtime uses interpreter, therefore the result depends on the interpreter implementation.
 

--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -46,23 +46,23 @@ See [configuration documentation](https://github.com/ysugimoto/falco/blob/develo
 
 Supporting rules are described the following table and sections.
 
-| Name (configuration field)  | Type   | Default | Description                                                                                    |
-|:----------------------------|:------:|:-------:|------------------------------------------------------------------------------------------------|
-| indent_width                | INT    | 2       | Specify indent width                                                                           |
-| indent_style                | STRING | space   | Specify indent style character. Either `space(whitespace)` or `tab(\t)` is accepted            |
-| trailing_comment_width      | INT    | 2       | Specify space size for trailing comment                                                        |
-| line_width                  | INT    | 120     | Specify max characters for each line. The overflowed characters are displayed at the next line |
-| explicit_string_concat      | BOOL   | false   | Explicitly write string concatenation operator `+` between expressions                         |
-| sort_declaration_property   | BOOL   | false   | If true, sort declaration properties like table, backend and director alphabetically           |
-| align_declaration_property  | BOOL   | false   | If true, align declaration properties like table, backend and director                         |
-| else_if                     | BOOL   | false   | Coerce use `else if` keyword for another if statement                                          |
-| always_next_line_else_if    | BOOL   | false   | If true, always `else if` and `else` keywords print to the next line                           |
-| return_statement_parentheis | BOOL   | true    | Coerce surrounded return statement ident by parenthesis                                        |
-| sort_declaration            | BOOL   | false   | Sort root declaration by specific order                                                        |
-| align_trailing_comment      | BOOL   | false   | Align trailing comments                                                                        |
-| comment_style               | STRING | none    | Coerce comment character. Either `sharp(#)` or `slash(/)` is accepted                          |
-| should_use_unset            | BOOL   | false   | Replace `remove` statement into `unset` statement                                              |
-| indent_case_labels          | BOOL   | false   | If true, add indent for each `case` statement in `switch`                                      |
+| Name (configuration field)   | Type   | Default | Description                                                                                    |
+|:-----------------------------|:------:|:-------:|------------------------------------------------------------------------------------------------|
+| indent_width                 | INT    | 2       | Specify indent width                                                                           |
+| indent_style                 | STRING | space   | Specify indent style character. Either `space(whitespace)` or `tab(\t)` is accepted            |
+| trailing_comment_width       | INT    | 2       | Specify space size for trailing comment                                                        |
+| line_width                   | INT    | 120     | Specify max characters for each line. The overflowed characters are displayed at the next line |
+| explicit_string_concat       | BOOL   | false   | Explicitly write string concatenation operator `+` between expressions                         |
+| sort_declaration_property    | BOOL   | false   | If true, sort declaration properties like table, backend and director alphabetically           |
+| align_declaration_property   | BOOL   | false   | If true, align declaration properties like table, backend and director                         |
+| else_if                      | BOOL   | false   | Coerce use `else if` keyword for another if statement                                          |
+| always_next_line_else_if     | BOOL   | false   | If true, always `else if` and `else` keywords print to the next line                           |
+| return_statement_parenthesis | BOOL   | true    | Coerce surrounded return statement ident by parenthesis                                        |
+| sort_declaration             | BOOL   | false   | Sort root declaration by specific order                                                        |
+| align_trailing_comment       | BOOL   | false   | Align trailing comments                                                                        |
+| comment_style                | STRING | none    | Coerce comment character. Either `sharp(#)` or `slash(/)` is accepted                          |
+| should_use_unset             | BOOL   | false   | Replace `remove` statement into `unset` statement                                              |
+| indent_case_labels           | BOOL   | false   | If true, add indent for each `case` statement in `switch`                                      |
 
 ---
 

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -5,7 +5,7 @@ Will be updated when we find or implement a way to get accurate values.
 
 | Function                                                                                              | Tentative Value/behavior                        |
 |:-----------------------------------------------------------------------------------------------------:|:-----------------------------------------------:|
-| *fastly.hash(key, seed, from, to)*                                                                    | Returns originaly calculated hash string        |
+| *fastly.hash(key, seed, from, to)*                                                                    | Returns originally calculated hash string       |
 | *h2.push(resource [, as])*                                                                            | Ignore variadic arguments of "as"               |
 | *resp.tarpit(interval_s [, chunk_size_bytes])*                                                        | No effect due to not support tarpitting         |
 | *early_hints(resource [, resources...])*                                                              | No effect due to not support h2 and h3          |

--- a/docs/linter.md
+++ b/docs/linter.md
@@ -71,10 +71,10 @@ Following table describes subroutine name and recognizing scope:
 ### Annotation
 
 For some reasons, the subroutine name could not be changed. Or you want to use this function in multiple scopes. Multiple scopes
-are declared as comma seperated values.
+are declared as comma separated values.
 
 Then, if you apply a hint of scope on annotation, `falco` also understands scope. There are two ways to define the scope annotation:
-1. `@scope: <scope_name1>, <scope_name2>` this is the newest annotation method and it should be prefered over 2.
+1. `@scope: <scope_name1>, <scope_name2>` this is the newest annotation method and it should be preferred over 2.
 2. `@<scope_name1>, <scope_name2>`, this is used to maintain backwards compatibility and it may be deprecated in the future.
 
 ```vcl
@@ -140,10 +140,10 @@ Partially supports fetching Fastly managed VCL snippets. See [remote.md](https:/
 
 ## Ignoring errors
 
-Fastly also accepts some syntax and function which comes from Varnish (e.g `map()` function) but falco reports error for it. Then, you can put leading/trailing comemnts for each statements, falco will ignore the error.
+Fastly also accepts some syntax and function which comes from Varnish (e.g `map()` function) but falco reports error for it. Then, you can put leading/trailing comments for each statements, falco will ignore the error.
 
 The comment syntax is similar to eslint, but very simplified.
-Note that this feature only ignores linting error, the parser erorr will be reported.
+Note that this feature only ignores linting error, the parser error will be reported.
 
 ### Next Line
 
@@ -187,7 +187,7 @@ sub vcl_recv {
 
   // falco-ignore-start
   set req.http.Example = some.undefined.variable;
-  // falco-igore-end
+  // falco-ignore-end
 
   // You can disable specific rules only
   // falco-ignore-start function/arguments, function/argument-type

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -204,7 +204,7 @@ restart <comment>; <comment>
 return <comment> (<comment> <state> <comment>) <comment>; <comment>
 ```
 
-Parenthesis is artbitrary.
+Parenthesis is arbitrary.
 
 ## Set Statement
 

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -32,7 +32,7 @@ func main() {
 	// In this case, linting for *ast.BackendDeclaration object.
 	req, err := plugin.ReadLinterRequest[*ast.BackendDeclaration](os.Stdin)
 	if err != nil {
- 		// If some error has occured, send back message to stderr
+ 		// If some error has occurred, send back message to stderr
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
@@ -103,7 +103,7 @@ backend example_com {
 ...(other declarations)
 ```
 
-And then you can run custom plugin linter via falco linter. In this case, the backend nake does not have `F_` prefix so linter reports `ERROR` on linting results.
+And then you can run custom plugin linter via falco linter. In this case, the backend name does not have `F_` prefix so linter reports `ERROR` on linting results.
 
 Additionally, you can put additional arguments to plugin:
 
@@ -124,7 +124,7 @@ This is useful for switch or control linting behavior in your plugin without imp
 ## Other Specs
 
 1. To reduce binary message between falco linter and plugin, we enable custom linter for each *statement* only. You often want to access all declarations on your plugin, but it cannot do for now. Therefore if you want to do linting for all backends, you need to put annotation comment to all backend declarations.
-2. From performance reason, we omit AST meta informations like filename, line number and position and all comments. Typically you don't need to read AST meta informations on linting but the falco main process displays plugin error with AST meta informations.
+2. From performance reason, we omit AST meta information like filename, line number and position and all comments. Typically you don't need to read AST meta information on linting but the falco main process displays plugin error with AST meta information.
 3. AST is read-only on the plugin so your plugin cannot modify AST tree.
-4. You can everythin in your plugin. It means you can do network access, reading local file, etc... that as possible as the programming language can if you don't mind the linting performance.
-5. Binary messsaging is just raw binary treating so you can implement plugin not only Go but also other languages that can process binary.
+4. You can do everything in your plugin. It means you can do network access, reading local file, etc... that as possible as the programming language can if you don't mind the linting performance.
+5. Binary messaging is just raw binary treating so you can implement plugin not only Go but also other languages that can process binary.

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -18,8 +18,8 @@ falco -r -v /path/to/example.vcl
 
 ### Environment variables
 
-Fastly API requires `API key` to authenticate, and `Service ID` to distinguish service, therefore you need to specift these values in your environment variable.
-The environment varialbe name is fixed:
+Fastly API requires `API key` to authenticate, and `Service ID` to distinguish service, therefore you need to specify these values in your environment variable.
+The environment variable name is fixed:
 
 | variable name     | usage |
 |:------------------|:----  |
@@ -137,7 +137,7 @@ include "snippet::example_snippet";
 
 #### Include in block statement
 
-You can include VCL Snippets in some of block statements (e.g sburoutine, if block, etc):
+You can include VCL Snippets in some of block statements (e.g subroutine, if block, etc):
 
 ```
 sub vcl_recv {
@@ -176,6 +176,6 @@ acl my_acl {
 ## Remote configuration caching
 
 If you are enabled `-r, --remote` CLI option to fetch remote resources, falco will make many API requests and then sometimes it exceeds API rate limit.
-To avoid API rate limit exceedance, and remote resources won't be changed frequently (except Edge Dictionary Item), falco makes cache file in your local machine temporarily and use them if found.
+To avoid exceeding the API rate limit, and remote resources won't be changed frequently (except Edge Dictionary Item), falco makes cache file in your local machine temporarily and use them if found.
 
 You can refresh the cache by using `--refresh` CLI option.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -303,7 +303,7 @@ Fastly document: https://developer.fastly.com/reference/vcl/declarations/table/
 
 ## table/type-variation
 
-Invalid `value_type` spefication on TABLE. `value_type` is allowed to specify with `STRING`, `INTEGER`, `BOOL`, `FLOAT`, `BACKEND`, `ACL`, `RTIME` and `REGEX`.
+Invalid `value_type` specification on TABLE. `value_type` is allowed to specify with `STRING`, `INTEGER`, `BOOL`, `FLOAT`, `BACKEND`, `ACL`, `RTIME` and `REGEX`.
 
 Problem:
 
@@ -674,7 +674,7 @@ remove req.http.X-Forwarded-For;
 
 Note: `remove` is just alias for `unset`.
 
-Faslty document: https://developer.fastly.com/reference/vcl/statements/remove/
+Fastly document: https://developer.fastly.com/reference/vcl/statements/remove/
 
 ## operator/conditional
 
@@ -694,7 +694,7 @@ if (beresp.status == 200) {
 }
 ```
 
-Faslty document: https://developer.fastly.com/reference/vcl/operators/#conditional-operators
+Fastly document: https://developer.fastly.com/reference/vcl/operators/#conditional-operators
 
 ## restart-statement/scope
 
@@ -792,7 +792,7 @@ Fastly document: https://developer.fastly.com/reference/vcl/statements/error/
 
 ## error-statement/code
 
-Faslty recommends error statement code should use in range of 600-699.
+Fastly recommends error statement code should use in range of 600-699.
 
 Problem:
 ```vcl
@@ -845,7 +845,7 @@ Fastly document: https://developer.fastly.com/reference/vcl/statements/synthetic
 
 ## condition/literal
 
-`if` condtion expression accepts STRING or BOOL (evaluate as truthy/falsy), but forbid to use literal.
+`if` condition expression accepts STRING or BOOL (evaluate as truthy/falsy), but forbid to use literal.
 
 For example:
 
@@ -873,7 +873,7 @@ Calling function arguments count mismatch.
 Problem:
 ```vcl
 declare local var.LocalIP IP;
-set var.LocalIP = std.ip("192.168.0.1"); // std.ip function expects 2 arguemnts but supply 1 argument
+set var.LocalIP = std.ip("192.168.0.1"); // std.ip function expects 2 arguments but supply 1 argument
 ```
 
 Fix:

--- a/docs/simulator.md
+++ b/docs/simulator.md
@@ -172,7 +172,7 @@ Limitations are the following:
 - Origin-Shielding and clustering, fetch-related features are unsupported
 - Cache object is not stored persistently, only managed in-memory, so when the process is killed, all cache objects are deleted
 - `Stale-While-Revalidate` does not work
-- Extracted VCL in Faslty boilerplate marco is different. Only extracts VCL snippets
+- Extracted VCL in Fastly boilerplate marco is different. Only extracts VCL snippets
 - May not add some of Fastly specific request/response headers
 - WAF does not work
 - ESI will not work correctly

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -211,7 +211,7 @@ sub some_test_suite {
 
 #### Specify `@tag` annotation and match against `-t,--tag` cli option
 
-When you write `@tag: [tag1],[tag2],...` annotation comment in leading comment of testing subroutine, falco evaluates tag maching and run if matched..
+When you write `@tag: [tag1],[tag2],...` annotation comment in leading comment of testing subroutine, falco evaluates tag matching and run if matched..
 
 ```vcl
 // @tag: prod
@@ -227,7 +227,7 @@ falco test -t prod /path/to/vcl/default.vcl
 ```
 
 Then, falco evaluates whether `prod` tag matches against `@tag` values (on the above case, test will be run).
-And the `@tag` annotation could appect inverse flag like `!prod`:
+And the `@tag` annotation could expect inverse flag like `!prod`:
 
 ```vcl
 // @tag: !prod
@@ -273,7 +273,7 @@ sub pre_condition_test {
 
     // Typically set query string might be set on vcl_recv.
     // But vcl_recv is not called in testing process, so you need to set in here.
-    set req.url = quetystring.add(req.url, "foo", "bar")
+    set req.url = querystring.add(req.url, "foo", "bar")
 
     // Override backend response before calling "vcl_fetch" for test case of 500 status code.
     // It means there is a `hook` point before calling `vcl_fetch`.
@@ -757,7 +757,7 @@ sub test_vcl {
     // Pass because expression to be true
     assert(req.http.Foo == var.testing);
 
-    // Pass because expression is thuthy
+    // Pass because expression is truthy
     assert(req.http.Foo);
 
     // Fail because expression to be false
@@ -769,7 +769,7 @@ sub test_vcl {
 
 ### assert.true(ANY actual [, STRING message])
 
-Assert actualvalue should be `true`.
+Assert actual value should be `true`.
 
 ```vcl
 sub test_vcl {
@@ -783,7 +783,7 @@ sub test_vcl {
     // Pass because expression value is  true
     assert.true(var.testing == true);
 
-    // Fail because experssion value is not BOOL true
+    // Fail because expression value is not BOOL true
     assert.true(req.http.Foo);
 }
 ```
@@ -792,7 +792,7 @@ sub test_vcl {
 
 ### assert.false(ANY actual [, STRING message])
 
-Assert actualvalue should be `false`.
+Assert actual value should be `false`.
 
 ```vcl
 sub test_vcl {
@@ -804,7 +804,7 @@ sub test_vcl {
     // Pass because expression value is  false
     assert.false(var.testing != true);
 
-    // Fail because experssion value is not BOOL false
+    // Fail because expression value is not BOOL false
     assert.false(req.http.Foo);
 }
 ```
@@ -835,7 +835,7 @@ sub test_vcl {
 
 ### assert.is_notset(ANY actual [, STRING message])
 
-Assert actualvalue should be [NotSet](https://developer.fastly.com/reference/vcl/types/#not-set).
+Assert actual value should be [NotSet](https://developer.fastly.com/reference/vcl/types/#not-set).
 
 ```vcl
 sub test_vcl {
@@ -970,7 +970,7 @@ sub test_vcl {
 
     set var.testing = "foobarbaz";
 
-    // Pass because value does not matche regular expression
+    // Pass because value does not match regular expression
     assert.not_match(var.testing, ".+other.+");
 
     // Fail because value matches regular expression

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -3,7 +3,7 @@
 Following table describes variables that will return tentative values,
 but you can override these values by configuration or cli arguments for testing.
 
-## Overide by Configuration
+## Override by Configuration
 
 Put override configuration in `testing.overrides` section as map.
 
@@ -84,7 +84,7 @@ falco test /path/to/main.vcl -o "client.class.checker=true" -o "client.as.name=o
 | client.socket.pace                         | 0                                  |
 | client.socket.ploss                        | 0                                  |
 | client.socket.cwnd                         | 60                                 |
-| fastly_info.is_clueter_edge                | false                              |
+| fastly_info.is_cluster_edge                | false                              |
 | obj.is_pci                                 | false                              |
 | req.backend.is_cluster                     | false                              |
 | resp.is_locally_generated                  | false                              |
@@ -192,7 +192,7 @@ falco test /path/to/main.vcl -o "client.class.checker=true" -o "client.as.name=o
 | tls.client.certificate.raw_certificate_b64 | (empty string)                     |
 | tls.client.certificate.serial_number       | (empty string)                     |
 | transport.bw_estimate                      | 0                                  |
-| transpoty.type                             | "tcp"                              |
+| transport.type                             | "tcp"                              |
 | waf.failures                               | 0                                  |
 | waf.php_injection_score                    | 0                                  |
 | waf.rce_score                              | 0                                  |

--- a/examples/testing/README.md
+++ b/examples/testing/README.md
@@ -11,4 +11,4 @@ You can run unit test as following command:
 falco -I . test ./default.vcl
 ```
 
-Then test-runner will run and diplay testing results.
+Then test-runner will run and display testing results.


### PR DESCRIPTION
  - Fix small spelling errors in Markdown files