### PR TITLE
replacement with capture groups when not all are participating in the match fail

### DIFF
--- a/interpreter/function/builtin/regsub_test.go
+++ b/interpreter/function/builtin/regsub_test.go
@@ -127,6 +127,14 @@ func Test_Regsub(t *testing.T) {
 			expect:      "hello",
 			literal:     true,
 		},
+		{
+			name:        "HIT MISS pattern replacement",
+			input:       "HIT-MISS something",
+			pattern:     "^(HIT-(SYNTH)|(HITPASS|HIT|MISS|PASS|ERROR|PIPE)).*",
+			replacement: `\2\3`,
+			expect:      "HIT",
+			literal:     true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Currently this PR will fail, due to the fact that when trying to use string replacement like in:
https://regex101.com/r/UY23Ne/1
so having regular expression:
```
^(HIT-(SYNTH)|(HITPASS|HIT|MISS|PASS|ERROR|PIPE)).*
```
and test string:
```
HIT-MISS
```
and replacement:
```
${2}${3}
```
so in [STRING **regsub** STRING input REGEX pattern STRING replacement](https://www.fastly.com/documentation/reference/vcl/functions/strings/regsub/)'s _replacement_ parameter expressed as:
```
\2\3
```
would result in the following runtime error thrown:
```
panic: runtime error: slice bounds out of range [:18446744073709551615] with capacity 18 [recovered, repanicked]

goroutine 270 [running]:
testing.tRunner.func1.2({0x10077f440, 0x140001ac4e0})
	/opt/homebrew/opt/go/libexec/src/testing/testing.go:1872 +0x190
testing.tRunner.func1()
	/opt/homebrew/opt/go/libexec/src/testing/testing.go:1875 +0x31c
panic({0x10077f440?, 0x140001ac4e0?})
	/opt/homebrew/opt/go/libexec/src/runtime/panic.go:783 +0x120
go.elara.ws/pcre.(*Regexp).ReplaceAll.func1({0x140007274f2, 0x1})
	/myhomedir/.go/pkg/mod/go.elara.ws/pcre@v0.0.0-20230805032557-4ce849193f64/pcre.go:421 +0x104
os.Expand({0x140007274f0, 0x8}, 0x14000267868)
	/opt/homebrew/opt/go/libexec/src/os/env.go:35 +0x240
go.elara.ws/pcre.(*Regexp).ReplaceAll(0x14000163700, {0x140001ac4b0, 0x12, 0x12}, {0x140007274e8, 0x8, 0x140000a6000?})
	/myhomedir/.go/pkg/mod/go.elara.ws/pcre@v0.0.0-20230805032557-4ce849193f64/pcre.go:406 +0x174
go.elara.ws/pcre.(*Regexp).ReplaceAllString(...)
	/myhomedir/.go/pkg/mod/go.elara.ws/pcre@v0.0.0-20230805032557-4ce849193f64/pcre.go:483
github.com/ysugimoto/falco/interpreter/function/builtin.replaceOneString.func1({0x140001ac4b0?, 0x140001ac480?})
	/somemydir/falco/interpreter/function/builtin/regsub.go:33 +0x64
github.com/ysugimoto/falco/interpreter/function/builtin.replaceOneString.(*Regexp).ReplaceAllStringFunc.func2({0x140001ac480?, 0x0?, 0x0?})
	/myhomedir/.go/pkg/mod/go.elara.ws/pcre@v0.0.0-20230805032557-4ce849193f64/pcre.go:489 +0x40
go.elara.ws/pcre.(*Regexp).ReplaceAllFunc(0x140001c2280?, {0x140001ac480, 0x12, 0x18}, 0x14000267a38)
	/myhomedir/.go/pkg/mod/go.elara.ws/pcre@v0.0.0-20230805032557-4ce849193f64/pcre.go:451 +0x170
go.elara.ws/pcre.(*Regexp).ReplaceAllStringFunc(...)
	/myhomedir/.go/pkg/mod/go.elara.ws/pcre@v0.0.0-20230805032557-4ce849193f64/pcre.go:488
github.com/ysugimoto/falco/interpreter/function/builtin.replaceOneString(0x14000163700, {0x100625630?, 0x4?}, {0x140007274e8?, 0x5?})
	/somemydir/falco/interpreter/function/builtin/regsub.go:28 +0x74
github.com/ysugimoto/falco/interpreter/function/builtin.Regsub(0x14000267b50, {0x14000735f28, 0x3, 0x10035a318?})
	/somemydir/falco/interpreter/function/builtin/regsub.go:76 +0x1c8
```
instead of the expected expected:
```
HIT
```
value.

This is due to bug in underlying regex library - see https://github.com/Elara6331/pcre/pull/3