### PR TITLE
Fix math functions

### DIFF
--- a/interpreter/function/builtin/math_exp.go
+++ b/interpreter/function/builtin/math_exp.go
@@ -41,7 +41,7 @@ func Math_exp(ctx *context.Context, args ...value.Value) (value.Value, error) {
 	case x.IsNAN:
 		return &value.Float{IsNAN: true}, nil
 	case x.IsNegativeInf:
-		return &value.Float{IsNegativeInf: true}, nil
+		return &value.Float{Value: 0}, nil
 	case x.IsPositiveInf:
 		return &value.Float{IsPositiveInf: true}, nil
 	}

--- a/interpreter/function/builtin/math_exp_test.go
+++ b/interpreter/function/builtin/math_exp_test.go
@@ -22,7 +22,7 @@ func Test_Math_exp(t *testing.T) {
 		err    *value.String
 	}{
 		{input: &value.Float{IsNAN: true}, expect: &value.Float{IsNAN: true}, err: nil},
-		{input: &value.Float{IsNegativeInf: true}, expect: &value.Float{IsNegativeInf: true}, err: nil},
+		{input: &value.Float{IsNegativeInf: true}, expect: &value.Float{Value: 0}, err: nil},
 		{input: &value.Float{IsPositiveInf: true}, expect: &value.Float{IsPositiveInf: true}, err: nil},
 		{input: &value.Float{Value: math.MaxFloat64}, expect: &value.Float{Value: math.Inf(1)}, err: nil},
 		{input: &value.Float{Value: -math.MaxFloat64}, expect: &value.Float{Value: 0}, err: nil},

--- a/interpreter/function/builtin/math_is_finite.go
+++ b/interpreter/function/builtin/math_is_finite.go
@@ -35,5 +35,5 @@ func Math_is_finite(ctx *context.Context, args ...value.Value) (value.Value, err
 	}
 
 	x := value.Unwrap[*value.Float](args[0])
-	return &value.Boolean{Value: !x.IsNegativeInf && !x.IsPositiveInf}, nil
+	return &value.Boolean{Value: !x.IsNegativeInf && !x.IsPositiveInf && !x.IsNAN}, nil
 }

--- a/interpreter/function/builtin/math_is_finite_test.go
+++ b/interpreter/function/builtin/math_is_finite_test.go
@@ -20,7 +20,7 @@ func Test_Math_is_finite(t *testing.T) {
 		expect *value.Boolean
 		err    *value.String
 	}{
-		{input: &value.Float{IsNAN: true}, expect: &value.Boolean{Value: true}, err: nil},
+		{input: &value.Float{IsNAN: true}, expect: &value.Boolean{Value: false}, err: nil},
 		{input: &value.Float{IsNegativeInf: true}, expect: &value.Boolean{Value: false}, err: nil},
 		{input: &value.Float{IsPositiveInf: true}, expect: &value.Boolean{Value: false}, err: nil},
 		{input: &value.Float{Value: 1.2}, expect: &value.Boolean{Value: true}, err: nil},

--- a/interpreter/function/builtin/math_log.go
+++ b/interpreter/function/builtin/math_log.go
@@ -41,9 +41,16 @@ func Math_log(ctx *context.Context, args ...value.Value) (value.Value, error) {
 	case x.IsNAN:
 		return &value.Float{IsNAN: true}, nil
 	case x.IsNegativeInf:
-		return &value.Float{IsNegativeInf: true}, nil
+		ctx.FastlyError = &value.String{Value: "EDOM"}
+		return &value.Float{IsNAN: true}, nil
 	case x.IsPositiveInf:
 		return &value.Float{IsPositiveInf: true}, nil
+	case x.Value == 0:
+		ctx.FastlyError = &value.String{Value: "ERANGE"}
+		return &value.Float{IsNegativeInf: true}, nil
+	case x.Value < 0:
+		ctx.FastlyError = &value.String{Value: "EDOM"}
+		return &value.Float{IsNAN: true}, nil
 	}
 	return &value.Float{Value: math.Log(x.Value)}, nil
 }

