### PR TITLE
fix: return req/beresp.backend.port as INTEGER

### DIFF
--- a/interpreter/variable/backend_test.go
+++ b/interpreter/variable/backend_test.go
@@ -1,0 +1,80 @@
+package variable
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+// backendWithPort builds a context whose current backend declares the given
+// port property, e.g. ".port = "8443";".
+func backendWithPort(port string) *context.Context {
+	return &context.Context{
+		Backend: &value.Backend{
+			Value: &ast.BackendDeclaration{
+				Name: &ast.Ident{Value: "example"},
+				Properties: []*ast.BackendProperty{
+					{
+						Key:   &ast.Ident{Value: "port"},
+						Value: &ast.String{Value: port},
+					},
+				},
+			},
+		},
+	}
+}
+
+// req.backend.port and beresp.backend.port are INTEGER per Fastly:
+// https://www.fastly.com/documentation/reference/vcl/variables/miscellaneous/req-backend-port/
+// https://www.fastly.com/documentation/reference/vcl/variables/backend-connection/beresp-backend-port/
+//
+// The port property is stored as an *ast.String. Reading it via
+// p.Value.String() yields the quoted form (`"8443"`), which strconv.ParseInt
+// rejects; the value must be read from the *ast.String's Value field. Each
+// scope must also return the result as a *value.Integer.
+func TestBackendPortReturnsInteger(t *testing.T) {
+	tests := []struct {
+		name string
+		get  func(*context.Context) (value.Value, error)
+	}{
+		{
+			name: "req.backend.port in deliver scope",
+			get: func(c *context.Context) (value.Value, error) {
+				return NewDeliverScopeVariables(c).Get(context.DeliverScope, REQ_BACKEND_PORT)
+			},
+		},
+		{
+			name: "req.backend.port in error scope",
+			get: func(c *context.Context) (value.Value, error) {
+				return NewErrorScopeVariables(c).Get(context.ErrorScope, REQ_BACKEND_PORT)
+			},
+		},
+		{
+			name: "req.backend.port in log scope",
+			get: func(c *context.Context) (value.Value, error) {
+				return NewLogScopeVariables(c).Get(context.LogScope, REQ_BACKEND_PORT)
+			},
+		},
+		{
+			name: "beresp.backend.port in fetch scope",
+			get: func(c *context.Context) (value.Value, error) {
+				return NewFetchScopeVariables(c).Get(context.FetchScope, BERESP_BACKEND_PORT)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.get(backendWithPort("8443"))
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
+			if diff := cmp.Diff(value.Value(&value.Integer{Value: 8443}), got); diff != "" {
+				t.Errorf("port value mismatch, diff: %s", diff)
+			}
+		})
+	}
+}

--- a/interpreter/variable/backend_test.go
+++ b/interpreter/variable/backend_test.go
@@ -78,3 +78,38 @@ func TestBackendPortReturnsInteger(t *testing.T) {
 		})
 	}
 }
