### PR TITLE
feat(wasm): add include resolution and structured lint diagnostics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,4 +62,4 @@ wasm:
 
 wasm_exec:
 	@mkdir -p wasm
-	cp "$$(find "$$(go env GOROOT)" -name 'wasm_exec.js' 2>/dev/null | head -1)" wasm/
+	cp -f "$$(find "$$(go env GOROOT)" -name 'wasm_exec.js' 2>/dev/null | head -1)" wasm/

--- a/cmd/wasm/api.go
+++ b/cmd/wasm/api.go
@@ -128,16 +128,47 @@ func lint(_ js.Value, args []js.Value) any {
 		opts = parseLintOptions(args[1])
 	}
 
-	// Parse VCL to AST
-	lx := lexer.NewFromString(vcl)
+	mainName := opts.MainFile
+	if mainName == "" {
+		mainName = "main.vcl"
+	}
+
+	// Parse VCL to AST. Attribute positions to the main file name so cross-file
+	// diagnostics carry a file reference.
+	lx := lexer.NewFromString(vcl, lexer.WithFile(mainName))
 	p := parser.New(lx)
 	ast, err := p.ParseVCLOrSnippet()
 	if err != nil {
+		// Surface parse-error position as structured data (mirroring the FatalError
+		// path below) so consumers don't have to scrape line/position from a string.
+		var parseErr *parser.ParseError
+		if errors.As(err, &parseErr) {
+			file := parseErr.Token.File
+			if file == "" {
+				file = mainName
+			}
+			return toJS(LintResult{
+				Errors: []LintError{{
+					Severity: "error",
+					Message:  parseErr.Message,
+					Line:     parseErr.Token.Line,
+					Position: parseErr.Token.Position,
+					File:     file,
+				}},
+			})
+		}
+		// Non-ParseError parse failures: fall back to the free-form error string.
 		return toJS(LintResult{Error: "Parse error: " + err.Error()})
 	}
 
-	// Create linter context with scope if specified
-	ctx := context.New()
+	// Create linter context with scope if specified. When includes are supplied,
+	// back the resolver with the in-memory file map so `include "..."` statements
+	// resolve cross-file, matching CLI -I semantics.
+	var ctxOpts []context.Option
+	if len(opts.Includes) > 0 {
+		ctxOpts = append(ctxOpts, context.WithResolver(newMapResolver(opts.Includes)))
+	}
+	ctx := context.New(ctxOpts...)
 	if opts.Scope != "" {
 		scope := parseScope(opts.Scope)
 		if scope > 0 {
@@ -154,19 +185,24 @@ func lint(_ js.Value, args []js.Value) any {
 	l.Lint(ast, ctx)
 
 	// Collect errors
-	var lintErrors []LintError
+	lintErrors := []LintError{}
 	if l.FatalError != nil {
 		line, pos := 1, 1
+		file := mainName
 		var parseErr *parser.ParseError
 		if errors.As(l.FatalError.Error, &parseErr) {
 			line = parseErr.Token.Line
 			pos = parseErr.Token.Position
+			if parseErr.Token.File != "" {
+				file = parseErr.Token.File
+			}
 		}
 		lintErrors = append(lintErrors, LintError{
 			Severity: "error",
 			Message:  l.FatalError.Error.Error(),
 			Line:     line,
 			Position: pos,
+			File:     file,
 		})
 	}
 
@@ -177,10 +213,11 @@ func lint(_ js.Value, args []js.Value) any {
 			Line:     le.Token.Line,
 			Position: le.Token.Position,
 			Rule:     string(le.Rule),
+			File:     le.Token.File,
 		})
 	}
 
-	return toJS(LintResult{Errors: lintErrors})
+	return toJS(LintResult{Errors: lintErrors, AST: ast})
 }
 
 // toJS converts a Go struct to a JS object via JSON.
