### PR TITLE
fix: preserve percent escapes in formatter output

### DIFF
--- a/formatter/expression_format.go
+++ b/formatter/expression_format.go
@@ -81,8 +81,8 @@ func (f *Formatter) formatString(expr *ast.String) string {
 	if expr.LongString {
 		return fmt.Sprintf(`{%s"%s"%s}`, expr.Delimiter, expr.Value, expr.Delimiter)
 	}
-	// Otherwise, double-quoted string
-	return fmt.Sprintf(`"%s"`, expr.Value)
+	// Otherwise, double-quoted string - use original token literal to preserve escapes
+	return fmt.Sprintf(`"%s"`, expr.Token.Literal)
 }
 
 func (f *Formatter) formatRTime(expr *ast.RTime) string {

--- a/formatter/statement_format_test.go
+++ b/formatter/statement_format_test.go
@@ -1155,3 +1155,59 @@ set req.http.Foo = "baz";
 		})
 	}
 }
+
+func TestFormatStringEscapes(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect string
+		conf   *config.FormatConfig
+	}{
+		{
+			name: "preserve percent escape sequences",
+			input: `sub vcl_recv {
+  if (req.url ~ "/%257") {
+    error 403;
+  }
+}
+`,
+			expect: `sub vcl_recv {
+  if (req.url ~ "/%257") {
+    error 403;
+  }
+}
+`,
+		},
+		{
+			name: "preserve multiple escape sequences",
+			input: `sub vcl_recv {
+  if (req.url ~ "/search/%24" || req.url ~ "/search/%7B" || req.url ~ "/search/%7D") {
+    error 404;
+  }
+}
+`,
+			expect: `sub vcl_recv {
+  if (req.url ~ "/search/%24" || req.url ~ "/search/%7B" || req.url ~ "/search/%7D") {
+    error 404;
+  }
+}
+`,
+		},
+		{
+			name: "preserve unicode escape sequences",
+			input: `sub vcl_recv {
+  set req.http.X-Test = "%u0024%u00A3";
+}
+`,
+			expect: `sub vcl_recv {
+  set req.http.X-Test = "%u0024%u00A3";
+}
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert(t, tt.input, tt.expect, tt.conf)
+		})
+	}
+}


### PR DESCRIPTION
- Use original token literal instead of decoded value for double-quoted strings
- Prevents `%25` from being incorrectly decoded to `%`, which produces invalid VCL (e.g., `%257` → `%7`)
- Add `TestFormatStringEscapes` with test cases for `%XX` and `%uXXXX` escapes