### PR TITLE
fix: Fix GetField to correctly handle quoted strings with escaped quotes

### DIFF
--- a/interpreter/variable/field.go
+++ b/interpreter/variable/field.go
@@ -36,8 +36,8 @@ func GetField(subject, key, sep string) *value.String {
 
 	// Due to fastly behavior with header values that do not conform to RFC-8941
 	// we don't always want to strip quotes.
-	if strings.HasPrefix(val, "\"") {
-		val = strings.Trim(val, "\"")
+	if len(val) >= 2 && strings.HasPrefix(val, `"`) && strings.HasSuffix(val, `"`) {
+		val = strings.ReplaceAll(val[1:len(val)-1], `\"`, `"`)
 	}
 	return &value.String{Value: val}
 }

--- a/interpreter/variable/field_test.go
+++ b/interpreter/variable/field_test.go
@@ -64,6 +64,7 @@ func TestGetField(t *testing.T) {
 		{input: `a=1,b="a,c=asdf",d=asdf`, field: "b", expect: "a,c=asdf"},
 		{input: `a=1,b="a,c=asdf",d=asdf`, field: "c", expect: `asdf"`},
 		{input: `a=1,b="a,c=asdf",d=asdf`, field: "d", expect: "asdf"},
+		{input: `a=1,b="\"asdf\""`, field: "b", expect: `"asdf"`},
 		{input: `a=c\,adf,b=asdf`, field: "a", expect: `c\`},
 		{input: `a=c\,adf,b=asdf`, field: "c", notSet: true},
 		{input: `a=c\,adf,b=asdf`, field: "adf", expect: ""},


### PR DESCRIPTION
## Summary

- Fix `GetField` to correctly handle quoted strings containing escaped quotes (e.g. `"\"asdf\""`)
- Previously, `strings.Trim(val, "\"")` would strip all leading/trailing `"` characters greedily, breaking values like `"\"asdf\""` which should resolve to `"asdf"`
- Now only the outermost quotes are removed, and inner escaped quotes (`\"`) are unescaped properly

## Changes

- field.go
  - Replace `strings.Trim` with explicit prefix/suffix check and `strings.ReplaceAll` for escaped quote handling
- field_test.go
  - Add test case for quoted string with escaped quotes

## Test plan

- [x] Existing `TestGetField` cases continue to pass
- [x] New test case `b="\"asdf\""` correctly returns `"asdf"`