@@ -358,5 +395,27 @@ func parseLintOptions(opts js.Value) LintOptions {
 	if v := opts.Get("scope"); !v.IsUndefined() {
 		o.Scope = v.String()
 	}
+	if v := opts.Get("mainFile"); !v.IsUndefined() && !v.IsNull() {
+		o.MainFile = v.String()
+	}
+	if v := opts.Get("includes"); !v.IsUndefined() && !v.IsNull() {
+		o.Includes = parseStringMap(v)
+	}
 	return o
+}
+
+// parseStringMap converts a JS object of string values to a Go map.
+// Non-string values are skipped.
+func parseStringMap(v js.Value) map[string]string {
+	keys := js.Global().Get("Object").Call("keys", v)
+	n := keys.Length()
+	m := make(map[string]string, n)
+	for i := 0; i < n; i++ {
+		key := keys.Index(i).String()
+		val := v.Get(key)
+		if val.Type() == js.TypeString {
+			m[key] = val.String()
+		}
+	}
+	return m
 }

--- a/cmd/wasm/resolver.go
+++ b/cmd/wasm/resolver.go
@@ -1,0 +1,62 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/ysugimoto/falco/v2/ast"
+	"github.com/ysugimoto/falco/v2/resolver"
+)
+
+// mapResolver is an in-memory resolver backed by a caller-supplied file map.
+//
+// It mirrors resolver.TerraformResolver: include modules are matched by their
+// module path (as written in the include statement), normalized with a ".vcl"
+// suffix. Wasm has no filesystem access, so JS callers pre-read files from disk
+// and pass them in via the lint `includes` option.
+//
+// The wasm lint path parses the main source itself and passes the AST straight
+// to the linter, so only Resolve() is exercised; MainVCL() is never called and
+// is therefore unsupported.
+type mapResolver struct {
+	modules map[string]*resolver.VCL
+}
+
+// newMapResolver builds a resolver from an include map. Include keys are
+// normalized with a ".vcl" suffix so callers may pass either "shared/util" or
+// "shared/util.vcl".
+func newMapResolver(includes map[string]string) *mapResolver {
+	modules := make(map[string]*resolver.VCL, len(includes))
+	for name, data := range includes {
+		key := normalizeVCLName(name)
+		modules[key] = &resolver.VCL{Name: key, Data: data}
+	}
+	return &mapResolver{modules: modules}
+}
+
+func normalizeVCLName(name string) string {
+	if !strings.HasSuffix(name, ".vcl") {
+		return name + ".vcl"
+	}
+	return name
+}
+
+// MainVCL is unsupported: the wasm lint path supplies the main AST directly.
+func (m *mapResolver) MainVCL() (*resolver.VCL, error) {
+	return nil, errors.New("mapResolver does not provide MainVCL")
+}
+
+func (m *mapResolver) Resolve(stmt *ast.IncludeStatement) (*resolver.VCL, error) {
+	module := normalizeVCLName(stmt.Module.Value)
+	if vcl, ok := m.modules[module]; ok {
+		return vcl, nil
+	}
+	// Message intentionally matches resolver.TerraformResolver verbatim (and the
+	// wasm test asserts on it), so we keep the capitalized form despite ST1005.
+	return nil, errors.Errorf("Failed to resolve include module: %s", module)
+}
+
+func (m *mapResolver) Name() string           { return "" }
+func (m *mapResolver) IncludePaths() []string { return []string{} }

--- a/cmd/wasm/types.go
+++ b/cmd/wasm/types.go
@@ -30,17 +30,26 @@ type LintError struct {
 	Line     int    `json:"line"`
 	Position int    `json:"position"`
 	Rule     string `json:"rule,omitempty"`
+	File     string `json:"file,omitempty"`
 }
 
 // LintResult is the response from lint().
 type LintResult struct {
 	Errors []LintError `json:"errors"`
+	AST    any         `json:"ast,omitempty"` // The parsed main-file VCL AST (same shape as parse())
 	Error  string      `json:"error,omitempty"`
 }
 
 // LintOptions configures linting behavior.
 type LintOptions struct {
 	Scope string `json:"scope,omitempty"` // recv, hash, hit, miss, pass, fetch, error, deliver, log, pipe
+	// Includes maps include module paths to their VCL source. When supplied,
+	// `include "..."` statements resolve against this in-memory map instead of
+	// a filesystem, matching CLI -I semantics (.vcl suffix handling).
+	Includes map[string]string `json:"includes,omitempty"`
+	// MainFile is the logical filename for the main source, used for position
+	// attribution in diagnostics. Defaults to "main.vcl".
+	MainFile string `json:"mainFile,omitempty"`
 }
 
 // ParseResult is the response from parse().

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -3,7 +3,10 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "build:wasm": "make -C .. wasm wasm_exec",
+    "pretest": "npm run build:wasm",
     "test": "vitest run",
