### PR TITLE
if_statement: fix else-if comment restored from the wrong variable

### DIFF
--- a/ast/if_statement.go
+++ b/ast/if_statement.go
@@ -43,9 +43,10 @@ func (i *IfStatement) String() string {
 		buf.WriteString(")")
 		buf.WriteString(paddingLeft(a.Consequence.LeadingComment(inline)))
 		buf.WriteString(" ")
+		aTmp := a.Consequence.Leading
 		a.Consequence.Leading = Comments{}
 		buf.WriteString(a.Consequence.String())
-		a.Consequence.Leading = tmp
+		a.Consequence.Leading = aTmp
 		buf.WriteString(a.TrailingComment(inline))
 	}
 	if i.Alternative != nil {

--- a/ast/if_statement_test.go
+++ b/ast/if_statement_test.go
@@ -70,3 +70,43 @@ else /* infix */ {
 
 	assert(t, ifs.String(), expect)
 }
+
+func TestIfStatementStringDoesNotCorruptElseIfLeadingComments(t *testing.T) {
+	elseIfComments := comments("/* else_if_block */")
+	ifComments := comments("/* if_block */")
+
+	ifs := &IfStatement{
+		Meta:    New(T, 0),
+		Keyword: "if",
+		Condition: &Ident{
+			Meta:  New(T, 0),
+			Value: "req.http.Host",
+		},
+		Consequence: &BlockStatement{
+			Meta:       New(T, 0, ifComments),
+			Statements: []Statement{},
+		},
+		Another: []*IfStatement{
+			{
+				Meta:    New(T, 0),
+				Keyword: "else if",
+				Condition: &Ident{
+					Meta:  New(T, 0),
+					Value: "req.http.X-Foo",
+				},
+				Consequence: &BlockStatement{
+					Meta:       New(T, 0, elseIfComments),
+					Statements: []Statement{},
+				},
+			},
+		},
+	}
+
+	ifs.String()
+
+	got := ifs.Another[0].Consequence.Leading[0].Value
+	if got != "/* else_if_block */" {
+		t.Errorf("else-if leading comment was corrupted: got %q, want %q",
+			got, "/* else_if_block */")
+	}
+}


### PR DESCRIPTION
The loop over `else-if` branches was restoring from the outer 'tmp' variable (which holds the main if-block's comments),instead of the value saved from the current else-if branch.