### PR TITLE
fix: align multi-line comments in declaration blocks

### DIFF
--- a/formatter/declaration_format.go
+++ b/formatter/declaration_format.go
@@ -61,8 +61,7 @@ func (f *Formatter) formatAclDeclaration(decl *ast.AclDeclaration) *Declaration 
 	buf.WriteString("acl " + decl.Name.String() + " {\n")
 	buf.WriteString(group.String())
 	if len(decl.Infix) > 0 {
-		buf.WriteString(f.indent(1))
-		buf.WriteString(f.formatComment(decl.Infix, "\n", 0))
+		buf.WriteString(f.formatComment(decl.Infix, "\n", 1))
 	}
 	buf.WriteString("}")
 
@@ -82,8 +81,7 @@ func (f *Formatter) formatBackendDeclaration(decl *ast.BackendDeclaration) *Decl
 	buf.WriteString("backend " + decl.Name.String() + " {\n")
 	buf.WriteString(f.formatBackendProperties(decl.Properties, 1))
 	if len(decl.Infix) > 0 {
-		buf.WriteString(f.indent(1))
-		buf.WriteString(f.formatComment(decl.Infix, "\n", 0))
+		buf.WriteString(f.formatComment(decl.Infix, "\n", 1))
 	}
 	buf.WriteString("}")
 
@@ -221,8 +219,7 @@ func (f *Formatter) formatDirectorDeclaration(decl *ast.DirectorDeclaration) *De
 	buf.WriteString("director " + decl.Name.String() + " " + decl.DirectorType.String() + " {\n")
 	buf.WriteString(group.String())
 	if len(decl.Infix) > 0 {
-		buf.WriteString(f.indent(1))
-		buf.WriteString(f.formatComment(decl.Infix, "\n", 0))
+		buf.WriteString(f.formatComment(decl.Infix, "\n", 1))
 	}
 	buf.WriteString("}")
 
@@ -246,8 +243,7 @@ func (f *Formatter) formatTableDeclaration(decl *ast.TableDeclaration) *Declarat
 	buf.WriteString(" {\n")
 	buf.WriteString(f.formatTableProperties(decl.Properties))
 	if len(decl.Infix) > 0 {
-		buf.WriteString(f.indent(1))
-		buf.WriteString(f.formatComment(decl.Infix, "\n", 0))
+		buf.WriteString(f.formatComment(decl.Infix, "\n", 1))
 	}
 	buf.WriteString("}")
 
@@ -314,8 +310,7 @@ func (f *Formatter) formatPenaltyboxDeclaration(decl *ast.PenaltyboxDeclaration)
 	// penaltybox does not have properties
 	if len(decl.Block.Infix) > 0 {
 		buf.WriteString("\n")
-		buf.WriteString(f.indent(1))
-		buf.WriteString(f.formatComment(decl.Block.Infix, "\n", 0))
+		buf.WriteString(f.formatComment(decl.Block.Infix, "\n", 1))
 	}
 	buf.WriteString("}")
 
@@ -337,8 +332,7 @@ func (f *Formatter) formatRatecounterDeclaration(decl *ast.RatecounterDeclaratio
 	// ratecounter does not have properties
 	if len(decl.Block.Infix) > 0 {
 		buf.WriteString("\n")
-		buf.WriteString(f.indent(1))
-		buf.WriteString(f.formatComment(decl.Block.Infix, "\n", 0))
+		buf.WriteString(f.formatComment(decl.Block.Infix, "\n", 1))
 	}
 	buf.WriteString("}")
 

--- a/formatter/declaration_format_test.go
+++ b/formatter/declaration_format_test.go
@@ -47,6 +47,20 @@ func TestAclDeclarationFormat(t *testing.T) {
 }  // trailing
 `,
 		},
+		{
+			name: "multiple trailing comments are consistently indented",
+			input: `acl name {
+			  "192.0.2.0"/24;
+			  # comment 1
+			  # comment 2
+			}`,
+			expect: `acl name {
+  "192.0.2.0"/24;
+  # comment 1
+  # comment 2
+}
+`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -217,6 +231,20 @@ backend /* before_name */ example /* after_name */ {
 				LineWidth:                80,
 			},
 		},
+		{
+			name: "multiple trailing comments are consistently indented",
+			input: `backend example {
+				.host = "example.com";
+				# comment 1
+				# comment 2
+			}`,
+			expect: `backend example {
+  .host = "example.com";
+  # comment 1
+  # comment 2
+}
+`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -253,6 +281,20 @@ director /* before_name */ example /* after_name */ hash /* after_type */ {
   { .backend = F_backend3; .weight = 1; }
   // infix
 }  // trailing
+`,
+		},
+		{
+			name: "multiple trailing comments are consistently indented",
+			input: `director example hash {
+				{ .backend=F_backend1; .weight=1; }
+				# comment 1
+				# comment 2
+			}`,
+			expect: `director example hash {
+  { .backend = F_backend1; .weight = 1; }
+  # comment 1
+  # comment 2
+}
 `,
 		},
 		{
@@ -380,6 +422,32 @@ table /* before_name */ routing_table /* after_name */ BACKEND /* after_type */ 
 				LineWidth:                80,
 			},
 		},
+		{
+			name: "consecutive commented-out properties are consistently indented",
+			input: `table t1 {
+			# "a": "x" # DISABLED 1
+			# "b": "y" # DISABLED 2
+			}`,
+			expect: `table t1 {
+  # "a": "x" # DISABLED 1
+  # "b": "y" # DISABLED 2
+}
+`,
+		},
+		{
+			name: "commented-out properties around a real entry are consistently indented",
+			input: `table t2 {
+			# "a": "x" # DISABLED 1
+			"c.example.com": "z",
+			# "b": "y" # DISABLED 2
+			}`,
+			expect: `table t2 {
+  # "a": "x" # DISABLED 1
+  "c.example.com": "z",
+  # "b": "y" # DISABLED 2
+}
+`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -408,6 +476,18 @@ penaltybox /* before_name */ banned_users /* after_name */ {
 }  // trailing comment
 `,
 		},
+		{
+			name: "multiple comments are consistently indented",
+			input: `penaltybox banned_users {
+			# comment 1
+			# comment 2
+			}`,
+			expect: `penaltybox banned_users {
+  # comment 1
+  # comment 2
+}
+`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -434,6 +514,18 @@ func TestRatecounterDeclarationFormat(t *testing.T) {
 ratecounter /* before_name */ requests_rate /* after_name */ {
   # no properties
 }  // trailing comment
+`,
+		},
+		{
+			name: "multiple comments are consistently indented",
+			input: `ratecounter requests_rate {
+			# comment 1
+			# comment 2
+			}`,
+			expect: `ratecounter requests_rate {
+  # comment 1
+  # comment 2
+}
 `,
 		},
 	}


### PR DESCRIPTION
- Ensure comments inside acl, backend, director, table, penaltybox, and ratecounter blocks are consistently indented
- Previously only the first line of a multi-line comment was indented; remaining lines fell to column 0
- Add regression tests for multiple consecutive comments in each