--- a/interpreter/function/builtin/math_log10.go
+++ b/interpreter/function/builtin/math_log10.go
@@ -41,9 +41,16 @@ func Math_log10(ctx *context.Context, args ...value.Value) (value.Value, error) 
 	case x.IsNAN:
 		return &value.Float{IsNAN: true}, nil
 	case x.IsNegativeInf:
-		return &value.Float{IsNegativeInf: true}, nil
+		ctx.FastlyError = &value.String{Value: "EDOM"}
+		return &value.Float{IsNAN: true}, nil
 	case x.IsPositiveInf:
 		return &value.Float{IsPositiveInf: true}, nil
+	case x.Value == 0:
+		ctx.FastlyError = &value.String{Value: "ERANGE"}
+		return &value.Float{IsNegativeInf: true}, nil
+	case x.Value < 0:
+		ctx.FastlyError = &value.String{Value: "EDOM"}
+		return &value.Float{IsNAN: true}, nil
 	}
 	return &value.Float{Value: math.Log10(x.Value)}, nil
 }

--- a/interpreter/function/builtin/math_log10_test.go
+++ b/interpreter/function/builtin/math_log10_test.go
@@ -21,8 +21,10 @@ func Test_Math_log10(t *testing.T) {
 		err    *value.String
 	}{
 		{input: &value.Float{IsNAN: true}, expect: &value.Float{IsNAN: true}, err: nil},
-		{input: &value.Float{IsNegativeInf: true}, expect: &value.Float{IsNegativeInf: true}, err: nil},
+		{input: &value.Float{IsNegativeInf: true}, expect: &value.Float{IsNAN: true}, err: &value.String{Value: "EDOM"}},
 		{input: &value.Float{IsPositiveInf: true}, expect: &value.Float{IsPositiveInf: true}, err: nil},
+		{input: &value.Float{Value: 0}, expect: &value.Float{IsNegativeInf: true}, err: &value.String{Value: "ERANGE"}},
+		{input: &value.Float{Value: -1}, expect: &value.Float{IsNAN: true}, err: &value.String{Value: "EDOM"}},
 		{input: &value.Float{Value: 0.5}, expect: &value.Float{Value: -0.3010299956639812}, err: nil},
 	}
 

--- a/interpreter/function/builtin/math_log2.go
+++ b/interpreter/function/builtin/math_log2.go
@@ -41,9 +41,16 @@ func Math_log2(ctx *context.Context, args ...value.Value) (value.Value, error) {
 	case x.IsNAN:
 		return &value.Float{IsNAN: true}, nil
 	case x.IsNegativeInf:
-		return &value.Float{IsNegativeInf: true}, nil
+		ctx.FastlyError = &value.String{Value: "EDOM"}
+		return &value.Float{IsNAN: true}, nil
 	case x.IsPositiveInf:
 		return &value.Float{IsPositiveInf: true}, nil
+	case x.Value == 0:
+		ctx.FastlyError = &value.String{Value: "ERANGE"}
+		return &value.Float{IsNegativeInf: true}, nil
+	case x.Value < 0:
+		ctx.FastlyError = &value.String{Value: "EDOM"}
+		return &value.Float{IsNAN: true}, nil
 	}
 	return &value.Float{Value: math.Log2(x.Value)}, nil
 }

