### PR TITLE
feat: default explicit string concat to true

### DIFF
--- a/cmd/wasm/api.go
+++ b/cmd/wasm/api.go
@@ -288,7 +288,7 @@ func defaultFormatConfig() *config.FormatConfig {
 		IndentStyle:                config.IndentStyleSpace,
 		TrailingCommentWidth:       1,
 		LineWidth:                  120,
-		ExplicitStringConcat:       false,
+		ExplicitStringConcat:       true,
 		SortDeclarationProperty:    false,
 		AlignDeclarationProperty:   false,
 		ElseIf:                     false,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,7 +31,7 @@ format:
   indent_style: space
   trailing_comment_width: 2                                                        |
   line_width: 120
-  explicit_string_concat: false
+  explicit_string_concat: true
   sort_declaration_property: false
   align_declaration_property: false
   else_if: false


### PR DESCRIPTION
- Flip WASM formatter default for `explicit_string_concat` to `true`, matching the CLI default
- Update docs sample config to reflect the true default

It defaulted to true since https://github.com/ysugimoto/falco/pull/534