+    "pretest:watch": "npm run build:wasm",
     "test:watch": "vitest"
   },
   "devDependencies": {

--- a/wasm/tests/api.test.js
+++ b/wasm/tests/api.test.js
@@ -107,12 +107,14 @@ describe('FalcoVCL.lint', () => {
         line: 1,
         position: 1,
         rule: 'subroutine/boilerplate-macro',
+        file: 'main.vcl',
       },
       {
         severity: 'error',
         message: 'undefined variable "undefined_var"',
         line: 1,
         position: 33,
+        file: 'main.vcl',
       },
       {
         severity: 'error',
@@ -120,6 +122,7 @@ describe('FalcoVCL.lint', () => {
         line: 1,
         position: 31,
         rule: 'operator/assignment',
+        file: 'main.vcl',
       },
     ]);
   });
@@ -129,8 +132,148 @@ describe('FalcoVCL.lint', () => {
     expect(result.error).toBeUndefined();
   });
 
+  it('returns a parse error as a structured entry in errors (not the error string)', () => {
+    const result = FalcoVCL.lint('sub { invalid }');
+    // Position must come from structured data, not the free-form error string.
+    expect(result.error).toBeUndefined();
+    expect(result.errors).toEqual([
+      {
+        severity: 'error',
+        message: 'Unexpected token "{", expects IDENT',
+        line: 1,
+        position: 5,
+        file: 'main.vcl',
+      },
+    ]);
+    expect(typeof result.errors[0].line).toBe('number');
+    expect(typeof result.errors[0].position).toBe('number');
+  });
+
+  it('attributes a parse error to the supplied mainFile', () => {
+    const result = FalcoVCL.lint('sub { invalid }', { mainFile: 'entry.vcl' });
+    expect(result.error).toBeUndefined();
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].file).toBe('entry.vcl');
+    expect(result.errors[0].position).toBe(5);
+  });
+
   it('returns error when called without arguments', () => {
     const result = FalcoVCL.lint();
     expect(result.error).toBe('lint requires a VCL string argument');
+  });
+});
+
+describe('FalcoVCL.lint include resolution', () => {
+  const mainVcl = [
+    'include "shared/custom";',
+    '',
+    'sub vcl_recv {',
+    '  #FASTLY RECV',
+    '  call custom_logic;',
+    '}',
+  ].join('\n');
+
+  const customVcl = [
+    'sub custom_logic {',
+    '  set req.http.X-Custom = "1";',
+    '}',
+  ].join('\n');
+
+  it('reports an undefined subroutine when the include is not supplied', () => {
+    // Baseline: without the include map, the cross-file symbol is unknown.
+    const result = FalcoVCL.lint(mainVcl);
+    expect(result.error).toBeUndefined();
+    const unresolved = result.errors.filter(e => /custom_logic/.test(e.message));
+    expect(unresolved.length).toBeGreaterThan(0);
+  });
+
+  it('resolves a cross-file subroutine from the includes map', () => {
+    const result = FalcoVCL.lint(mainVcl, {
+      includes: { 'shared/custom': customVcl },
+      mainFile: 'main.vcl',
+    });
+    expect(result.error).toBeUndefined();
+    // The included subroutine is now known, so no "not defined" error for it.
+    const unresolved = result.errors.filter(e => /custom_logic/.test(e.message));
+    expect(unresolved).toEqual([]);
+  });
+
+  it('accepts include keys with an explicit .vcl suffix', () => {
+    const result = FalcoVCL.lint(mainVcl, {
+      includes: { 'shared/custom.vcl': customVcl },
+    });
+    expect(result.error).toBeUndefined();
+    const unresolved = result.errors.filter(e => /custom_logic/.test(e.message));
+    expect(unresolved).toEqual([]);
+  });
+
+  it('reports an error when an included module is missing from the map', () => {
+    const result = FalcoVCL.lint('include "missing";\n', { includes: { 'other': customVcl } });
+    expect(result.error).toBeUndefined();
+    const resolveErrors = result.errors.filter(e =>
+      /Failed to resolve include module/.test(e.message)
+    );
+    expect(resolveErrors.length).toBeGreaterThan(0);
+  });
+
+  it('resolves nested includes from the map', () => {
+    const main = 'include "a";\n\nsub vcl_recv {\n  #FASTLY RECV\n  call from_a;\n}\n';
+    const a = 'include "b";\n\nsub from_a {\n  call from_b;\n}\n';
+    const b = 'sub from_b {\n  set req.http.X-B = "1";\n}\n';
+    const result = FalcoVCL.lint(main, { includes: { a, b } });
+    expect(result.error).toBeUndefined();
+    const unresolved = result.errors.filter(e =>
+      /(from_a|from_b)/.test(e.message)
+    );
+    expect(unresolved).toEqual([]);
+  });
+
+  it('exposes the parsed AST in the lint result', () => {
+    const result = FalcoVCL.lint('sub vcl_recv { return(pass); }');
+    expect(result.error).toBeUndefined();
+    expect(result.ast).toBeDefined();
+    expect(result.ast).not.toBeNull();
+  });
+
+  it('attributes a main-file error to the default main file name', () => {
+    const main = 'sub vcl_recv {\n  #FASTLY RECV\n  set req.http.X-Main = undefined_main;\n}\n';
+    const result = FalcoVCL.lint(main);
+    expect(result.error).toBeUndefined();
+    const errs = result.errors.filter(e => /undefined_main/.test(e.message));
+    expect(errs.length).toBeGreaterThan(0);
+    expect(errs.every(e => e.file === 'main.vcl')).toBe(true);
+  });
+
+  it('attributes a main-file error to the supplied mainFile option', () => {
+    const main = 'sub vcl_recv {\n  #FASTLY RECV\n  set req.http.X-Main = undefined_main;\n}\n';
+    const result = FalcoVCL.lint(main, { mainFile: 'entry.vcl' });
+    expect(result.error).toBeUndefined();
+    const errs = result.errors.filter(e => /undefined_main/.test(e.message));
+    expect(errs.length).toBeGreaterThan(0);
+    expect(errs.every(e => e.file === 'entry.vcl')).toBe(true);
+  });
+
+  it('attributes an included-file error to that include module key', () => {
+    const main = [
+      'include "shared/custom";',
+      '',
+      'sub vcl_recv {',
+      '  #FASTLY RECV',
+      '  call custom_logic;',
+      '}',
+    ].join('\n');
+    const custom = [
+      'sub custom_logic {',
+      '  set req.http.X-Custom = undefined_in_include;',
+      '}',
+    ].join('\n');
+    const result = FalcoVCL.lint(main, {
+      includes: { 'shared/custom': custom },
+      mainFile: 'main.vcl',
+    });
+    expect(result.error).toBeUndefined();
+    const errs = result.errors.filter(e => /undefined_in_include/.test(e.message));
+    expect(errs.length).toBeGreaterThan(0);
+    expect(errs.every(e => e.file === 'shared/custom.vcl')).toBe(true);
   });
 });

