### PR TITLE
strftime: %0 is a valid padding modifier

### DIFF
--- a/interpreter/function/builtin/strftime.go
+++ b/interpreter/function/builtin/strftime.go
@@ -592,10 +592,11 @@ func Strftime(ctx *context.Context, args ...value.Value) (value.Value, error) {
 				formatted.WriteString(t.Format("-0700"))
 			case 0x5A: // %0Z
 				formatted.WriteString(t.Format("MST"))
+			default:
+				return value.Null, errors.New(
+					Strftime_Name, "Unexpected format token: %s at position %d", []byte{vvv}, i,
+				)
 			}
-			return value.Null, errors.New(
-				Strftime_Name, "Unexpected format token: %s at position %d", []byte{vvv}, i,
-			)
 		default:
 			return value.Null, errors.New(
 				Strftime_Name, "Unexpected format token: %s at position %d", []byte{vv}, i,

--- a/interpreter/function/builtin/strftime_test.go
+++ b/interpreter/function/builtin/strftime_test.go
@@ -24,6 +24,9 @@ func Test_Strftime(t *testing.T) {
 		{input: "%Y-%m-%d %H:%M", expect: "2023-03-03 01:48"},
 		{input: "%a, %d %b %Y %T %z", expect: "Fri, 03 Mar 2023 01:48:10 +0000"},
 		{input: "%Y-%m-%dT%H:%M:%SZ", expect: "2023-03-03T01:48:10Z"},
+		{input: "%0I", expect: "01"},
+		{input: "%0m", expect: "03"},
+		{input: "%0d", expect: "03"},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
`%0` is a valid padding modifier and should produce zero-padded output (e.g., %0I returns "02" for the 12-hour time).

However, in our implementation, the %0 modifier in strftime had its error return statement outside the switch statement rather than inside a default: case.

That unconditionally returned an error.