### PR TITLE
fix(interpreter): return NOT SET from std.strstr on miss

### DIFF
--- a/interpreter/function/builtin/std_strstr.go
+++ b/interpreter/function/builtin/std_strstr.go
@@ -41,7 +41,10 @@ func Std_strstr(ctx *context.Context, args ...value.Value) (value.Value, error) 
 
 	idx := strings.Index(haystack, needle)
 	if idx == -1 {
-		return &value.String{Value: ""}, nil
+		// Fastly returns NOT SET when the needle is not found. That is
+		// distinct from an empty string: NOT SET is falsy in a boolean
+		// context, an empty string is truthy.
+		return &value.String{IsNotSet: true}, nil
 	}
 
 	return &value.String{Value: haystack[idx:]}, nil

--- a/interpreter/statement_test.go
+++ b/interpreter/statement_test.go
@@ -529,6 +529,26 @@ func TestIfStatement(t *testing.T) {
 			},
 			isError: false,
 		},
+		{
+			// Regression: std.strstr must return NOT SET when the needle is
+			// not found, so `if (std.strstr(...))` is falsy. An earlier bug
+			// returned an empty (but set) string, which made the condition
+			// unconditionally truthy.
+			name: "std.strstr miss is falsy",
+			vcl: `
+			sub vcl_recv {
+				set req.url = "/foo";
+				if (std.strstr(req.url, "/nothing-that-matches")) {
+					header.set(req, "foo", "truthy");
+				} else {
+					header.set(req, "foo", "falsy");
+				}
+			}`,
+			assertions: map[string]value.Value{
+				"req.http.foo": &value.String{Value: "falsy"},
+			},
+			isError: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
- Return `&value.String{IsNotSet: true}` instead of an empty string when the needle is not found, matching Fastly's documented behavior https://www.fastly.com/documentation/reference/vcl/functions/strings/std-strstr/index.md
- Fixes `if (std.strstr(...))` being unconditionally truthy: an empty-but-set string is truthy in VCL boolean context, only NOT SET is falsy
- Add `TestIfStatement` regression case covering the reported `if (std.strstr(req.url, "/nothing-that-matches"))` scenario