### PR TITLE
fix(formatter): use formatExpression for error statement args

### DIFF
--- a/formatter/statement_format.go
+++ b/formatter/statement_format.go
@@ -521,10 +521,10 @@ func (f *Formatter) formatErrorStatement(stmt *ast.ErrorStatement) string {
 	defer bufferPool.Put(buf)
 
 	buf.Reset()
-	buf.WriteString("error " + stmt.Code.String())
+	buf.WriteString("error " + f.formatExpression(stmt.Code).String())
 	// argument is arbitrary
 	if stmt.Argument != nil {
-		buf.WriteString(" " + stmt.Argument.String())
+		buf.WriteString(" " + f.formatExpression(stmt.Argument).ChunkedString(stmt.Nest, buf.Len()))
 	}
 	buf.WriteString(";")
 

--- a/formatter/statement_format_test.go
+++ b/formatter/statement_format_test.go
@@ -444,6 +444,23 @@ func TestFormatErrorStatement(t *testing.T) {
 }
 `,
 		},
+		{
+			name: "formatting with string concatenation",
+			input: `sub vcl_recv {
+  error 600 "https://" + req.http.Host + "/splash";
+}
+`,
+			expect: `sub vcl_recv {
+  error 600 "https://" + req.http.Host + "/splash";
+}
+`,
+			conf: &config.FormatConfig{
+				IndentWidth:          2,
+				IndentStyle:          "space",
+				LineWidth:            120,
+				ExplicitStringConcat: true,
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
- Call `f.formatExpression()` instead of `.String()` on error statement Code and Argument fields
- Prevents spurious parentheses from `InfixExpression.String()` wrapping each infix operation in parens
- Add test case for error statement with string concatenation

Before this change,

```vcl
error 600 "https://" + req.http.Host + "/splash";
```

was formatted with extra parentheses:

```vcl
error 600 (("https://" + req.http.Host) + "/splash");
```

and now it stays the same.