--- a/interpreter/function/builtin/math_log2_test.go
+++ b/interpreter/function/builtin/math_log2_test.go
@@ -21,8 +21,10 @@ func Test_Math_log2(t *testing.T) {
 		err    *value.String
 	}{
 		{input: &value.Float{IsNAN: true}, expect: &value.Float{IsNAN: true}, err: nil},
-		{input: &value.Float{IsNegativeInf: true}, expect: &value.Float{IsNegativeInf: true}, err: nil},
+		{input: &value.Float{IsNegativeInf: true}, expect: &value.Float{IsNAN: true}, err: &value.String{Value: "EDOM"}},
 		{input: &value.Float{IsPositiveInf: true}, expect: &value.Float{IsPositiveInf: true}, err: nil},
+		{input: &value.Float{Value: 0}, expect: &value.Float{IsNegativeInf: true}, err: &value.String{Value: "ERANGE"}},
+		{input: &value.Float{Value: -1}, expect: &value.Float{IsNAN: true}, err: &value.String{Value: "EDOM"}},
 		{input: &value.Float{Value: 0.5}, expect: &value.Float{Value: -1}, err: nil},
 	}
 

--- a/interpreter/function/builtin/math_log_test.go
+++ b/interpreter/function/builtin/math_log_test.go
@@ -21,8 +21,10 @@ func Test_Math_log(t *testing.T) {
 		err    *value.String
 	}{
 		{input: &value.Float{IsNAN: true}, expect: &value.Float{IsNAN: true}, err: nil},
-		{input: &value.Float{IsNegativeInf: true}, expect: &value.Float{IsNegativeInf: true}, err: nil},
+		{input: &value.Float{IsNegativeInf: true}, expect: &value.Float{IsNAN: true}, err: &value.String{Value: "EDOM"}},
 		{input: &value.Float{IsPositiveInf: true}, expect: &value.Float{IsPositiveInf: true}, err: nil},
+		{input: &value.Float{Value: 0}, expect: &value.Float{IsNegativeInf: true}, err: &value.String{Value: "ERANGE"}},
+		{input: &value.Float{Value: -1}, expect: &value.Float{IsNAN: true}, err: &value.String{Value: "EDOM"}},
 		{input: &value.Float{Value: 0.5}, expect: &value.Float{Value: -0.6931471805599453}, err: nil},
 	}
 

--- a/interpreter/function/builtin/math_sin.go
+++ b/interpreter/function/builtin/math_sin.go
@@ -45,7 +45,7 @@ func Math_sin(ctx *context.Context, args ...value.Value) (value.Value, error) {
 		ctx.FastlyError = &value.String{Value: "EDOM"}
 		return &value.Float{IsNAN: true}, nil
 	case x.Value == 0:
-		return &value.Float{Value: 1.0}, nil
+		return &value.Float{Value: 0}, nil
 	case shared.IsSubnormalFloat64(x.Value):
 		ctx.FastlyError = &value.String{Value: "ERANGE"}
 		return &value.Float{Value: x.Value}, nil

--- a/interpreter/function/builtin/math_sin_test.go
+++ b/interpreter/function/builtin/math_sin_test.go
@@ -24,7 +24,7 @@ func Test_Math_sin(t *testing.T) {
 		err    *value.String
 	}{
 		{input: &value.Float{IsNAN: true}, expect: &value.Float{IsNAN: true}, err: nil},
-		{input: &value.Float{Value: 0}, expect: &value.Float{Value: 1.0}, err: nil},
+		{input: &value.Float{Value: 0}, expect: &value.Float{Value: 0}, err: nil},
 		{input: &value.Float{IsNegativeInf: true}, expect: &value.Float{IsNAN: true}, err: &value.String{Value: "EDOM"}},
 		{input: &value.Float{IsPositiveInf: true}, expect: &value.Float{IsNAN: true}, err: &value.String{Value: "EDOM"}},
 		{input: &value.Float{Value: subnormalValue}, expect: &value.Float{Value: subnormalValue}, err: &value.String{Value: "ERANGE"}},


### PR DESCRIPTION
- math.sin(0) returned 1 instead of 0
- math.exp(-Infinity) returned `-Infinity` instead of 0
- math.is_finite(NaN) returned `true` instead of `false`
- math.log, math.log10, math.log2 were missing domain validation

Matches Fastly's behavior, but also math :)