--- a/wasm/vitest.config.js
+++ b/wasm/vitest.config.js
@@ -2,7 +2,13 @@ import { defineConfig } from 'vitest/config';
 import { playwright } from '@vitest/browser-playwright';
 
 export default defineConfig({
+  optimizeDeps: {
+    // Node-only packages pulled in transitively by the playwright provider.
+    // They must not be pre-bundled for the browser test environment.
+    exclude: ['playwright', 'playwright-core', 'fsevents', 'chromium-bidi'],
+  },
   test: {
+    include: ['tests/**/*.test.js'],
     setupFiles: ['./tests/setup.js'],
     testTimeout: 10000,
     browser: {


### PR DESCRIPTION
- Add in-memory `mapResolver` so `lint` resolves `include "..."` against a caller-supplied file map (matches CLI `-I`, `.vcl` suffix)
- Add `includes`/`mainFile` lint options; bare-string lint unchanged
- Expose parsed `AST` in the `lint` result alongside `errors`
- Add `File` origin attribution to each `LintError`
- Return parse failures as structured `errors` (line/position/file) instead of a flattened `error` string
- Always initialize `errors` as an array to avoid null on success
- Wire `pretest` to rebuild `falco.wasm`; fix `cp -f` in Makefile `wasm_exec` target; scope vitest to `tests/` and exclude node-only deps from optimization

Used by https://github.com/fastly/vscode-fastly-vcl/pull/102