### PR TITLE
fix: use http.NoBody for synthetic console/tester requests

### DIFF
--- a/cmd/falco/runner_test.go
+++ b/cmd/falco/runner_test.go
@@ -443,6 +443,12 @@ func TestTester(t *testing.T) {
 			filter: "*default.test.vcl",
 			passes: 2,
 		},
+		{
+			name:   "request byte-count reads with no body",
+			main:   "../../examples/testing/request_byte_reads/request_byte_reads.vcl",
+			filter: "*request_byte_reads.test.vcl",
+			passes: 2,
+		},
 	}
 
 	for _, tt := range tests {

--- a/examples/testing/request_byte_reads/request_byte_reads.test.vcl
+++ b/examples/testing/request_byte_reads/request_byte_reads.test.vcl
@@ -1,0 +1,18 @@
+// req.body_bytes_read reads the request body in the deliver and log scopes.
+// net/http guarantees a server request's Body is always non-nil
+// (https://pkg.go.dev/net/http#Request.Body), so the tester synthesizes its mock
+// request with an http.NoBody body to match. The read then returns a byte count
+// instead of dereferencing a nil body; the mock GET request has no body, so the
+// count is 0.
+
+// @scope: deliver
+sub test_deliver_request_byte_reads {
+  testing.call_subroutine("vcl_deliver");
+  assert.equal(req.body_bytes_read, 0);
+}
+
+// @scope: log
+sub test_log_request_byte_reads {
+  testing.call_subroutine("vcl_log");
+  assert.equal(req.body_bytes_read, 0);
+}

--- a/examples/testing/request_byte_reads/request_byte_reads.vcl
+++ b/examples/testing/request_byte_reads/request_byte_reads.vcl
@@ -1,0 +1,7 @@
+sub vcl_deliver {
+  #FASTLY deliver
+}
+
+sub vcl_log {
+  #FASTLY log
+}

--- a/interpreter/console.go
+++ b/interpreter/console.go
@@ -19,13 +19,13 @@ func (i *Interpreter) ConsoleProcessInit() error {
 	i.ctx = context.New(i.options...)
 
 	// On console process, all request/response variables should be set initially
-	i.ctx.Request, err = http.NewRequest(ghttp.MethodGet, "http://localhost:3124", nil)
+	i.ctx.Request, err = http.NewRequest(ghttp.MethodGet, "http://localhost:3124", ghttp.NoBody)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 	// Set default RemoteAddr so that client.ip returns a valid value
 	i.ctx.Request.RemoteAddr = "192.0.2.1:11111"
-	i.ctx.BackendRequest, err = http.NewRequest(ghttp.MethodGet, "http://localhost:3124", nil)
+	i.ctx.BackendRequest, err = http.NewRequest(ghttp.MethodGet, "http://localhost:3124", ghttp.NoBody)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/interpreter/console_test.go
+++ b/interpreter/console_test.go
@@ -1,0 +1,43 @@
+package interpreter
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/ysugimoto/falco/interpreter/context"
+	"github.com/ysugimoto/falco/interpreter/value"
+)
+
+// ConsoleProcessInit synthesizes the request that drives console evaluation.
+// req.body_bytes_read reads req.Body in the deliver and log scopes. net/http
+// guarantees a server request's Body is always non-nil
+// (https://pkg.go.dev/net/http#Request.Body), so the synthetic request must
+// carry a non-nil body (http.NoBody) for the read to return 0 instead of
+// dereferencing nil and panicking.
+func TestConsoleRequestBodyByteReads(t *testing.T) {
+	scopes := []struct {
+		name  string
+		scope context.Scope
+	}{
+		{name: "deliver", scope: context.DeliverScope},
+		{name: "log", scope: context.LogScope},
+	}
+
+	for _, sc := range scopes {
+		t.Run("req.body_bytes_read in "+sc.name+" scope", func(t *testing.T) {
+			ip := New()
+			if err := ip.ConsoleProcessInit(); err != nil {
+				t.Fatalf("ConsoleProcessInit failed: %s", err)
+			}
+			ip.SetScope(sc.scope)
+
+			got, err := ip.vars.Get(sc.scope, "req.body_bytes_read")
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
+			if diff := cmp.Diff(value.Value(&value.Integer{Value: 0}), got); diff != "" {
+				t.Errorf("Return value unmatch, diff=%s", diff)
+			}
+		})
+	}
+}

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -145,7 +145,7 @@ func (t *Tester) run(testFile string) (*TestResult, error) {
 				// so we always initialize interpreter, inject testing functions for each subroutine
 				i := t.setupInterpreter(defs)
 
-				mockRequest, err := http.NewRequest(ghttp.MethodGet, "http://localhost", nil)
+				mockRequest, err := http.NewRequest(ghttp.MethodGet, "http://localhost", ghttp.NoBody)
 				if err != nil {
 					errChan <- errors.WithStack(err)
 					return
@@ -213,7 +213,7 @@ func (t *Tester) runDescribedTests(
 ) ([]*TestCase, error) {
 
 	var cases []*TestCase
-	mockRequest, err := http.NewRequest(ghttp.MethodGet, "http://localhost", nil)
+	mockRequest, err := http.NewRequest(ghttp.MethodGet, "http://localhost", ghttp.NoBody)
 	if err != nil {
 		return cases, errors.WithStack(err)
 	}


### PR DESCRIPTION
### Problem
Reading `req.body_bytes_read` (or `req.bytes_read`) in the `deliver`/`log` scopes panics when the request came from falco's synthetic constructors, because the getter calls `buf.ReadFrom(req.Body)` and `req.Body` is nil.

### Cause
Per the [`net/http.Request.Body` contract](https://pkg.go.dev/net/http#Request.Body), *"For server requests, the Request Body is always non-nil"* — so falco's real `ServeHTTP` path never yields nil. The nil arises only where falco builds requests with `http.NewRequest(..., nil)`: `NewRequest` leaves `Body == nil` when passed a nil body. `http.NoBody` is net/http's sentinel for an explicit empty body and yields a non-nil `Body`.

### Fix
Pass `http.NoBody` instead of `nil` at the four synthetic-request sites (`tester/tester.go`, `interpreter/console.go`) so they honor the same non-nil-Body contract as real server requests.

### Tests
- `examples/testing/request_byte_reads/` (in `TestTester`) drives the tester boundary via `call_subroutine("vcl_deliver"/"vcl_log")` reading `req.body_bytes_read`.
- `interpreter/console_test.go` `TestConsoleRequestBodyByteReads` drives the console boundary, same variable, both scopes.

Both panic without the fix.
