### PR TITLE
Enforce the VCL call tree and request workspace limits

### DIFF
--- a/interpreter/context/context.go
+++ b/interpreter/context/context.go
@@ -79,6 +79,11 @@ type Context struct {
 	RequestStartTime time.Time
 	CacheHitItem     *cache.CacheItem
 
+	// RequestWorkspaceBytes tracks how much of the per-request workspace has been
+	// consumed by assembling request headers. Fastly never reclaims it within a
+	// request, not even across restarts, so this is never reset once set.
+	RequestWorkspaceBytes int
+
 	// Interpreter states, following variables could be set in each subroutine directives
 	Restarts                            int
 	State                               string

--- a/interpreter/helper.go
+++ b/interpreter/helper.go
@@ -59,6 +59,23 @@ func isRequestHeaderIdent(ident *ast.Ident) bool {
 	return strings.HasPrefix(ident.Value, "req.http.")
 }
 
+// requestHeaderName returns the bare header name Fastly charges the workspace
+// for (e.g. `X-Foo`), not the VCL identifier.
+func requestHeaderName(ident *ast.Ident) string {
+	name := strings.TrimPrefix(ident.Value, "req.http.")
+	if before, _, found := strings.Cut(name, ":"); found {
+		name = before
+	}
+	return name
+}
+
+// roundUpToPointer rounds a workspace allocation up to the next 8 byte boundary,
+// as Fastly does for every header allocation.
+func roundUpToPointer(n int) int {
+	const align = 8
+	return (n + align - 1) &^ (align - 1)
+}
+
 // Validate type string is Fastly supported value type
 func isValidFastlyTypeString(t string) bool {
 	switch t {

--- a/interpreter/helper.go
+++ b/interpreter/helper.go
@@ -53,6 +53,12 @@ func isHeaderFieldIdent(ident *ast.Ident) bool {
 	return found && strings.Contains(name, ".http.")
 }
 
+// isRequestHeaderIdent reports whether the identifier refers to a request header
+// (req.http.*). Each write to one is assembled in the request workspace.
+func isRequestHeaderIdent(ident *ast.Ident) bool {
+	return strings.HasPrefix(ident.Value, "req.http.")
+}
+
 // Validate type string is Fastly supported value type
 func isValidFastlyTypeString(t string) bool {
 	switch t {

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -168,6 +168,10 @@ func (i *Interpreter) ProcessInit(r *http.Request) error {
 	if err := limitations.CheckFastlyResourceLimit(i.ctx); err != nil {
 		return errors.WithStack(err)
 	}
+	if err := limitations.CheckFastlyCallTreeLimit(i.ctx); err != nil {
+		i.Debugger.Message(err.Error())
+		return errors.WithStack(err)
+	}
 
 	return nil
 }

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -135,6 +135,7 @@ func (i *Interpreter) ProcessInit(r *http.Request) error {
 	i.ctx = ctx
 	i.ctx.Request = r
 	r.Header.Set("Host", r.Host)
+	i.chargeInboundRequestWorkspace()
 
 	// OriginalHost value may be overridden. If not empty, set the request value
 	if i.ctx.OriginalHost == "" {

--- a/interpreter/limitations/limitations.go
+++ b/interpreter/limitations/limitations.go
@@ -4,9 +4,12 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"maps"
 	ghttp "net/http"
+	"sort"
 	"strings"
 
+	"github.com/ysugimoto/falco/ast"
 	"github.com/ysugimoto/falco/interpreter/context"
 	"github.com/ysugimoto/falco/interpreter/exception"
 	"github.com/ysugimoto/falco/interpreter/http"
@@ -39,6 +42,18 @@ const (
 	MaxVarnishRestarts   = 3
 	MaxLogLineSize       = 16 * KB
 
+	// MaxSubroutineCallTree is the ceiling Fastly enforces on the fully inlined
+	// subroutine call graph. The cost of a subroutine is the sum, over each of
+	// its `call` statements, of one plus the callee's own cost, so nested calls
+	// multiply. Past this, Fastly rejects activation with "Too many sub calls".
+	MaxSubroutineCallTree = 25000
+
+	// MaxRequestWorkspaceSize is the size of the per-request workspace. Request
+	// headers are assembled into this workspace and the previous copy is never
+	// reclaimed, even across restarts, so a VCL that rewrites a header many
+	// times eventually overflows it and Fastly returns "503 Header overflow".
+	MaxRequestWorkspaceSize = 256 * KB
+
 	// Increasable limitations by contacting Fastly support
 	// These are defaults, you can override by configuration
 	MaxACLCounts     = 1000
@@ -53,6 +68,105 @@ func CheckFastlyVCLLimitation(vcl string) error {
 		)
 	}
 	return nil
+}
+
+// CheckFastlyCallTreeLimit emulates Fastly's compile-time check on the fully
+// inlined subroutine call graph. Fastly inlines every `call` statement, so a
+// subroutine that calls another many times multiplies the callee's whole
+// subtree. When the expansion of any subroutine exceeds MaxSubroutineCallTree,
+// activation fails with "Too many sub calls".
+func CheckFastlyCallTreeLimit(ctx *context.Context) error {
+	subroutines := make(
+		map[string]*ast.SubroutineDeclaration,
+		len(ctx.Subroutines)+len(ctx.SubroutineFunctions),
+	)
+	maps.Copy(subroutines, ctx.Subroutines)
+	maps.Copy(subroutines, ctx.SubroutineFunctions)
+
+	costs := make(map[string]int, len(subroutines))
+	visiting := make(map[string]bool, len(subroutines))
+
+	var cost func(name string) int
+	cost = func(name string) int {
+		if c, ok := costs[name]; ok {
+			return c
+		}
+		sub, ok := subroutines[name]
+		if !ok {
+			return 0
+		}
+		// Guard against recursive VCL (which Fastly rejects anyway) so the walk
+		// always terminates; the interpreter reports the recursion separately
+		// through its runtime call-stack guard.
+		if visiting[name] {
+			return 0
+		}
+		visiting[name] = true
+		var total int
+		for _, call := range collectCallStatements(sub.Block) {
+			total += 1 + cost(call.Subroutine.Value)
+		}
+		visiting[name] = false
+		costs[name] = total
+		return total
+	}
+
+	// Report deterministically by visiting subroutines in name order.
+	names := make([]string, 0, len(subroutines))
+	for name := range subroutines {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if c := cost(name); c > MaxSubroutineCallTree {
+			return exception.Runtime(
+				&subroutines[name].GetMeta().Token,
+				"Too many sub calls: subroutine %s expands to %d calls, exceeding the limit of %d",
+				name, c, MaxSubroutineCallTree,
+			)
+		}
+	}
+	return nil
+}
+
+// collectCallStatements returns every `call` statement reachable inside a
+// subroutine block, descending into nested if/else and switch blocks.
+func collectCallStatements(block *ast.BlockStatement) []*ast.CallStatement {
+	if block == nil {
+		return nil
+	}
+	var calls []*ast.CallStatement
+	walkCallStatements(block.Statements, &calls)
+	return calls
+}
+
+func walkCallStatements(statements []ast.Statement, calls *[]*ast.CallStatement) {
+	for _, stmt := range statements {
+		switch t := stmt.(type) {
+		case *ast.CallStatement:
+			*calls = append(*calls, t)
+		case *ast.BlockStatement:
+			walkCallStatements(t.Statements, calls)
+		case *ast.IfStatement:
+			walkIfCallStatements(t, calls)
+		case *ast.SwitchStatement:
+			for _, c := range t.Cases {
+				walkCallStatements(c.Statements, calls)
+			}
+		}
+	}
+}
+
+func walkIfCallStatements(stmt *ast.IfStatement, calls *[]*ast.CallStatement) {
+	if stmt.Consequence != nil {
+		walkCallStatements(stmt.Consequence.Statements, calls)
+	}
+	for _, another := range stmt.Another {
+		walkIfCallStatements(another, calls)
+	}
+	if stmt.Alternative != nil && stmt.Alternative.Consequence != nil {
+		walkCallStatements(stmt.Alternative.Consequence.Statements, calls)
+	}
 }
 
 func CheckFastlyResourceLimit(ctx *context.Context) error {

--- a/interpreter/limitations/limitations.go
+++ b/interpreter/limitations/limitations.go
@@ -54,6 +54,12 @@ const (
 	// times eventually overflows it and Fastly returns "503 Header overflow".
 	MaxRequestWorkspaceSize = 256 * KB
 
+	// BaseRequestWorkspaceOverhead approximates what Fastly has already consumed
+	// before any user VCL runs (internal structures and injected headers). A
+	// production service shows ~8.5KB, varying by POP and connection, so we charge
+	// a conservative 10KB on top of the inbound headers we can see.
+	BaseRequestWorkspaceOverhead = 10 * KB
+
 	// Increasable limitations by contacting Fastly support
 	// These are defaults, you can override by configuration
 	MaxACLCounts     = 1000

--- a/interpreter/limitations/limitations_test.go
+++ b/interpreter/limitations/limitations_test.go
@@ -1,0 +1,94 @@
+package limitations
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ysugimoto/falco/ast"
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/lexer"
+	"github.com/ysugimoto/falco/parser"
+)
+
+// callTreeContext parses VCL and registers its subroutines the way the
+// interpreter does, so the call-tree limit can be exercised in isolation.
+func callTreeContext(t *testing.T, vcl string) *context.Context {
+	t.Helper()
+	v, err := parser.New(lexer.NewFromString(vcl)).ParseVCL()
+	if err != nil {
+		t.Fatalf("parse error: %s", err)
+	}
+	ctx := context.New()
+	for _, s := range v.Statements {
+		sub, ok := s.(*ast.SubroutineDeclaration)
+		if !ok {
+			continue
+		}
+		if sub.ReturnType != nil {
+			ctx.SubroutineFunctions[sub.Name.Value] = sub
+		} else {
+			ctx.Subroutines[sub.Name.Value] = sub
+		}
+	}
+	return ctx
+}
+
+func TestCheckFastlyCallTreeLimit(t *testing.T) {
+	t.Run("flat tree is well under the limit", func(t *testing.T) {
+		vcl := "sub leaf {}\nsub vcl_recv {\n" +
+			strings.Repeat("  call leaf;\n", 100) + "}"
+		if err := CheckFastlyCallTreeLimit(callTreeContext(t, vcl)); err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+	})
+
+	t.Run("nested tree under the limit passes", func(t *testing.T) {
+		// mid expands to 100, top to 100 * (1 + 100) = 10100.
+		vcl := "sub leaf {}\n" +
+			"sub mid {\n" + strings.Repeat("  call leaf;\n", 100) + "}\n" +
+			"sub top {\n" + strings.Repeat("  call mid;\n", 100) + "}"
+		if err := CheckFastlyCallTreeLimit(callTreeContext(t, vcl)); err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+	})
+
+	t.Run("nested tree over the limit is rejected", func(t *testing.T) {
+		// mid expands to 200, top to 200 * (1 + 200) = 40200, over 25000.
+		vcl := "sub leaf {}\n" +
+			"sub mid {\n" + strings.Repeat("  call leaf;\n", 200) + "}\n" +
+			"sub top {\n" + strings.Repeat("  call mid;\n", 200) + "}"
+		err := CheckFastlyCallTreeLimit(callTreeContext(t, vcl))
+		if err == nil {
+			t.Fatal("expected error but got nil")
+		}
+		if !strings.Contains(err.Error(), "Too many sub calls") {
+			t.Errorf("unexpected message: %s", err)
+		}
+		if !strings.Contains(err.Error(), "top") {
+			t.Errorf("error should name the offending subroutine: %s", err)
+		}
+	})
+
+	t.Run("calls inside nested blocks are counted", func(t *testing.T) {
+		// Each call sits inside an if/else or switch block to make sure the
+		// walker descends into them.
+		body := strings.Repeat(
+			"  if (req.http.X) { call leaf; } else { call leaf; }\n", 200,
+		)
+		vcl := "sub leaf {}\n" +
+			"sub mid {\n" + body + "}\n" +
+			"sub top {\n" + strings.Repeat("  call mid;\n", 200) + "}"
+		if err := CheckFastlyCallTreeLimit(callTreeContext(t, vcl)); err == nil {
+			t.Error("expected error but got nil")
+		}
+	})
+
+	t.Run("recursive VCL terminates without error", func(t *testing.T) {
+		// Recursion is rejected by the runtime call-stack guard, not here; the
+		// static walk must simply not loop forever.
+		vcl := "sub a { call b; }\nsub b { call a; }"
+		if err := CheckFastlyCallTreeLimit(callTreeContext(t, vcl)); err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+	})
+}

--- a/interpreter/limits_test.go
+++ b/interpreter/limits_test.go
@@ -1,10 +1,12 @@
 package interpreter
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/limitations"
 	"github.com/ysugimoto/falco/interpreter/value"
 )
 
@@ -51,6 +53,54 @@ func TestRequestWorkspaceLimit(t *testing.T) {
 		}`
 		assertInterpreter(t, vcl, context.RecvScope, nil, true)
 	})
+}
+
+func TestRequestWorkspaceAccounting(t *testing.T) {
+	// The probe reads workspace.bytes_free right after the write under test, so it
+	// equals the workspace minus the inbound baseline and the write cost. The
+	// baseline is the fixed overhead plus the only inbound header the test request
+	// carries, Host (localhost).
+	baseline := int64(limitations.BaseRequestWorkspaceOverhead) +
+		int64(roundUpToPointer(len("Host")+len("localhost")+3))
+	free := func(writeCost int64) int64 {
+		return int64(limitations.MaxRequestWorkspaceSize) - baseline - writeCost
+	}
+
+	tests := []struct {
+		name  string
+		write string
+		free  int64
+	}{
+		{
+			// roundUp8(5 + 5 + 3) = roundUp8(13) = 16
+			name:  "bare name plus value plus three, rounded to 8",
+			write: `set req.http.X-Foo = "hello";`,
+			free:  free(16),
+		},
+		{
+			// The req.http. prefix is not counted: roundUp8(1 + 1 + 3) = 8,
+			// not roundUp8(len("req.http.a") + 1) = 16.
+			name:  "short header does not pay for the req.http. prefix",
+			write: `set req.http.a = "b";`,
+			free:  free(8),
+		},
+		{
+			// add charges the appended line the same way: roundUp8(3 + 5 + 3) = 16
+			name:  "add charges the appended value",
+			write: `add req.http.Via = "proxy";`,
+			free:  free(16),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vcl := "sub vcl_recv {\n  " + tt.write + "\n" +
+				"  set req.http.Probe = workspace.bytes_free;\n}"
+			assertInterpreter(t, vcl, context.RecvScope, map[string]value.Value{
+				"req.http.Probe": &value.String{Value: strconv.FormatInt(tt.free, 10)},
+			}, false)
+		})
+	}
 }
 
 func TestSubroutineCallTreeLimit(t *testing.T) {

--- a/interpreter/limits_test.go
+++ b/interpreter/limits_test.go
@@ -1,0 +1,71 @@
+package interpreter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+func TestRequestWorkspaceLimit(t *testing.T) {
+	t.Run("ordinary header writes stay within the workspace", func(t *testing.T) {
+		vcl := `sub vcl_recv {
+			set req.http.A = "hello";
+			set req.http.B = "world";
+		}`
+		assertInterpreter(t, vcl, context.RecvScope, map[string]value.Value{
+			"req.http.A": &value.String{Value: "hello"},
+		}, false)
+	})
+
+	t.Run("rewriting a header until the workspace overflows fails", func(t *testing.T) {
+		// Each set leaks its assembled value into the workspace, so repeatedly
+		// rewriting the same header exhausts the 256KB workspace even though the
+		// header itself stays small.
+		chunk := strings.Repeat("a", 4000)
+		body := strings.Repeat(`set req.http.A = "`+chunk+`";`+"\n", 80)
+		vcl := "sub vcl_recv {\n" + body + "}"
+		assertInterpreter(t, vcl, context.RecvScope, nil, true)
+	})
+
+	t.Run("growing a header leaks every intermediate copy", func(t *testing.T) {
+		// This mirrors how the signer builds an accumulator: each append
+		// reassembles the whole value, and every leaked intermediate copy
+		// counts, so a header that only ever reaches a few KB still overflows.
+		chunk := strings.Repeat("a", 1000)
+		body := strings.Repeat(`set req.http.A = req.http.A "`+chunk+`";`+"\n", 40)
+		vcl := "sub vcl_recv {\n" + body + "}"
+		assertInterpreter(t, vcl, context.RecvScope, nil, true)
+	})
+
+	t.Run("workspace is not reclaimed across restarts", func(t *testing.T) {
+		// A single pass fits, but the header is rebuilt on the restart and the
+		// leaked copies accumulate, so the second pass overflows.
+		chunk := strings.Repeat("a", 170000)
+		vcl := `sub vcl_recv {
+			set req.http.Big = "` + chunk + `";
+			if (req.restarts == 0) {
+				restart;
+			}
+		}`
+		assertInterpreter(t, vcl, context.RecvScope, nil, true)
+	})
+}
+
+func TestSubroutineCallTreeLimit(t *testing.T) {
+	t.Run("a modest call graph is accepted", func(t *testing.T) {
+		vcl := "sub leaf {}\n" +
+			"sub helper {\n" + strings.Repeat("  call leaf;\n", 50) + "}\n" +
+			"sub vcl_recv {\n  call helper;\n}"
+		assertInterpreter(t, vcl, context.RecvScope, nil, false)
+	})
+
+	t.Run("an explosive call graph is rejected at init", func(t *testing.T) {
+		// helper expands to 200, recv to 200 * (1 + 200) = 40200, over 25000.
+		vcl := "sub leaf {}\n" +
+			"sub helper {\n" + strings.Repeat("  call leaf;\n", 200) + "}\n" +
+			"sub vcl_recv {\n" + strings.Repeat("  call helper;\n", 200) + "}"
+		assertInterpreter(t, vcl, context.RecvScope, nil, true)
+	})
+}

--- a/interpreter/statement.go
+++ b/interpreter/statement.go
@@ -285,13 +285,32 @@ func (i *Interpreter) ProcessSetStatement(stmt *ast.SetStatement) error {
 	return nil
 }
 
-// accountRequestWorkspace charges a request-header write of the given assembled
-// value against the per-request workspace. Fastly assembles a fresh copy of the
-// header value in the workspace and never reclaims the previous one, even across
-// restarts, so rewriting a header in a loop eventually overflows it and the
-// request fails with "503 Header overflow".
+// chargeInboundRequestWorkspace seeds RequestWorkspaceBytes with what Fastly has
+// already spent when vcl_recv begins: a fixed overhead plus every inbound header
+// line, each charged the same way a VCL write is.
+func (i *Interpreter) chargeInboundRequestWorkspace() {
+	i.ctx.RequestWorkspaceBytes += limitations.BaseRequestWorkspaceOverhead
+	if i.ctx.Request == nil {
+		return
+	}
+	for name, values := range i.ctx.Request.Header {
+		for _, v := range values {
+			i.ctx.RequestWorkspaceBytes += roundUpToPointer(len(name) + len(v) + 3)
+		}
+	}
+}
+
+// accountRequestWorkspace charges a request-header write against the per-request
+// workspace. Fastly assembles a fresh copy of the value and never reclaims the
+// previous one, even across restarts, so rewriting a header in a loop eventually
+// overflows it and the request fails with "503 Header overflow".
+//
+// Measured on a production Fastly service, a write consumes
+// roundUp8(len(name) + len(value) + 3): the bare header name, the value, and
+// three bytes of fixed overhead, rounded up to an 8 byte boundary.
 func (i *Interpreter) accountRequestWorkspace(ident *ast.Ident, val value.Value) error {
-	i.ctx.RequestWorkspaceBytes += len(ident.Value) + len([]byte(val.String()))
+	name := requestHeaderName(ident)
+	i.ctx.RequestWorkspaceBytes += roundUpToPointer(len(name) + len([]byte(val.String())) + 3)
 	if i.ctx.RequestWorkspaceBytes > limitations.MaxRequestWorkspaceSize {
 		return exception.Runtime(
 			&ident.GetMeta().Token,

--- a/interpreter/statement.go
+++ b/interpreter/statement.go
@@ -270,6 +270,35 @@ func (i *Interpreter) ProcessSetStatement(stmt *ast.SetStatement) error {
 		return errors.WithStack(err)
 	}
 
+	// A `set` assembles the full new header value, which for a compound operator
+	// such as `+=` differs from the right-hand side, so charge the stored value.
+	if isRequestHeaderIdent(stmt.Ident) {
+		assembled, err := i.vars.Get(i.ctx.Scope, stmt.Ident.Value)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if err := i.accountRequestWorkspace(stmt.Ident, assembled); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	return nil
+}
+
+// accountRequestWorkspace charges a request-header write of the given assembled
+// value against the per-request workspace. Fastly assembles a fresh copy of the
+// header value in the workspace and never reclaims the previous one, even across
+// restarts, so rewriting a header in a loop eventually overflows it and the
+// request fails with "503 Header overflow".
+func (i *Interpreter) accountRequestWorkspace(ident *ast.Ident, val value.Value) error {
+	i.ctx.RequestWorkspaceBytes += len(ident.Value) + len([]byte(val.String()))
+	if i.ctx.RequestWorkspaceBytes > limitations.MaxRequestWorkspaceSize {
+		return exception.Runtime(
+			&ident.GetMeta().Token,
+			"Header overflow: request workspace limitation of %d bytes exceeded",
+			limitations.MaxRequestWorkspaceSize,
+		)
+	}
 	return nil
 }
 
@@ -318,6 +347,12 @@ func (i *Interpreter) ProcessAddStatement(stmt *ast.AddStatement) error {
 	}
 	if err := i.vars.Add(i.ctx.Scope, stmt.Ident.Value, right); err != nil {
 		return exception.Runtime(&stmt.GetMeta().Token, "%s", err.Error())
+	}
+	// `add` appends a fresh header line, so charge the value being added.
+	if isRequestHeaderIdent(stmt.Ident) {
+		if err := i.accountRequestWorkspace(stmt.Ident, right); err != nil {
+			return errors.WithStack(err)
+		}
 	}
 	return nil
 }

--- a/interpreter/variable/all.go
+++ b/interpreter/variable/all.go
@@ -422,10 +422,7 @@ func (v *AllScopeVariables) Get(s context.Scope, name string) (value.Value, erro
 		if v := lookupOverride(v.ctx, name); v != nil {
 			return v, nil
 		}
-		free := int64(limitations.MaxRequestWorkspaceSize - v.ctx.RequestWorkspaceBytes)
-		if free < 0 {
-			free = 0
-		}
+		free := max(int64(limitations.MaxRequestWorkspaceSize-v.ctx.RequestWorkspaceBytes), 0)
 		return &value.Integer{Value: free}, nil
 	case WORKSPACE_BYTES_TOTAL:
 		if v := lookupOverride(v.ctx, name); v != nil {

--- a/interpreter/variable/all.go
+++ b/interpreter/variable/all.go
@@ -417,17 +417,21 @@ func (v *AllScopeVariables) Get(s context.Scope, name string) (value.Value, erro
 		}
 		return &value.String{Value: "FALCO"}, nil // Intend to set string not exists in Fastly POP certainly
 
-	// workspace related values respects Fastly fiddle one
+	// 256KB workspace; bytes_free is what the accounting so far leaves unused.
 	case WORKSPACE_BYTES_FREE:
 		if v := lookupOverride(v.ctx, name); v != nil {
 			return v, nil
 		}
-		return &value.Integer{Value: 125008}, nil
+		free := int64(limitations.MaxRequestWorkspaceSize - v.ctx.RequestWorkspaceBytes)
+		if free < 0 {
+			free = 0
+		}
+		return &value.Integer{Value: free}, nil
 	case WORKSPACE_BYTES_TOTAL:
 		if v := lookupOverride(v.ctx, name); v != nil {
 			return v, nil
 		}
-		return &value.Integer{Value: 139392}, nil
+		return &value.Integer{Value: int64(limitations.MaxRequestWorkspaceSize)}, nil
 
 	// backend.src_ip always indicates this server, means localhost
 	case BERESP_BACKEND_SRC_IP:


### PR DESCRIPTION
Fastly rejects VCL whose fully inlined call graph exceeds 25000 calls, and returns a 503 once the 256 KB request workspace is exhausted.

Do the same thing to avoid scripts that work in Falco, but not on Fastly.