### PR TITLE
fix(simulate): prevent response headers from appearing as body in proxy mode

### DIFF
--- a/interpreter/handler.go
+++ b/interpreter/handler.go
@@ -89,15 +89,45 @@ func (i *Interpreter) sendResponse(w ghttp.ResponseWriter) {
 		return
 	}
 
-	// We have to use (*http.Response).Write(io.Writer)
-	// in order to write custom status text which is set via obj.response variable.
-	//
-	// Typically, on handling HTTP, http.ResponseWriter interface is enough to respond regular HTTP specs
-	// but could not set custom status text on the status line.
-	//
-	// Fortunately (*http.Response).Write(io.Writer) method will support to output custom status text
-	// so we need to send HTTP response via this method.
-	i.ctx.Response.Write(w) // nolint:errcheck
+	// Hijack preserves custom status text from obj.response (HTTP/1.x only).
+	// HTTP/2 does not support Hijack and has no reason phrase in the protocol,
+	// so we fall back to the standard ResponseWriter.
+	if i.sendRawResponse(w) != nil {
+		i.sendFormattedResponse(w)
+	}
+}
+
+// sendRawResponse writes the HTTP response directly to the hijacked connection,
+// preserving custom status text set via obj.response (e.g. "HTTP/1.1 200 Custom Text").
+func (i *Interpreter) sendRawResponse(w ghttp.ResponseWriter) error {
+	hj, ok := w.(ghttp.Hijacker)
+	if !ok {
+		return errors.New("hijack not supported")
+	}
+	conn, buf, err := hj.Hijack()
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	i.ctx.Response.Write(buf) // nolint:errcheck
+	buf.Flush()               // nolint:errcheck
+	return nil
+}
+
+// sendFormattedResponse writes the response using the standard http.ResponseWriter API.
+// Custom status text from obj.response is not preserved because WriteHeader only accepts
+// a status code integer, but this matches HTTP/2 behavior where reason phrase does not exist.
+func (i *Interpreter) sendFormattedResponse(w ghttp.ResponseWriter) {
+	resp := i.ctx.Response
+	for key, values := range resp.Header {
+		for _, v := range values {
+			w.Header().Add(key, v)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	if resp.Body != nil {
+		io.Copy(w, resp.Body) // nolint:errcheck
+	}
 }
 
 func (i *Interpreter) sendPurgeRequestResponse(w ghttp.ResponseWriter, err error) {

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -2,6 +2,7 @@ package interpreter
 
 import (
 	"fmt"
+	"io"
 	"testing"
 
 	"net/http"
@@ -214,4 +215,99 @@ func TestSyntheticAfterRestart(t *testing.T) {
 			"resp.http.synthetic-returned": &value.String{Value: "yes"},
 		}, false)
 	})
+}
+
+func TestCustomStatusTextPreserved(t *testing.T) {
+	tests := []struct {
+		name           string
+		vcl            string
+		enableHTTP2    bool
+		expectedStatus string
+		expectedBody   string
+	}{
+		{
+			name: "custom status text via obj.response in vcl_error",
+			vcl: `
+				sub vcl_recv {
+					error 700;
+				}
+				sub vcl_error {
+					set obj.status = 200;
+					set obj.response = "custom status text";
+					synthetic "response body";
+				}
+			`,
+			enableHTTP2:    false,
+			expectedStatus: "200 custom status text",
+			expectedBody:   "response body",
+		},
+		{
+			name: "default status text when obj.response is not set",
+			vcl: `
+				sub vcl_recv {
+					error 503;
+				}
+				sub vcl_error {
+					synthetic "response body";
+				}
+			`,
+			enableHTTP2:    false,
+			expectedStatus: "503 Service Unavailable",
+			expectedBody:   "response body",
+		},
+		{
+			name: "custom status text not preserved over HTTP/2",
+			vcl: `
+				sub vcl_recv {
+					error 700;
+				}
+				sub vcl_error {
+					set obj.status = 200;
+					set obj.response = "custom status text";
+					synthetic "response body";
+				}
+			`,
+			enableHTTP2:    true,
+			expectedStatus: "200 OK",
+			expectedBody:   "response body",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := New(
+				context.WithResolver(resolver.NewStaticResolver("main", tt.vcl)),
+				context.WithActualResponse(true),
+			)
+
+			server := httptest.NewUnstartedServer(ip)
+			if tt.enableHTTP2 {
+				server.EnableHTTP2 = true
+				server.StartTLS()
+			} else {
+				server.Start()
+			}
+			defer server.Close()
+
+			client := server.Client()
+
+			resp, err := client.Get(server.URL)
+			if err != nil {
+				t.Fatalf("Failed to make request: %s", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.Status != tt.expectedStatus {
+				t.Errorf("Expected status %q, got %q", tt.expectedStatus, resp.Status)
+			}
+
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("Failed to read body: %s", err)
+			}
+			if string(body) != tt.expectedBody {
+				t.Errorf("Expected body %q, got %q", tt.expectedBody, string(body))
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Fix `falco simulate --proxy` returning HTTP response headers as body content, a regression introduced by #509.

## Problem

#509 changed `sendResponse()` to use `(*http.Response).Write(w)` to preserve custom status text set via `obj.response`. However, `Response.Write()` writes the full raw HTTP response (status line + headers + body) into the `io.Writer`. Since Go's `http.ResponseWriter` auto-generates its own status line and headers on the first `Write()` call, the raw output ended up appearing as the response body.

## Fix

Split response writing into two paths:

- **HTTP/1.x** (`sendRawResponse`): Hijack the TCP connection and write the raw HTTP response directly, preserving custom status text from `obj.response`.
- **HTTP/2** (`sendFormattedResponse`): Use the standard `http.ResponseWriter` API to write headers and body separately. Custom status text is not preserved, but this is correct because HTTP/2 has no reason phrase in the protocol.

## What is preserved from #509

- `synthetic` and `obj.response` independence (removed `HasSyntheticResponse` flag)
- Default Fastly headers set before `vcl_deliver` (allowing them to be unset by VCL)
- Custom status text via `obj.response` (on HTTP/1.x connections)

---

Generated with [Claude Code](https://claude.com/claude-code)
