### PR TITLE
Make += append to HTTP headers instead of overwriting them

### DIFF
--- a/interpreter/append_assign_test.go
+++ b/interpreter/append_assign_test.go
@@ -1,0 +1,62 @@
+package interpreter
+
+import (
+	"testing"
+
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+// On Fastly an appending assignment prepends the current header value to the
+// assembled string, so `set req.http.X += "y"` appends rather than overwrites.
+func TestAppendAssignHeader(t *testing.T) {
+	t.Run("+= appends to an existing request header", func(t *testing.T) {
+		vcl := `sub vcl_recv {
+			set req.http.A = "abc";
+			set req.http.A += "xy";
+		}`
+		assertInterpreter(t, vcl, context.RecvScope, map[string]value.Value{
+			"req.http.A": &value.String{Value: "abcxy"},
+		}, false)
+	})
+
+	t.Run("+= onto an unset request header sets it", func(t *testing.T) {
+		vcl := `sub vcl_recv {
+			set req.http.A += "xy";
+		}`
+		assertInterpreter(t, vcl, context.RecvScope, map[string]value.Value{
+			"req.http.A": &value.String{Value: "xy"},
+		}, false)
+	})
+
+	t.Run("+= concatenates several fragments", func(t *testing.T) {
+		vcl := `sub vcl_recv {
+			set req.http.A = "1";
+			set req.http.A += "2";
+			set req.http.A += "3" "4";
+		}`
+		assertInterpreter(t, vcl, context.RecvScope, map[string]value.Value{
+			"req.http.A": &value.String{Value: "1234"},
+		}, false)
+	})
+
+	t.Run("plain = still overwrites", func(t *testing.T) {
+		vcl := `sub vcl_recv {
+			set req.http.A = "abc";
+			set req.http.A = "xy";
+		}`
+		assertInterpreter(t, vcl, context.RecvScope, map[string]value.Value{
+			"req.http.A": &value.String{Value: "xy"},
+		}, false)
+	})
+
+	t.Run("+= appends to a response header", func(t *testing.T) {
+		vcl := `sub vcl_deliver {
+			set resp.http.A = "abc";
+			set resp.http.A += "xy";
+		}`
+		assertInterpreter(t, vcl, context.DeliverScope, map[string]value.Value{
+			"resp.http.A": &value.String{Value: "abcxy"},
+		}, false)
+	})
+}

--- a/interpreter/variable/all.go
+++ b/interpreter/variable/all.go
@@ -993,8 +993,7 @@ func (v *AllScopeVariables) Set(s context.Scope, name, operator string, val valu
 				"BACKEND literal %s cannot be assigned to %s in scope: %s", v.String(), name, s.String(),
 			))
 		}
-		setRequestHeaderValue(v.ctx.Request, match[1], val)
-		return nil
+		return assignRequestHeaderValue(v.ctx.Request, match[1], operator, val)
 	}
 
 	if injectedVariable != nil {

--- a/interpreter/variable/deliver.go
+++ b/interpreter/variable/deliver.go
@@ -340,8 +340,7 @@ func (v *DeliverScopeVariables) Set(s context.Scope, name, operator string, val 
 			return errors.WithStack(err)
 		}
 
-		setResponseHeaderValue(v.ctx.Response, match[1], val)
-		return nil
+		return assignResponseHeaderValue(v.ctx.Response, match[1], operator, val)
 	}
 
 	// If not found, pass to all scope value

--- a/interpreter/variable/error.go
+++ b/interpreter/variable/error.go
@@ -249,8 +249,7 @@ func (v *ErrorScopeVariables) Set(s context.Scope, name, operator string, val va
 		if err := limitations.CheckProtectedHeader(match[1]); err != nil {
 			return errors.WithStack(err)
 		}
-		setResponseHeaderValue(v.ctx.Object, match[1], val)
-		return nil
+		return assignResponseHeaderValue(v.ctx.Object, match[1], operator, val)
 	}
 
 	// If not found, pass to all scope value

--- a/interpreter/variable/fetch.go
+++ b/interpreter/variable/fetch.go
@@ -374,7 +374,7 @@ func (v *FetchScopeVariables) Set(s context.Scope, name, operator string, val va
 		return nil
 	}
 
