### PR TITLE
fix: testing.inject_variable now works for request headers

### DIFF
--- a/interpreter/variable/all.go
+++ b/interpreter/variable/all.go
@@ -839,6 +839,9 @@ func (v *AllScopeVariables) getFromRegex(name string) (value.Value, error) {
 
 	// HTTP request header matching
 	if match := requestHttpHeaderRegex.FindStringSubmatch(name); match != nil {
+		if v := lookupOverride(v.ctx, name); v != nil {
+			return v, nil
+		}
 		return getRequestHeaderValue(v.ctx.Request, match[1]), nil
 	}
 

--- a/interpreter/variable/all_test.go
+++ b/interpreter/variable/all_test.go
@@ -391,6 +391,48 @@ func TestGetClientVendor(t *testing.T) {
 	}
 }
 
+func TestGetFromRegexRequestHeaderOverride(t *testing.T) {
+	// testing.inject_variable stores values in ctx.OverrideVariables. The
+	// request header read path must consult that map so injected headers are
+	// returned in tests -- the only way to set protected headers like
+	// req.http.Fastly-FF, which `set` rejects.
+	t.Run("returns injected override for request header", func(t *testing.T) {
+		vars := &AllScopeVariables{
+			ctx: &context.Context{
+				Request: http.WrapRequest(&ghttp.Request{Header: ghttp.Header{}}),
+				OverrideVariables: map[string]value.Value{
+					"req.http.Fastly-FF": &value.String{Value: "injected"},
+				},
+			},
+		}
+		val, err := vars.getFromRegex("req.http.Fastly-FF")
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		if diff := cmp.Diff(val, &value.String{Value: "injected"}); diff != "" {
+			t.Errorf("Return value unmatch, diff: %s", diff)
+		}
+	})
+
+	t.Run("falls through to actual header when no override", func(t *testing.T) {
+		req := http.WrapRequest(&ghttp.Request{Header: ghttp.Header{}})
+		req.Header.Set("X-Custom", "real")
+		vars := &AllScopeVariables{
+			ctx: &context.Context{
+				Request:           req,
+				OverrideVariables: map[string]value.Value{},
+			},
+		}
+		val, err := vars.getFromRegex("req.http.X-Custom")
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		if diff := cmp.Diff(val, &value.String{Value: "real"}); diff != "" {
+			t.Errorf("Return value unmatch, diff: %s", diff)
+		}
+	})
+}
+
 func TestGetFromRegex(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
### Problem
`testing.inject_variable` had no effect on `req.http.*` reads — it stores into `ctx.OverrideVariables`, but the request-header read path never consulted that map. This matters most for protected headers like `Fastly-FF`: `set req.http.Fastly-FF` is rejected by `CheckProtectedHeader`, so `inject_variable` is the *only* way to give them a value in a test.

### Cause
The request-header branch of `getFromRegex` (`interpreter/variable/all.go`) read straight from `req.Header`, ignoring `ctx.OverrideVariables`. Other read paths honor overrides; this one didn't.

### Fix
Consult `lookupOverride` in that branch.

### Test
`TestGetFromRegexRequestHeaderOverride`: an injected override is returned; with no override the read falls through to the actual header.