+
+// When the backend is nil or declares no port property, getBackendPort falls
+// back to INTEGER 0 rather than erroring.
+func TestBackendPortFallsBackToZero(t *testing.T) {
+	tests := []struct {
+		name    string
+		backend *value.Backend
+	}{
+		{
+			name:    "nil backend",
+			backend: nil,
+		},
+		{
+			name: "backend without port property",
+			backend: &value.Backend{
+				Value: &ast.BackendDeclaration{
+					Name:       &ast.Ident{Value: "example"},
+					Properties: []*ast.BackendProperty{},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getBackendPort(tt.backend)
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
+			if diff := cmp.Diff(value.Value(&value.Integer{Value: 0}), got); diff != "" {
+				t.Errorf("port value mismatch, diff: %s", diff)
+			}
+		})
+	}
+}

--- a/interpreter/variable/deliver.go
+++ b/interpreter/variable/deliver.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"strconv"
 	"strings"
 	"time"
 
@@ -148,22 +147,7 @@ func (v *DeliverScopeVariables) Get(s context.Scope, name string) (value.Value, 
 		}
 		return &value.String{Value: name}, nil
 	case REQ_BACKEND_PORT:
-		if v.ctx.Backend == nil {
-			return &value.Integer{Value: 0}, nil
-		}
-		var port int64
-		for _, p := range v.ctx.Backend.Value.Properties {
-			if p.Key.Value != PORT {
-				continue
-			}
-			n, err := strconv.ParseInt(p.Value.String(), 10, 64)
-			if err != nil {
-				return value.Null, errors.WithStack(err)
-			}
-			port = n
-			break
-		}
-		return &value.Integer{Value: port}, nil
+		return getBackendPort(v.ctx.Backend)
 	case REQ_BODY_BYTES_READ:
 		var buf bytes.Buffer
 		n, err := buf.ReadFrom(req.Body)

--- a/interpreter/variable/error.go
+++ b/interpreter/variable/error.go
@@ -2,7 +2,6 @@ package variable
 
 import (
 	"net"
-	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
@@ -113,22 +112,7 @@ func (v *ErrorScopeVariables) Get(s context.Scope, name string) (value.Value, er
 		}
 		return &value.String{Value: name}, nil
 	case REQ_BACKEND_PORT:
-		if v.ctx.Backend == nil {
-			return &value.Integer{Value: 0}, nil
-		}
-		var port int64
-		for _, p := range v.ctx.Backend.Value.Properties {
-			if p.Key.Value != PORT {
-				continue
-			}
-			n, err := strconv.ParseInt(p.Value.String(), 10, 64)
-			if err != nil {
-				return value.Null, errors.WithStack(err)
-			}
-			port = n
-			break
-		}
-		return &value.Integer{Value: port}, nil
+		return getBackendPort(v.ctx.Backend)
 
 	case REQ_ESI:
 		return v.ctx.EnableSSI, nil

--- a/interpreter/variable/fetch.go
+++ b/interpreter/variable/fetch.go
@@ -150,15 +150,7 @@ func (v *FetchScopeVariables) Get(s context.Scope, name string) (value.Value, er
 	case BERESP_BACKEND_NAME:
 		return &value.String{Value: v.ctx.Backend.Value.Name.Value}, nil
 	case BERESP_BACKEND_PORT:
-		for _, p := range v.ctx.Backend.Value.Properties {
-			if p.Key.Value != "port" {
-				continue
-			}
-			if s, ok := p.Value.(*ast.String); ok {
-				return &value.String{Value: s.Value}, nil
-			}
-		}
-		return &value.String{Value: ""}, nil
+		return getBackendPort(v.ctx.Backend)
 	case BERESP_BACKEND_REQUESTS:
 		return &value.Integer{Value: 1}, nil
 

--- a/interpreter/variable/log.go
+++ b/interpreter/variable/log.go
@@ -153,22 +153,7 @@ func (v *LogScopeVariables) Get(s context.Scope, name string) (value.Value, erro
 		}
 		return &value.String{Value: name}, nil
 	case REQ_BACKEND_PORT:
-		if v.ctx.Backend == nil {
-			return &value.Integer{Value: 0}, nil
-		}
-		var port int64
-		for _, p := range v.ctx.Backend.Value.Properties {
-			if p.Key.Value != "port" {
-				continue
-			}
-			n, err := strconv.ParseInt(p.Value.String(), 10, 64)
-			if err != nil {
-				return value.Null, errors.WithStack(err)
-			}
-			port = n
-			break
-		}
-		return &value.Integer{Value: port}, nil
+		return getBackendPort(v.ctx.Backend)
 	case REQ_BODY_BYTES_READ:
 		var buf bytes.Buffer
 		n, err := buf.ReadFrom(req.Body)

--- a/interpreter/variable/shared.go
+++ b/interpreter/variable/shared.go
@@ -2,13 +2,40 @@ package variable
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/ysugimoto/falco/ast"
 	"github.com/ysugimoto/falco/interpreter/context"
 	"github.com/ysugimoto/falco/interpreter/limitations"
 	"github.com/ysugimoto/falco/interpreter/value"
 )
+
+// getBackendPort reads the "port" property from a backend declaration and
+// returns it as an INTEGER, matching Fastly's req.backend.port and
+// beresp.backend.port (both INTEGER). The property is parsed as an
+// *ast.String literal (e.g. .port = "443";), so its Value must be read
+// directly; calling String() would re-serialize it to the quoted VCL form
+// and fail to parse. Returns 0 when the backend or port property is absent.
+func getBackendPort(backend *value.Backend) (value.Value, error) {
+	if backend == nil {
+		return &value.Integer{Value: 0}, nil
+	}
+	for _, p := range backend.Value.Properties {
+		if p.Key.Value != PORT {
+			continue
+		}
+		if s, ok := p.Value.(*ast.String); ok {
+			n, err := strconv.ParseInt(s.Value, 10, 64)
+			if err != nil {
+				return value.Null, errors.WithStack(err)
+			}
+			return &value.Integer{Value: n}, nil
+		}
+	}
+	return &value.Integer{Value: 0}, nil
+}
 
 func GetFastlyInfoVariable(ctx *context.Context, name string) (value.Value, error) {
 	switch name {


### PR DESCRIPTION
  ## Problem

  - `req.backend.port` (deliver/error/log) parsed the backend `.port` property
    via `strconv.ParseInt(p.Value.String())`, but `String()` returns the quoted
    VCL form (`"443"`), which `ParseInt` rejects — yielding `value.Null` and a
    runtime exception on any subsequent use.
  - `beresp.backend.port` (fetch) returned a `*value.String`, contradicting its
    declared INTEGER type, and lacked a nil-backend guard.

  ## Fix

  Add a `getBackendPort` helper in `shared.go` that reads the `*ast.String.Value`
  directly and returns `*value.Integer`; all four scopes call it. Adds a unit
  test covering each scope.

  Verified against Fastly docs:
  - https://www.fastly.com/documentation/reference/vcl/variables/miscellaneous/req-backend-port/
  - https://www.fastly.com/documentation/reference/vcl/variables/backend-connection/beresp-backend-port/