-	if ok, err := SetBackendRequestHeader(v.ctx, name, val); err != nil {
+	if ok, err := SetBackendRequestHeader(v.ctx, name, operator, val); err != nil {
 		return errors.WithStack(err)
 	} else if ok {
 		return nil
@@ -383,8 +383,7 @@ func (v *FetchScopeVariables) Set(s context.Scope, name, operator string, val va
 		if err := limitations.CheckProtectedHeader(match[1]); err != nil {
 			return errors.WithStack(err)
 		}
-		setResponseHeaderValue(v.ctx.BackendResponse, match[1], val)
-		return nil
+		return assignResponseHeaderValue(v.ctx.BackendResponse, match[1], operator, val)
 	}
 
 	// If not found, pass to all scope value

--- a/interpreter/variable/header.go
+++ b/interpreter/variable/header.go
@@ -4,9 +4,45 @@ import (
 	"net/textproto"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/ysugimoto/falco/interpreter/http"
 	"github.com/ysugimoto/falco/interpreter/value"
 )
+
+// assignHeaderValue stores val into a header, honoring the assignment operator.
+// "=" overwrites, while "+=" (and the other compound operators) read the current
+// value and apply the operation, so on Fastly `set req.http.X += "y"` appends to
+// the header rather than overwriting it. The current value is read lazily so the
+// common "=" case stays cheap. get and set adapt this to request or response
+// headers.
+func assignHeaderValue(operator string, val value.Value, get func() *value.String, set func(value.Value)) error {
+	if operator == "=" {
+		set(val)
+		return nil
+	}
+	left := get()
+	if err := doAssign(left, operator, val); err != nil {
+		return errors.WithStack(err)
+	}
+	// A compound assignment always leaves the header set.
+	left.IsNotSet = false
+	set(left)
+	return nil
+}
+
+func assignRequestHeaderValue(r *http.Request, name, operator string, val value.Value) error {
+	return assignHeaderValue(operator, val,
+		func() *value.String { return getRequestHeaderValue(r, name) },
+		func(v value.Value) { setRequestHeaderValue(r, name, v) },
+	)
+}
+
+func assignResponseHeaderValue(r *http.Response, name, operator string, val value.Value) error {
+	return assignHeaderValue(operator, val,
+		func() *value.String { return getResponseHeaderValue(r, name) },
+		func(v value.Value) { setResponseHeaderValue(r, name, v) },
+	)
+}
 
 func isNotSetValue(v value.Value) bool {
 	switch t := v.(type) {

--- a/interpreter/variable/hit.go
+++ b/interpreter/variable/hit.go
@@ -130,8 +130,7 @@ func (v *HitScopeVariables) Set(s context.Scope, name, operator string, val valu
 		if err := limitations.CheckProtectedHeader(match[1]); err != nil {
 			return errors.WithStack(err)
 		}
-		setResponseHeaderValue(v.ctx.Object, match[1], val)
-		return nil
+		return assignResponseHeaderValue(v.ctx.Object, match[1], operator, val)
 	}
 
 	// If not found, pass to all scope value

--- a/interpreter/variable/miss.go
+++ b/interpreter/variable/miss.go
@@ -192,7 +192,7 @@ func (v *MissScopeVariables) Set(s context.Scope, name, operator string, val val
 		return nil
 	}
 
-	if ok, err := SetBackendRequestHeader(v.ctx, name, val); err != nil {
+	if ok, err := SetBackendRequestHeader(v.ctx, name, operator, val); err != nil {
 		return errors.WithStack(err)
 	} else if ok {
 		return nil

--- a/interpreter/variable/pass.go
+++ b/interpreter/variable/pass.go
@@ -176,7 +176,7 @@ func (v *PassScopeVariables) Set(s context.Scope, name, operator string, val val
 		return nil
 	}
 
-	if ok, err := SetBackendRequestHeader(v.ctx, name, val); err != nil {
+	if ok, err := SetBackendRequestHeader(v.ctx, name, operator, val); err != nil {
 		return errors.WithStack(err)
 	} else if ok {
 		return nil

--- a/interpreter/variable/shared.go
+++ b/interpreter/variable/shared.go
@@ -390,12 +390,14 @@ func GetWafVariables(ctx *context.Context, name string) (value.Value, error) {
 	return nil, nil
 }
 
-func SetBackendRequestHeader(ctx *context.Context, name string, val value.Value) (bool, error) {
+func SetBackendRequestHeader(ctx *context.Context, name, operator string, val value.Value) (bool, error) {
 	if match := backendRequestHttpHeaderRegex.FindStringSubmatch(name); match != nil {
 		if err := limitations.CheckProtectedHeader(match[1]); err != nil {
 			return true, errors.WithStack(err)
 		}
-		setRequestHeaderValue(ctx.BackendRequest, match[1], val)
+		if err := assignRequestHeaderValue(ctx.BackendRequest, match[1], operator, val); err != nil {
+			return true, errors.WithStack(err)
+		}
 		return true, nil
 	}
 	return false, nil


### PR DESCRIPTION
Header assignment ignored the operator in every scope.

`set req.http.X += "y"` replaced the value rather than appending to it.

Fix it.