### PR TITLE
feat: add WASI component build target

### DIFF
--- a/.github/actions/setup-wasm-toolchain/action.yml
+++ b/.github/actions/setup-wasm-toolchain/action.yml
@@ -1,0 +1,46 @@
+name: Setup wasm toolchain
+description: >-
+  Install pinned wasm-tools and wasmtime (Linux x86_64) for building and testing
+  the WASI Component Model build (make wasm-component / make test-wasm).
+
+inputs:
+  wasm-tools-version:
+    description: wasm-tools release version (no leading v).
+    required: false
+    default: "1.252.0"
+  wasmtime-version:
+    description: >-
+      wasmtime release version (no leading v). Keep in sync with
+      WASI_ADAPTER_VERSION in the Makefile so the preview1 adapter and runtime
+      match.
+    required: false
+    default: "46.0.0"
+
+runs:
+  using: composite
+  steps:
+    - name: Install wasm-tools and wasmtime
+      shell: bash
+      env:
+        WASM_TOOLS_VERSION: ${{ inputs.wasm-tools-version }}
+        WASMTIME_VERSION: ${{ inputs.wasmtime-version }}
+      run: |
+        set -euo pipefail
+        bindir="$RUNNER_TEMP/wasm-bin"
+        mkdir -p "$bindir"
+
+        wt_dir="wasm-tools-${WASM_TOOLS_VERSION}-x86_64-linux"
+        wt_url="https://github.com/bytecodealliance/wasm-tools/releases/download/v${WASM_TOOLS_VERSION}/${wt_dir}.tar.gz"
+        echo "downloading $wt_url"
+        curl --fail -sSL "$wt_url" | tar -xz -C "$RUNNER_TEMP"
+        install -m 0755 "$RUNNER_TEMP/${wt_dir}/wasm-tools" "$bindir/wasm-tools"
+
+        rt_dir="wasmtime-v${WASMTIME_VERSION}-x86_64-linux"
+        rt_url="https://github.com/bytecodealliance/wasmtime/releases/download/v${WASMTIME_VERSION}/${rt_dir}.tar.xz"
+        echo "downloading $rt_url"
+        curl --fail -sSL "$rt_url" | tar -xJ -C "$RUNNER_TEMP"
+        install -m 0755 "$RUNNER_TEMP/${rt_dir}/wasmtime" "$bindir/wasmtime"
+
+        echo "$bindir" >> "$GITHUB_PATH"
+        "$bindir/wasm-tools" --version
+        "$bindir/wasmtime" --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,3 +33,18 @@ jobs:
         install-mode: binary
     - name: Modernize check
       run: make modernize
+
+  wasm-component:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - name: Set up Go
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+      with:
+        go-version: 1.25.5
+    - name: Set up wasm toolchain
+      uses: ./.github/actions/setup-wasm-toolchain
+    - name: Build wasm component
+      run: make wasm-component
+    - name: Test wasm component
+      run: make test-wasm

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -26,3 +26,18 @@ jobs:
         install-mode: binary
     - name: Modernize check
       run: make modernize
+
+  wasm-component:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - name: Set up Go
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+      with:
+        go-version: 1.25.5
+    - name: Set up wasm toolchain
+      uses: ./.github/actions/setup-wasm-toolchain
+    - name: Build wasm component
+      run: make wasm-component
+    - name: Test wasm component
+      run: make test-wasm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,16 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Build platform binaries
         run: VERSION=${{ steps.version.outputs.version }} make all
+      - name: Set up wasm toolchain
+        uses: ./.github/actions/setup-wasm-toolchain
+      - name: Build and test wasm component
+        run: |
+          make wasm-component
+          make test-wasm
+      - name: Package wasm component
+        run: |
+          cp wasm/falco-component.wasm dist/falco-component.wasm
+          cd dist && tar cfz falco-component-wasm.tar.gz falco-component.wasm
       - name: Create Release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
         if: startsWith(github.ref, 'refs/tags/')
@@ -48,5 +58,7 @@ jobs:
             dist/falco-linux-arm64.tar.gz
             dist/falco-darwin-amd64.tar.gz
             dist/falco-darwin-arm64.tar.gz
+            dist/falco-component.wasm
+            dist/falco-component-wasm.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,18 @@ issue-*
 
 # WebAssembly build output
 wasm/falco.wasm
+wasm/falco-component.wasm
+# wasm-component build intermediates (left behind if the pipeline fails)
+wasm/falco-core.wasm
+wasm/falco-embedded.wasm
+wasm/wasi_snapshot_preview1.reactor*.wasm
 wasm/node_modules/
 wasm/package-lock.json
 wasm/wasm_exec.js
+
+# Go workspace overlay: a local-only convenience for pointing replace directives
+# (e.g. go-pcre) at a working tree. It contains developer-machine-specific paths
+# and must not be committed -- the toolchain auto-detects a repo-root go.work and
+# would force every contributor's build through it. See docs/wasm-component.md.
+go.work
+go.work.sum

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test benchmark wasm wasm_exec
+.PHONY: test test-wasm benchmark wasm wasm-component wasm_exec
 
 BUILD_VERSION=$(or ${VERSION}, dev)
 
@@ -59,6 +59,65 @@ benchmark:
 wasm:
 	@mkdir -p wasm
 	GOOS=js GOARCH=wasm go build -ldflags="-s -w" -o wasm/falco.wasm ./cmd/wasm
+
+# wasm-component builds the WASI Component Model ("reactor") artifact:
+# wasm/falco-component.wasm, exporting lint/format/parse/tokenize at the world
+# root per wit/falco.wit. Consume it from any wasmtime embedding
+# (Rust/Python/Ruby/.NET/C) or, for JS, via `jco transpile`. See
+# docs/wasm-component.md and cmd/falco-component/hosts/ for host smoke tests.
+#
+# Requires `wasm-tools` (cargo install wasm-tools / brew install wasm-tools) and
+# the preview1 reactor adapter (auto-downloaded to $(WASI_ADAPTER) if missing).
+#
+# The adapter is cached at a version-keyed path so bumping WASI_ADAPTER_VERSION
+# invalidates a stale download, and it is verified against a pinned SHA-256
+# after a --fail download into a temp file -- so a 404/5xx error page, a
+# truncated transfer, or a tampered artifact can never poison the cache or get
+# embedded into the component. Update WASI_ADAPTER_SHA256 whenever you bump the
+# version.
+WASI_ADAPTER_VERSION ?= v46.0.0
+WASI_ADAPTER_SHA256 ?= 447b27d25221a12afd2c0732f7c150833aad9a2af42ae36ccff9270f4c7559bf
+WASI_ADAPTER ?= wasm/wasi_snapshot_preview1.reactor-$(WASI_ADAPTER_VERSION).wasm
+WASI_ADAPTER_URL := https://github.com/bytecodealliance/wasmtime/releases/download/$(WASI_ADAPTER_VERSION)/wasi_snapshot_preview1.reactor.wasm
+
+# Minimum wasm-tools major version. `wasm-tools component embed/new/validate`
+# flags and the emitted component encoding vary across releases, so the build
+# asserts at least this major to stay reproducible across machines.
+WASM_TOOLS_MIN_MAJOR ?= 1
+
+wasm-component:
+	@mkdir -p wasm
+	@command -v wasm-tools >/dev/null 2>&1 || { echo "error: wasm-tools not found (cargo install wasm-tools / brew install wasm-tools)"; exit 1; }
+	@wt_ver=$$(wasm-tools --version | awk '{print $$2}'); \
+		wt_major=$${wt_ver%%.*}; \
+		if [ -z "$$wt_major" ] || [ "$$wt_major" -lt "$(WASM_TOOLS_MIN_MAJOR)" ] 2>/dev/null; then \
+			echo "error: wasm-tools $$wt_ver is too old; need >= $(WASM_TOOLS_MIN_MAJOR).0.0 (the component embed/new flags used here vary across versions)"; exit 1; \
+		fi
+	@test -f "$(WASI_ADAPTER)" || { \
+		echo "downloading WASI adapter $(WASI_ADAPTER_VERSION)..."; \
+		curl --fail -sSL -o "$(WASI_ADAPTER).tmp" "$(WASI_ADAPTER_URL)" || { rm -f "$(WASI_ADAPTER).tmp"; echo "error: failed to download $(WASI_ADAPTER_URL)"; exit 1; }; \
+		if command -v shasum >/dev/null 2>&1; then sum=$$(shasum -a 256 "$(WASI_ADAPTER).tmp" | cut -d' ' -f1); \
+		elif command -v sha256sum >/dev/null 2>&1; then sum=$$(sha256sum "$(WASI_ADAPTER).tmp" | cut -d' ' -f1); \
+		else rm -f "$(WASI_ADAPTER).tmp"; echo "error: no shasum/sha256sum found to verify adapter"; exit 1; fi; \
+		if [ "$$sum" != "$(WASI_ADAPTER_SHA256)" ]; then rm -f "$(WASI_ADAPTER).tmp"; echo "error: adapter checksum mismatch: got $$sum want $(WASI_ADAPTER_SHA256)"; exit 1; fi; \
+		mv "$(WASI_ADAPTER).tmp" "$(WASI_ADAPTER)"; \
+	}
+	GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared -ldflags="-s -w" -o wasm/falco-core.wasm ./cmd/falco-component
+	wasm-tools component embed wit --world falco wasm/falco-core.wasm -o wasm/falco-embedded.wasm
+	wasm-tools component new wasm/falco-embedded.wasm --adapt wasi_snapshot_preview1="$(WASI_ADAPTER)" -o wasm/falco-component.wasm
+	wasm-tools validate --features component-model wasm/falco-component.wasm
+	@rm -f wasm/falco-core.wasm wasm/falco-embedded.wasm
+	@echo "built wasm/falco-component.wasm"
+
+# test-wasm runs the wasip1/wasm-tagged unit tests for cmd/falco-component
+# (including the canonical-ABI allocator/alignment and
+# return-area encoding guards in abi_test.go) under wasmtime. Those files carry
+# `//go:build wasip1 && wasm`, so the default `make test` (host `go test ./...`)
+# cannot build them; this target is the only place they execute. Requires
+# wasmtime on PATH.
+test-wasm:
+	@command -v wasmtime >/dev/null 2>&1 || { echo "error: wasmtime not found (brew install wasmtime)"; exit 1; }
+	GOOS=wasip1 GOARCH=wasm go test -exec "$$(go env GOROOT)/lib/wasm/go_wasip1_wasm_exec" ./cmd/falco-component/...
 
 wasm_exec:
 	@mkdir -p wasm

--- a/cmd/falco-component/abi.go
+++ b/cmd/falco-component/abi.go
@@ -1,0 +1,202 @@
+//go:build wasip1 && wasm
+
+package main
+
+// Hand-written Component Model canonical-ABI glue for the reactor build.
+// wit-bindgen-go's generated wrappers don't work under standard Go's
+// //go:wasmexport, so strings and result<string, string> are marshaled by hand.
+// See docs/wasm-component.md for the design.
+
+import (
+	"encoding/binary"
+	"time"
+	"unsafe"
+)
+
+// arenaSize bounds one call's combined string arguments. cabi_realloc serves
+// allocations from this static arena (not the Go heap) because the host calls
+// it re-entrantly on g0 during _initialize, where a heap allocation would trap.
+// Oversized input yields a null allocation, which traps the reactor.
+const arenaSize = 16 << 20
+
+var (
+	arena    [arenaSize]byte
+	arenaOff uint32
+
+	// arenaFloor is the bump offset resetArena rewinds to between calls,
+	// preserving allocations below it. arenaFloorLatched tracks whether it's set.
+	arenaFloor        uint32
+	arenaFloorLatched bool
+)
+
+func arenaBase() uintptr { return uintptr(unsafe.Pointer(&arena[0])) }
+
+// init latches the reset floor during _initialize, after forcing the preview1
+// adapter to allocate its persistent State (via a clock import) so the floor
+// sits above it. Resets then preserve State without pinning any call's input.
+func init() {
+	_ = time.Now() // force the adapter to allocate its persistent State now
+	arenaFloor, arenaOff, arenaFloorLatched = resolveReset(false, 0, arenaOff)
+}
+
+func arenaAlloc(size, align uint32) uint32 {
+	ptr, newOff, ok := alignAlloc(arenaBase(), arenaOff, size, align)
+	if !ok {
+		return 0
+	}
+	arenaOff = newOff
+	return ptr
+}
+
+// alignAlloc computes one bump allocation, aligning the absolute linear-memory
+// address (not just the offset) to satisfy the canonical-ABI alignment
+// contract. Pure arithmetic so it is unit-testable (see abi_test.go).
+func alignAlloc(base uintptr, off, size, align uint32) (ptr uint32, newOff uint32, ok bool) {
+	if align == 0 {
+		align = 1
+	}
+	mask := uintptr(align - 1)
+	addr := (base + uintptr(off) + mask) &^ mask
+	used := uint64(addr - base)
+	if used+uint64(size) > arenaSize {
+		return 0, off, false
+	}
+	return uint32(addr), uint32(used) + size, true
+}
+
+//go:wasmexport cabi_realloc
+func cabiRealloc(ptr, oldSize, align, newSize uint32) uint32 {
+	if newSize == 0 {
+		// Canonical ABI requires a non-null, aligned pointer even for a zero-size
+		// allocation. Prefer a real in-arena address; fall back when exhausted (the
+		// bytes are never dereferenced for a zero-size request).
+		if p := arenaAlloc(0, align); p != 0 {
+			return p
+		}
+		if align == 0 {
+			return 1
+		}
+		return align
+	}
+	// Grow/shrink reallocates into a fresh block; there is no in-place extend.
+	np := arenaAlloc(newSize, align)
+	if ptr != 0 && oldSize != 0 && np != 0 {
+		base := arenaBase()
+		p := uintptr(ptr)
+		n := oldSize
+		if newSize < n {
+			n = newSize
+		}
+		// Validate provenance before copying: a foreign/out-of-arena ptr would
+		// panic the copy, and a panic in cabi_realloc is an unrecoverable trap. On
+		// a bad ptr, skip the copy and return the fresh block.
+		if p >= base && p-base <= uintptr(arenaSize) {
+			oldIdx := uint32(p - base)
+			if uint64(oldIdx)+uint64(n) <= arenaSize {
+				newIdx := uint32(uintptr(np) - base)
+				copy(arena[newIdx:newIdx+n], arena[oldIdx:oldIdx+n])
+			}
+		}
+	}
+	return np
+}
+
+// resolveReset computes the post-call bump state: latch the floor on first call,
+// then rewind to it thereafter. Pure function, unit-testable (see abi_test.go).
+func resolveReset(latched bool, floor, off uint32) (newFloor, newOff uint32, newLatched bool) {
+	if !latched {
+		return off, off, true
+	}
+	return floor, floor, true
+}
+
+// resetArena rewinds the bump pointer after each export (see resolveReset).
+func resetArena() {
+	arenaFloor, arenaOff, arenaFloorLatched = resolveReset(arenaFloorLatched, arenaFloor, arenaOff)
+}
+
+// liftString views a guest-memory (ptr, len) pair as a Go string without
+// copying. The view is valid only for the call duration (resetArena overwrites
+// it afterwards), so do not cache or return a value aliasing this memory.
+func liftString(ptr, length uint32) string {
+	if length == 0 {
+		return ""
+	}
+	return unsafe.String((*byte)(unsafe.Pointer(uintptr(ptr))), int(length))
+}
+
+// retArea is the return area for `result<string, string>`. Backed by [3]uint32
+// to force the 4-byte alignment the canonical ABI requires; a single static
+// buffer suffices because the host reads it synchronously before the next call.
+var retArea [3]uint32
+
+// retAreaBytes views the return area as a 12-byte slice laid out per the
+// canonical ABI:
+//
+//	[0]      discriminant (0 = ok, 1 = err)
+//	[4..8)   payload string pointer (i32, little-endian)
+//	[8..12)  payload string length  (i32, little-endian)
+func retAreaBytes() []byte {
+	return unsafe.Slice((*byte)(unsafe.Pointer(&retArea[0])), 12)
+}
+
+// retString pins the payload's backing bytes so they stay alive (and at a fixed
+// address, since Go's collector is non-moving) while the host lifts them.
+var retString string
+
+func lowerResult(payload string, isErr bool) uint32 {
+	retString = payload
+	b := retAreaBytes()
+	if isErr {
+		b[0] = 1
+	} else {
+		b[0] = 0
+	}
+	var ptr uint32
+	if retString != "" {
+		ptr = uint32(uintptr(unsafe.Pointer(unsafe.StringData(retString))))
+	}
+	binary.LittleEndian.PutUint32(b[4:], ptr)
+	binary.LittleEndian.PutUint32(b[8:], uint32(len(retString)))
+	return uint32(uintptr(unsafe.Pointer(&retArea[0])))
+}
+
+// emit lowers a (payload, error) pair: err -> err(message), else ok(payload).
+func emit(payload string, err error) uint32 {
+	if err != nil {
+		return lowerResult(err.Error(), true)
+	}
+	return lowerResult(payload, false)
+}
+
+//go:wasmexport lint
+func exportLint(srcPtr, srcLen, optPtr, optLen uint32) uint32 {
+	out, err := doLint(liftString(srcPtr, srcLen), liftString(optPtr, optLen))
+	ret := emit(out, err)
+	resetArena()
+	return ret
+}
+
+//go:wasmexport format
+func exportFormat(srcPtr, srcLen, cfgPtr, cfgLen uint32) uint32 {
+	out, err := doFormat(liftString(srcPtr, srcLen), liftString(cfgPtr, cfgLen))
+	ret := emit(out, err)
+	resetArena()
+	return ret
+}
+
+//go:wasmexport parse
+func exportParse(srcPtr, srcLen uint32) uint32 {
+	out, err := doParse(liftString(srcPtr, srcLen))
+	ret := emit(out, err)
+	resetArena()
+	return ret
+}
+
+//go:wasmexport tokenize
+func exportTokenize(srcPtr, srcLen uint32) uint32 {
+	out, err := doTokenize(liftString(srcPtr, srcLen))
+	ret := emit(out, err)
+	resetArena()
+	return ret
+}

--- a/cmd/falco-component/abi_test.go
+++ b/cmd/falco-component/abi_test.go
@@ -1,0 +1,250 @@
+//go:build wasip1 && wasm
+
+package main
+
+import (
+	"encoding/binary"
+	"errors"
+	"testing"
+	"unsafe"
+)
+
+// TestAlignAllocAlignsAbsoluteAddress guards the alignment contract: the
+// returned pointer must be aligned even when the arena base is misaligned.
+func TestAlignAllocAlignsAbsoluteAddress(t *testing.T) {
+	for _, base := range []uintptr{0, 1, 2, 3, 5, 7, 9, 13, 4096 + 1} {
+		for _, align := range []uint32{1, 2, 4, 8, 16} {
+			ptr, _, ok := alignAlloc(base, 0, 8, align)
+			if !ok {
+				t.Fatalf("base=%d align=%d: unexpected !ok", base, align)
+			}
+			if uintptr(ptr)%uintptr(align) != 0 {
+				t.Fatalf("base=%d align=%d: ptr=%d not aligned", base, align, ptr)
+			}
+			if uintptr(ptr) < base {
+				t.Fatalf("base=%d align=%d: ptr=%d below base", base, align, ptr)
+			}
+		}
+	}
+}
+
+// TestAlignAllocBumpsOffset checks the new offset accounts for both alignment
+// padding and size, so successive allocations do not overlap.
+func TestAlignAllocBumpsOffset(t *testing.T) {
+	// base 8-aligned; align=8 at off=1 must skip to off=8, new offset 8+size.
+	ptr, newOff, ok := alignAlloc(0, 1, 4, 8)
+	if !ok {
+		t.Fatal("unexpected !ok")
+	}
+	if ptr != 8 {
+		t.Fatalf("ptr=%d, want 8 (aligned up from off=1)", ptr)
+	}
+	if newOff != 12 {
+		t.Fatalf("newOff=%d, want 12 (8 padding + 4 size)", newOff)
+	}
+}
+
+// TestResolveResetLatchesFloor verifies the reset semantics: the first call
+// latches a floor and never rewinds past it; later calls rewind exactly to it.
+func TestResolveResetLatchesFloor(t *testing.T) {
+	// First call latches the floor at the current offset.
+	floor, off, latched := resolveReset(false, 0, 200_000)
+	if !latched {
+		t.Fatal("first reset must latch the floor")
+	}
+	if floor != 200_000 || off != 200_000 {
+		t.Fatalf("first reset: floor=%d off=%d, want 200000/200000", floor, off)
+	}
+
+	// Later call: a bigger offset must rewind back to the floor, not below it.
+	floor, off, latched = resolveReset(latched, floor, 1_200_000)
+	if !latched || floor != 200_000 || off != 200_000 {
+		t.Fatalf("later reset: floor=%d off=%d latched=%v, want 200000/200000/true", floor, off, latched)
+	}
+
+	// The floor must never grow on subsequent calls.
+	floor, off, _ = resolveReset(latched, floor, 5_000_000)
+	if floor != 200_000 || off != 200_000 {
+		t.Fatalf("floor drifted: floor=%d off=%d, want 200000/200000", floor, off)
+	}
+}
+
+// TestAlignAllocRejectsOverflow confirms an allocation past the arena end fails
+// rather than wrapping or returning an out-of-bounds pointer.
+func TestAlignAllocRejectsOverflow(t *testing.T) {
+	if _, _, ok := alignAlloc(0, arenaSize-2, 4, 1); ok {
+		t.Fatal("expected !ok for allocation past arena end")
+	}
+	// align=0 is normalized to 1 and must not panic.
+	if _, _, ok := alignAlloc(0, 0, 1, 0); !ok {
+		t.Fatal("expected ok for align=0 (normalized to 1)")
+	}
+}
+
+// TestAlignAllocRejectsAlignmentOverflow confirms that alignment padding
+// pushing past the arena tail is rejected even when the size alone would fit.
+func TestAlignAllocRejectsAlignmentOverflow(t *testing.T) {
+	if _, _, ok := alignAlloc(0, arenaSize-2, 4, 8); ok {
+		t.Fatal("expected !ok when alignment padding overflows the arena tail")
+	}
+}
+
+// resetArenaState zeroes the bump arena so each (serial) test starts empty.
+func resetArenaState() {
+	arenaOff, arenaFloor, arenaFloorLatched = 0, 0, false
+}
+
+// TestCabiReallocExhaustionReturnsNull pins the trap path: a non-zero
+// allocation that does not fit returns 0, which the canonical ABI treats as a trap.
+func TestCabiReallocExhaustionReturnsNull(t *testing.T) {
+	resetArenaState()
+	arenaOff = arenaSize - 2
+	if p := cabiRealloc(0, 0, 1, 100); p != 0 {
+		t.Fatalf("expected null when arena exhausted, got %d", p)
+	}
+}
+
+// TestCabiReallocZeroSizeNonNullWhenFull: a zero-size allocation must return a
+// non-null, aligned pointer even when the arena is full.
+func TestCabiReallocZeroSizeNonNullWhenFull(t *testing.T) {
+	resetArenaState()
+	arenaOff = arenaSize
+	for _, align := range []uint32{1, 4, 16} {
+		p := cabiRealloc(0, 0, align, 0)
+		if p == 0 {
+			t.Fatalf("align=%d: zero-size realloc must never be null even when full", align)
+		}
+		if uintptr(p)%uintptr(align) != 0 {
+			t.Fatalf("align=%d: ptr=%d not aligned", align, p)
+		}
+	}
+}
+
+// TestCabiReallocShrinkCopies exercises the shrink path (newSize < oldSize, so
+// only newSize bytes are copied).
+func TestCabiReallocShrinkCopies(t *testing.T) {
+	resetArenaState()
+	p := cabiRealloc(0, 0, 1, 8)
+	if p == 0 {
+		t.Fatal("initial alloc returned null")
+	}
+	idx := uint32(uintptr(p) - arenaBase())
+	copy(arena[idx:idx+8], []byte("abcdefgh"))
+
+	np := cabiRealloc(p, 8, 1, 4)
+	if np == 0 {
+		t.Fatal("shrink returned null")
+	}
+	nidx := uint32(uintptr(np) - arenaBase())
+	if got := string(arena[nidx : nidx+4]); got != "abcd" {
+		t.Fatalf("shrink did not copy the first newSize bytes: got %q, want \"abcd\"", got)
+	}
+}
+
+// TestCabiReallocForeignPointerDoesNotTrap covers the provenance guard: a grow
+// whose old pointer is outside the arena must skip the copy and return a fresh
+// block instead of panicking (a panic in cabi_realloc is an unrecoverable trap).
+func TestCabiReallocForeignPointerDoesNotTrap(t *testing.T) {
+	resetArenaState()
+	// A pointer below arenaBase with nonzero oldSize must not panic the copy.
+	np := cabiRealloc(1, 16, 1, 8)
+	if np == 0 {
+		t.Fatal("foreign-pointer grow should still allocate a fresh block")
+	}
+}
+
+// TestResetArenaPreservesFloor asserts resetArena's global mutation: the first
+// reset latches the floor, and a later reset rewinds exactly to it.
+func TestResetArenaPreservesFloor(t *testing.T) {
+	resetArenaState()
+	arenaOff = 80_000 // simulate the adapter State high-water mark
+	resetArena()
+	if !arenaFloorLatched || arenaFloor != 80_000 || arenaOff != 80_000 {
+		t.Fatalf("latch: floor=%d off=%d latched=%v, want 80000/80000/true",
+			arenaFloor, arenaOff, arenaFloorLatched)
+	}
+	arenaOff = 900_000 // simulate a call's lowered inputs
+	resetArena()
+	if arenaFloor != 80_000 || arenaOff != 80_000 {
+		t.Fatalf("rewind: floor=%d off=%d, want 80000/80000", arenaFloor, arenaOff)
+	}
+}
+
+// TestCabiReallocZeroSizeReturnsAlignedNonNull: even a zero-size allocation must
+// return a non-null, suitably-aligned pointer.
+func TestCabiReallocZeroSizeReturnsAlignedNonNull(t *testing.T) {
+	resetArenaState()
+	for _, align := range []uint32{1, 2, 4, 8, 16} {
+		p := cabiRealloc(0, 0, align, 0)
+		if p == 0 {
+			t.Fatalf("align=%d: zero-size realloc returned null", align)
+		}
+		if uintptr(p)%uintptr(align) != 0 {
+			t.Fatalf("align=%d: ptr=%d not aligned", align, p)
+		}
+	}
+}
+
+// TestCabiReallocGrowCopies checks that a grow (fresh block) copies the old
+// bytes forward, since there is no in-place extend.
+func TestCabiReallocGrowCopies(t *testing.T) {
+	resetArenaState()
+	p := cabiRealloc(0, 0, 1, 4)
+	if p == 0 {
+		t.Fatal("initial alloc returned null")
+	}
+	idx := uint32(uintptr(p) - arenaBase())
+	copy(arena[idx:idx+4], []byte("abcd"))
+
+	np := cabiRealloc(p, 4, 1, 8)
+	if np == 0 {
+		t.Fatal("grow returned null")
+	}
+	nidx := uint32(uintptr(np) - arenaBase())
+	if got := string(arena[nidx : nidx+4]); got != "abcd" {
+		t.Fatalf("grow did not preserve old bytes: got %q, want \"abcd\"", got)
+	}
+}
+
+// TestLowerResultEncoding asserts the result<string,string> encoding: ok/err
+// discriminant at byte 0, little-endian length at byte 8, non-null payload
+// pointer for non-empty payloads, and a 4-byte-aligned return-area pointer.
+func TestLowerResultEncoding(t *testing.T) {
+	resetArenaState()
+
+	ret := lowerResult("hello", false)
+	if uintptr(ret)%4 != 0 {
+		t.Fatalf("retArea base %d not 4-byte aligned", ret)
+	}
+	if uintptr(ret) != uintptr(unsafe.Pointer(&retArea[0])) {
+		t.Fatal("ret must point at retArea base")
+	}
+	b := retAreaBytes()
+	if b[0] != 0 {
+		t.Fatalf("ok discriminant = %d, want 0", b[0])
+	}
+	if got := binary.LittleEndian.Uint32(b[8:]); got != 5 {
+		t.Fatalf("payload len = %d, want 5", got)
+	}
+	if binary.LittleEndian.Uint32(b[4:]) == 0 {
+		t.Fatal("payload ptr must be non-zero for a non-empty payload")
+	}
+
+	// emit(err) -> err(message): discriminant 1, message length encoded.
+	emit("", errors.New("boom"))
+	b = retAreaBytes()
+	if b[0] != 1 {
+		t.Fatalf("err discriminant = %d, want 1", b[0])
+	}
+	if got := binary.LittleEndian.Uint32(b[8:]); got != 4 {
+		t.Fatalf("err message len = %d, want 4", got)
+	}
+
+	// emit(ok, empty): discriminant 0, ptr 0, len 0.
+	emit("", nil)
+	b = retAreaBytes()
+	if b[0] != 0 || binary.LittleEndian.Uint32(b[4:]) != 0 || binary.LittleEndian.Uint32(b[8:]) != 0 {
+		t.Fatalf("empty ok payload not zeroed: disc=%d ptr=%d len=%d",
+			b[0], binary.LittleEndian.Uint32(b[4:]), binary.LittleEndian.Uint32(b[8:]))
+	}
+}

--- a/cmd/falco-component/hosts/README.md
+++ b/cmd/falco-component/hosts/README.md
@@ -1,0 +1,71 @@
+# falco component — host smoke tests
+
+Smoke tests proving `wasm/falco-component.wasm` is callable, reactor-style
+(one instantiation, repeated calls), from Python, JS, and Ruby hosts.
+
+Build first:
+
+```sh
+make wasm-component       # -> wasm/falco-component.wasm
+```
+
+## Exports
+
+The WIT world (`wit/falco.wit`) exports `lint` / `format` / `parse` /
+`tokenize` at the **world root**, not nested in an interface. This is a hard
+requirement of Ruby's `wasmtime-rb`, whose `get_func(name)` only resolves
+root-level exports — an interface-nested export is unreachable. Every host
+reaches them by bare name: `get_func("lint")` (Ruby/Python) or
+`import { lint }` (jco/JS).
+
+Each function takes `(source, options)` and returns `result<string, string>`:
+the `ok` payload is JSON; `err` is an error message. The component has no
+filesystem — hosts supply included module sources via `options.includes`, and
+the component resolves transitive includes itself, keying diagnostics by module
+name. See `docs/wasm-component.md`.
+
+## Python (wasmtime embedding)
+
+```sh
+python3 -m venv .venv && .venv/bin/pip install 'wasmtime==46.*'
+.venv/bin/python cmd/falco-component/hosts/python/smoke.py \
+    wasm/falco-component.wasm cmd/falco-component/testdata/sample.vcl
+```
+
+Pin `wasmtime` to match `WASI_ADAPTER_VERSION` in the Makefile (currently
+v46.0.0); a newer adapter on an older runtime can fail to instantiate.
+
+## JS (jco transpile, Node)
+
+```sh
+cd cmd/falco-component/hosts/js
+npm ci
+npx jco transpile ../../../../wasm/falco-component.wasm -o dist
+node smoke.mjs
+```
+
+`jco` maps `result<string, string>` to "return `ok` / throw on `err`" and wires
+preview2 WASI imports automatically. `node:wasi` can't consume a component
+(preview1 core modules only), so `jco` is the JS path.
+
+## Ruby (wasmtime-rb embedding)
+
+```sh
+gem install wasmtime -v '~> 46.0'   # match WASI_ADAPTER_VERSION
+```
+
+```ruby
+require "wasmtime"
+require "json"
+
+engine    = Wasmtime::Engine.new
+component = Wasmtime::Component::Component.from_file(engine, "wasm/falco-component.wasm")
+linker    = Wasmtime::Component::Linker.new(engine)
+Wasmtime::WASI::P2.add_to_linker_sync(linker)
+store     = Wasmtime::Store.new(engine, wasi_config: Wasmtime::WasiConfig.new.inherit_stdout.inherit_stderr)
+instance  = linker.instantiate(store, component)
+
+lint = instance.get_func("lint")          # store is bound to the func
+res  = lint.call(src, "")                  # pass only the args
+report = JSON.parse(res.ok) if res.ok?     # res.ok / res.error accessors
+```

--- a/cmd/falco-component/hosts/js/.gitignore
+++ b/cmd/falco-component/hosts/js/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/cmd/falco-component/hosts/js/package-lock.json
+++ b/cmd/falco-component/hosts/js/package-lock.json
@@ -1,0 +1,2226 @@
+{
+  "name": "falco-component-js-smoke",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "falco-component-js-smoke",
+      "version": "0.0.0",
+      "dependencies": {
+        "@bytecodealliance/jco": "^1.24.3",
+        "@bytecodealliance/preview2-shim": "^0.19.0"
+      }
+    },
+    "node_modules/@bytecodealliance/componentize-js": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/componentize-js/-/componentize-js-0.21.0.tgz",
+      "integrity": "sha512-Av/XS3bJXE812P/bff3qtrJmehpgD0niK2A0fF3YIdM+jOD6E+mFrxOmuAgaIR0GNkpnm03+GE3ttt/+muqyCQ==",
+      "workspaces": [
+        "."
+      ],
+      "dependencies": {
+        "@bytecodealliance/jco": "^1.15.1",
+        "@bytecodealliance/weval": "^0.4.1",
+        "@bytecodealliance/wizer": "^10.0.0",
+        "es-module-lexer": "^1.6.0",
+        "oxc-parser": "^0.76.0"
+      },
+      "bin": {
+        "componentize-js": "src/cli.js"
+      }
+    },
+    "node_modules/@bytecodealliance/componentize-js-0-19-3": {
+      "name": "@bytecodealliance/componentize-js",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/componentize-js/-/componentize-js-0.19.3.tgz",
+      "integrity": "sha512-ju7Y4WeF0B9uMkSPHJgmT6ouEfSwbe9M1uR/YOnYZjBpxJjH9qzxIkJg/kf8NycVDyFJ2/lscmJ1E1uPiDQVRQ==",
+      "workspaces": [
+        "."
+      ],
+      "dependencies": {
+        "@bytecodealliance/jco": "^1.15.1",
+        "@bytecodealliance/wizer": "^10.0.0",
+        "es-module-lexer": "^1.6.0",
+        "oxc-parser": "^0.76.0"
+      },
+      "bin": {
+        "componentize-js": "src/cli.js"
+      }
+    },
+    "node_modules/@bytecodealliance/jco": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/jco/-/jco-1.24.3.tgz",
+      "integrity": "sha512-2NGY31zFdnMqusmmBMrQ9Rlxw89P/BHyQ5BAcrzCMqRRoc95SzuuCtOy8DwWgZ3WeXlWpG9ozAIEW4YPwspgQw==",
+      "license": "(Apache-2.0 WITH LLVM-exception)",
+      "dependencies": {
+        "@bytecodealliance/componentize-js": "^0.21.0",
+        "@bytecodealliance/componentize-js-0-19-3": "npm:@bytecodealliance/componentize-js@^0.19.3",
+        "@bytecodealliance/jco-transpile": "^0.3.3",
+        "@bytecodealliance/preview2-shim": "^0.17.9",
+        "@bytecodealliance/preview3-shim": "^0.1.2",
+        "binaryen": "^130.0.0",
+        "commander": "^14",
+        "mkdirp": "^3",
+        "ora": "^8",
+        "terser": "^5"
+      },
+      "bin": {
+        "jco": "src/jco.js"
+      }
+    },
+    "node_modules/@bytecodealliance/jco-transpile": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/jco-transpile/-/jco-transpile-0.3.3.tgz",
+      "integrity": "sha512-twkIb3oz8hGEjAnLQNBmQYCHI4YEkaMsSQ0k+iWFYfFefPcm4kFSkQUrjNe0DwMl00KM5kAvG/0r15AYHWs6aw==",
+      "license": "(Apache-2.0 WITH LLVM-exception)",
+      "dependencies": {
+        "@bytecodealliance/preview2-shim": "^0.17.5",
+        "binaryen": "^130.0.0",
+        "terser": "^5"
+      }
+    },
+    "node_modules/@bytecodealliance/jco-transpile/node_modules/@bytecodealliance/preview2-shim": {
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/preview2-shim/-/preview2-shim-0.17.9.tgz",
+      "integrity": "sha512-i0R3eQBe6PA/o/1EFE3Owe4In2rcccb6QxnjpntM/lPe3/duJ0bRQTVZM2Ufpo99X4eofGeltQUkape1C91FFA==",
+      "license": "(Apache-2.0 WITH LLVM-exception)"
+    },
+    "node_modules/@bytecodealliance/jco/node_modules/@bytecodealliance/preview2-shim": {
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/preview2-shim/-/preview2-shim-0.17.9.tgz",
+      "integrity": "sha512-i0R3eQBe6PA/o/1EFE3Owe4In2rcccb6QxnjpntM/lPe3/duJ0bRQTVZM2Ufpo99X4eofGeltQUkape1C91FFA==",
+      "license": "(Apache-2.0 WITH LLVM-exception)"
+    },
+    "node_modules/@bytecodealliance/preview2-shim": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/preview2-shim/-/preview2-shim-0.19.0.tgz",
+      "integrity": "sha512-OSUlcM62fXLuzYP0DjBn/SwjKMZ/y/2PMXZ8v5cRiiFcroauntlPRl/oCnx0xYjYiqdYvE0PY50VCNutll0xOw==",
+      "license": "(Apache-2.0 WITH LLVM-exception)"
+    },
+    "node_modules/@bytecodealliance/preview3-shim": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/preview3-shim/-/preview3-shim-0.1.2.tgz",
+      "integrity": "sha512-5twfO5h6zVkJ2QLxrLR21qyLS3jY35XvY0f+jZV4e9FkI6qa2RdPfNDgC50HYhGCtWmbH4TlN1puIyHfEemSNg==",
+      "license": "(Apache-2.0 WITH LLVM-exception)",
+      "dependencies": {
+        "@bytecodealliance/preview2-shim": "^0.17.3"
+      }
+    },
+    "node_modules/@bytecodealliance/preview3-shim/node_modules/@bytecodealliance/preview2-shim": {
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/preview2-shim/-/preview2-shim-0.17.9.tgz",
+      "integrity": "sha512-i0R3eQBe6PA/o/1EFE3Owe4In2rcccb6QxnjpntM/lPe3/duJ0bRQTVZM2Ufpo99X4eofGeltQUkape1C91FFA==",
+      "license": "(Apache-2.0 WITH LLVM-exception)"
+    },
+    "node_modules/@bytecodealliance/weval": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/weval/-/weval-0.4.1.tgz",
+      "integrity": "sha512-vJegSAkNjENhJcMUod76KUGAgQLdACDDCwB3JwyR14zDhyHVPAvArvtDDYEEi+c+ELzls62H6wxTvzRmaYTaqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@napi-rs/lzma": "^1.1.2",
+        "decompress": "^4.2.1",
+        "decompress-tar": "^4.1.1",
+        "decompress-unzip": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@bytecodealliance/wizer": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer/-/wizer-10.0.0.tgz",
+      "integrity": "sha512-ziWmovyu1jQl9TsKlfC2bwuUZwxVPFHlX4fOqTzxhgS76jITIo45nzODEwPgU+jjmOr8F3YX2V2wAChC5NKujg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "wizer": "wizer.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@bytecodealliance/wizer-darwin-arm64": "10.0.0",
+        "@bytecodealliance/wizer-darwin-x64": "10.0.0",
+        "@bytecodealliance/wizer-linux-arm64": "10.0.0",
+        "@bytecodealliance/wizer-linux-s390x": "10.0.0",
+        "@bytecodealliance/wizer-linux-x64": "10.0.0",
+        "@bytecodealliance/wizer-win32-x64": "10.0.0"
+      }
+    },
+    "node_modules/@bytecodealliance/wizer-darwin-arm64": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-darwin-arm64/-/wizer-darwin-arm64-10.0.0.tgz",
+      "integrity": "sha512-dhZTWel+xccGTKSJtI9A7oM4yyP20FWflsT+AoqkOqkCY7kCNrj4tmMtZ6GXZFRDkrPY5+EnOh62sfShEibAMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "wizer-darwin-arm64": "wizer"
+      }
+    },
+    "node_modules/@bytecodealliance/wizer-darwin-x64": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-darwin-x64/-/wizer-darwin-x64-10.0.0.tgz",
+      "integrity": "sha512-r/LUIZw6Q3Hf4htd46mD+EBxfwjBkxVIrTM1r+B2pTCddoBYQnKVdVsI4UFyy7NoBxzEg8F8BwmTNoSLmFRjpw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "wizer-darwin-x64": "wizer"
+      }
+    },
+    "node_modules/@bytecodealliance/wizer-linux-arm64": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-linux-arm64/-/wizer-linux-arm64-10.0.0.tgz",
+      "integrity": "sha512-pGSfFWXzeTqHm6z1PtVaEn+7Fm3QGC8YnHrzBV4sQDVS3N1NwmuHZAc8kslmlFPNdu61ycEvdOsSgCny8JPQvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "wizer-linux-arm64": "wizer"
+      }
+    },
+    "node_modules/@bytecodealliance/wizer-linux-s390x": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-linux-s390x/-/wizer-linux-s390x-10.0.0.tgz",
+      "integrity": "sha512-O8vHxRTAdb1lUnVXMIMTcp/9q4pq1D4iIKigJCipg2JN15taV9uFAWh0fO88wylXwuSlO7dOE1AwQl54fMKXQg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "wizer-linux-s390x": "wizer"
+      }
+    },
+    "node_modules/@bytecodealliance/wizer-linux-x64": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-linux-x64/-/wizer-linux-x64-10.0.0.tgz",
+      "integrity": "sha512-fJtM1sy43FBMnp+xpapFX6U1YdTBKA/1T4CYfG/qeE8jn0SXk2EuiYoY/EnC2uyNy9hjTrvfdYO5n4MXW0EIdQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "wizer-linux-x64": "wizer"
+      }
+    },
+    "node_modules/@bytecodealliance/wizer-win32-x64": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-win32-x64/-/wizer-win32-x64-10.0.0.tgz",
+      "integrity": "sha512-55BPLfGT7iT7gH5M69NpTM16QknJZ7OxJ0z73VOEoeGA9CT8QPKMRzFKsPIvLs+W8G28fdudFA94nElrdkp3Kg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "wizer-win32-x64": "wizer"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/lzma": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma/-/lzma-1.4.5.tgz",
+      "integrity": "sha512-zS5LuN1OBPAyZpda2ZZgYOEDC+xecUdAGnrvbYzjnLXkrq/OBC3B9qcRvlxbDR3k5H/gVfvef1/jyUqPknqjbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-android-arm-eabi": "1.4.5",
+        "@napi-rs/lzma-android-arm64": "1.4.5",
+        "@napi-rs/lzma-darwin-arm64": "1.4.5",
+        "@napi-rs/lzma-darwin-x64": "1.4.5",
+        "@napi-rs/lzma-freebsd-x64": "1.4.5",
+        "@napi-rs/lzma-linux-arm-gnueabihf": "1.4.5",
+        "@napi-rs/lzma-linux-arm64-gnu": "1.4.5",
+        "@napi-rs/lzma-linux-arm64-musl": "1.4.5",
+        "@napi-rs/lzma-linux-ppc64-gnu": "1.4.5",
+        "@napi-rs/lzma-linux-riscv64-gnu": "1.4.5",
+        "@napi-rs/lzma-linux-s390x-gnu": "1.4.5",
+        "@napi-rs/lzma-linux-x64-gnu": "1.4.5",
+        "@napi-rs/lzma-linux-x64-musl": "1.4.5",
+        "@napi-rs/lzma-wasm32-wasi": "1.4.5",
+        "@napi-rs/lzma-win32-arm64-msvc": "1.4.5",
+        "@napi-rs/lzma-win32-ia32-msvc": "1.4.5",
+        "@napi-rs/lzma-win32-x64-msvc": "1.4.5"
+      }
+    },
+    "node_modules/@napi-rs/lzma-android-arm-eabi": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-android-arm-eabi/-/lzma-android-arm-eabi-1.4.5.tgz",
+      "integrity": "sha512-Up4gpyw2SacmyKWWEib06GhiDdF+H+CCU0LAV8pnM4aJIDqKKd5LHSlBht83Jut6frkB0vwEPmAkv4NjQ5u//Q==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-android-arm64": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-android-arm64/-/lzma-android-arm64-1.4.5.tgz",
+      "integrity": "sha512-uwa8sLlWEzkAM0MWyoZJg0JTD3BkPknvejAFG2acUA1raXM8jLrqujWCdOStisXhqQjZ2nDMp3FV6cs//zjfuQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-darwin-arm64": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-darwin-arm64/-/lzma-darwin-arm64-1.4.5.tgz",
+      "integrity": "sha512-0Y0TQLQ2xAjVabrMDem1NhIssOZzF/y/dqetc6OT8mD3xMTDtF8u5BqZoX3MyPc9FzpsZw4ksol+w7DsxHrpMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-darwin-x64": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-darwin-x64/-/lzma-darwin-x64-1.4.5.tgz",
+      "integrity": "sha512-vR2IUyJY3En+V1wJkwmbGWcYiT8pHloTAWdW4pG24+51GIq+intst6Uf6D/r46citObGZrlX0QvMarOkQeHWpw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-freebsd-x64": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-freebsd-x64/-/lzma-freebsd-x64-1.4.5.tgz",
+      "integrity": "sha512-XpnYQC5SVovO35tF0xGkbHYjsS6kqyNCjuaLQ2dbEblFRr5cAZVvsJ/9h7zj/5FluJPJRDojVNxGyRhTp4z2lw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-arm-gnueabihf": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-arm-gnueabihf/-/lzma-linux-arm-gnueabihf-1.4.5.tgz",
+      "integrity": "sha512-ic1ZZMoRfRMwtSwxkyw4zIlbDZGC6davC9r+2oX6x9QiF247BRqqT94qGeL5ZP4Vtz0Hyy7TEViWhx5j6Bpzvw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-arm64-gnu": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-arm64-gnu/-/lzma-linux-arm64-gnu-1.4.5.tgz",
+      "integrity": "sha512-asEp7FPd7C1Yi6DQb45a3KPHKOFBSfGuJWXcAd4/bL2Fjetb2n/KK2z14yfW8YC/Fv6x3rBM0VAZKmJuz4tysg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-arm64-musl": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-arm64-musl/-/lzma-linux-arm64-musl-1.4.5.tgz",
+      "integrity": "sha512-yWjcPDgJ2nIL3KNvi4536dlT/CcCWO0DUyEOlBs/SacG7BeD6IjGh6yYzd3/X1Y3JItCbZoDoLUH8iB1lTXo3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-ppc64-gnu": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-ppc64-gnu/-/lzma-linux-ppc64-gnu-1.4.5.tgz",
+      "integrity": "sha512-0XRhKuIU/9ZjT4WDIG/qnX7Xz7mSQHYZo9Gb3MP2gcvBgr6BA4zywQ9k3gmQaPn9ECE+CZg2V7DV7kT+x2pUMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-riscv64-gnu": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-riscv64-gnu/-/lzma-linux-riscv64-gnu-1.4.5.tgz",
+      "integrity": "sha512-QrqDIPEUUB23GCpyQj/QFyMlr8SGxxyExeZz9OWFnHfb70kXdTLWrHS/hEI1Ru+lSbQ/6xRqeoGyQ4Aqdg+/RA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-s390x-gnu": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-s390x-gnu/-/lzma-linux-s390x-gnu-1.4.5.tgz",
+      "integrity": "sha512-k8RVM5aMhW86E9H0QXdquwojew4H3SwPxbRVbl49/COJQWCUjGi79X6mYruMnMPEznZinUiT1jgKbFo2A00NdA==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.4.5.tgz",
+      "integrity": "sha512-6rMtBgnIq2Wcl1rQdZsnM+rtCcVCbws1nF8S2NzaUsVaZv8bjrPiAa0lwg4Eqnn1d9lgwqT+cZgm5m+//K08Kw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-musl": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-musl/-/lzma-linux-x64-musl-1.4.5.tgz",
+      "integrity": "sha512-eiadGBKi7Vd0bCArBUOO/qqRYPHt/VQVvGyYvDFt6C2ZSIjlD+HuOl+2oS1sjf4CFjK4eDIog6EdXnL0NE6iyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-wasm32-wasi": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-wasm32-wasi/-/lzma-wasm32-wasi-1.4.5.tgz",
+      "integrity": "sha512-+VyHHlr68dvey6fXc2hehw9gHVFIW3TtGF1XkcbAu65qVXsA9D/T+uuoRVqhE+JCyFHFrO0ixRbZDRK1XJt1sA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@napi-rs/lzma-win32-arm64-msvc": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-win32-arm64-msvc/-/lzma-win32-arm64-msvc-1.4.5.tgz",
+      "integrity": "sha512-eewnqvIyyhHi3KaZtBOJXohLvwwN27gfS2G/YDWdfHlbz1jrmfeHAmzMsP5qv8vGB+T80TMHNkro4kYjeh6Deg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-win32-ia32-msvc": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-win32-ia32-msvc/-/lzma-win32-ia32-msvc-1.4.5.tgz",
+      "integrity": "sha512-OeacFVRCJOKNU/a0ephUfYZ2Yt+NvaHze/4TgOwJ0J0P4P7X1mHzN+ig9Iyd74aQDXYqc7kaCXA2dpAOcH87Cg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-win32-x64-msvc": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-win32-x64-msvc/-/lzma-win32-x64-msvc-1.4.5.tgz",
+      "integrity": "sha512-T4I1SamdSmtyZgDXGAGP+y5LEK5vxHUFwe8mz6D4R7Sa5/WCxTcCIgPJ9BD7RkpO17lzhlaM2vmVvMy96Lvk9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.76.0.tgz",
+      "integrity": "sha512-1XJW/16CDmF5bHE7LAyPPmEEVnxSadDgdJz+xiLqBrmC4lfAeuAfRw3HlOygcPGr+AJsbD4Z5sFJMkwjbSZlQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.76.0.tgz",
+      "integrity": "sha512-yoQwSom8xsB+JdGsPUU0xxmxLKiF2kdlrK7I56WtGKZilixuBf/TmOwNYJYLRWkBoW5l2/pDZOhBm2luwmLiLw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.76.0.tgz",
+      "integrity": "sha512-uRIopPLvr3pf2Xj7f5LKyCuqzIU6zOS+zEIR8UDYhcgJyZHnvBkfrYnfcztyIcrGdQehrFUi3uplmI09E7RdiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.76.0.tgz",
+      "integrity": "sha512-a0EOFvnOd2FqmDSvH6uWLROSlU6KV/JDKbsYDA/zRLyKcG6HCsmFnPsp8iV7/xr9WMbNgyJi6R5IMpePQlUq7Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.76.0.tgz",
+      "integrity": "sha512-ikRYDHL3fOdZwfJKmcdqjlLgkeNZ3Ez0qM8wAev5zlHZ+lY/Ig7qG5SCqPlvuTu+nNQ6zrFFaKvvt69EBKXU/g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.76.0.tgz",
+      "integrity": "sha512-dtRv5J5MRCLR7x39K8ufIIW4svIc7gYFUaI0YFXmmeOBhK/K2t/CkguPnDroKtsmXIPHDRtmJ1JJYzNcgJl6Wg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.76.0.tgz",
+      "integrity": "sha512-IE4iiiggFH2snagQxHrY5bv6dDpRMMat+vdlMN/ibonA65eOmRLp8VLTXnDiNrcla/itJ1L9qGABHNKU+SnE8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.76.0.tgz",
+      "integrity": "sha512-wi9zQPMDHrBuRuT7Iurfidc9qlZh7cKa5vfYzOWNBCaqJdgxmNOFzvYen02wVUxSWGKhpiPHxrPX0jdRyJ8Npg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.76.0.tgz",
+      "integrity": "sha512-0tqqu1pqPee2lLGY8vtYlX1L415fFn89e0a3yp4q5N9f03j1rRs0R31qesTm3bt/UK8HYjECZ+56FCVPs2MEMQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.76.0.tgz",
+      "integrity": "sha512-y36Hh1a5TA+oIGtlc8lT7N9vdHXBlhBetQJW0p457KbiVQ7jF7AZkaPWhESkjHWAsTVKD2OjCa9ZqfaqhSI0FQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.76.0.tgz",
+      "integrity": "sha512-7/acaG9htovp3gp/J0kHgbItQTuHctl+rbqPPqZ9DRBYTz8iV8kv3QN8t8Or8i/hOmOjfZp9McDoSU1duoR4/A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.76.0.tgz",
+      "integrity": "sha512-AxFt0reY6Q2rfudABmMTFGR8tFFr58NlH2rRBQgcj+F+iEwgJ+jMwAPhXd2y1I2zaI8GspuahedUYQinqxWqjA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.76.0.tgz",
+      "integrity": "sha512-wHdkHdhf6AWBoO8vs5cpoR6zEFY1rB+fXWtq6j/xb9j/lu1evlujRVMkh8IM/M/pOUIrNkna3nzST/mRImiveQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.76.0.tgz",
+      "integrity": "sha512-G7ZlEWcb2hNwCK3qalzqJoyB6HaTigQ/GEa7CU8sAJ/WwMdG/NnPqiC9IqpEAEy1ARSo4XMALfKbKNuqbSs5mg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.76.0.tgz",
+      "integrity": "sha512-0jLzzmnu8/mqNhKBnNS2lFUbPEzRdj5ReiZwHGHpjma0+ullmmwP2AqSEqx3ssHDK9CpcEMdKOK2LsbCfhHKIA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.76.0.tgz",
+      "integrity": "sha512-CH3THIrSViKal8yV/Wh3FK0pFhp40nzW1MUDCik9fNuid2D/7JJXKJnfFOAvMxInGXDlvmgT6ACAzrl47TqzkQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/binaryen": {
+      "version": "130.0.0",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-130.0.0.tgz",
+      "integrity": "sha512-XDrb+zql0RbFPKgj7MuH9zOc78R3Fa/P/VSGnnpdwYsvNZPWjcMYMdAkKCOQEL2A7yqgjSMTDRFp6gfSDW+/QQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "wasm-as": "bin/wasm-as",
+        "wasm-ctor-eval": "bin/wasm-ctor-eval",
+        "wasm-dis": "bin/wasm-dis",
+        "wasm-merge": "bin/wasm-merge",
+        "wasm-metadce": "bin/wasm-metadce",
+        "wasm-opt": "bin/wasm-opt",
+        "wasm-reduce": "bin/wasm-reduce",
+        "wasm-shell": "bin/wasm-shell",
+        "wasm2js": "bin/wasm2js"
+      }
+    },
+    "node_modules/bl": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+      "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "license": "MIT"
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
+      "license": "MIT"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/decompress": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
+      "integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "decompress-tar": "^4.0.0",
+        "decompress-tarbz2": "^4.0.0",
+        "decompress-targz": "^4.0.0",
+        "decompress-unzip": "^4.0.1",
+        "graceful-fs": "^4.1.10",
+        "make-dir": "^1.0.0",
+        "pify": "^2.3.0",
+        "strip-dirs": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/decompress-tar": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
+      "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-type": "^5.2.0",
+        "is-stream": "^1.1.0",
+        "tar-stream": "^1.5.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/decompress-tarbz2": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
+      "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
+      "license": "MIT",
+      "dependencies": {
+        "decompress-tar": "^4.1.0",
+        "file-type": "^6.1.0",
+        "is-stream": "^1.1.0",
+        "seek-bzip": "^1.0.5",
+        "unbzip2-stream": "^1.0.9"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/decompress-tarbz2/node_modules/file-type": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
+      "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/decompress-targz": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
+      "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
+      "license": "MIT",
+      "dependencies": {
+        "decompress-tar": "^4.1.1",
+        "file-type": "^5.2.0",
+        "is-stream": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/decompress-unzip": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
+      "integrity": "sha512-1fqeluvxgnn86MOh66u8FjbtJpAFv5wgCT9Iw8rcBqQcCo5tO8eiJw7NNTrvt9n4CRBVq7CstiS922oPgyGLrw==",
+      "license": "MIT",
+      "dependencies": {
+        "file-type": "^3.8.0",
+        "get-stream": "^2.2.0",
+        "pify": "^2.3.0",
+        "yauzl": "^2.4.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/decompress-unzip/node_modules/file-type": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+      "integrity": "sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+      "integrity": "sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+      "integrity": "sha512-AUGhbbemXxrZJRD5cDvKtQxLuYaIbNtDTK8YqupCI393Q2KSTreEsLUN3ZxAWFGiKTzL6nKuzfcIvieflUX9qA==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.0.1",
+        "pinkie-promise": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-natural-number": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
+      "integrity": "sha512-Y4LTamMe0DDQIIAlaer9eKebAlDSV6huy+TWhJVPlzZh2o4tRP5SQWFlLn5N0To4mDD22/qdOq+veo1cSISLgQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/make-dir/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/oxc-parser": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.76.0.tgz",
+      "integrity": "sha512-l98B2e9evuhES7zN99rb1QGhbzx25829TJFaKi2j0ib3/K/G5z1FdGYz6HZkrU3U8jdH7v2FC8mX1j2l9JrOUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.76.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm64": "0.76.0",
+        "@oxc-parser/binding-darwin-arm64": "0.76.0",
+        "@oxc-parser/binding-darwin-x64": "0.76.0",
+        "@oxc-parser/binding-freebsd-x64": "0.76.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.76.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.76.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.76.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.76.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.76.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.76.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.76.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.76.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.76.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.76.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.76.0"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "pinkie": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/seek-bzip": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
+      "integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.8.1"
+      },
+      "bin": {
+        "seek-bunzip": "bin/seek-bunzip",
+        "seek-table": "bin/seek-bzip-table"
+      }
+    },
+    "node_modules/seek-bzip/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-dirs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
+      "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-natural-number": "^4.0.1"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.2.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.1",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
+      "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "license": "MIT"
+    },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/to-buffer/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    }
+  }
+}

--- a/cmd/falco-component/hosts/js/package.json
+++ b/cmd/falco-component/hosts/js/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "falco-component-js-smoke",
+  "private": true,
+  "type": "module",
+  "version": "0.0.0",
+  "dependencies": {
+    "@bytecodealliance/jco": "^1.24.3",
+    "@bytecodealliance/preview2-shim": "^0.19.0"
+  }
+}

--- a/cmd/falco-component/hosts/js/smoke.mjs
+++ b/cmd/falco-component/hosts/js/smoke.mjs
@@ -1,0 +1,113 @@
+// Node/jco host smoke test for the falco WASI component.
+//
+// Imports the jco-transpiled component (one instantiation) and calls `lint`
+// and `format` repeatedly on sample VCL strings. jco maps the WIT
+// `result<string, string>` to "return the ok string / throw on err", and wires
+// the preview2 WASI imports to @bytecodealliance/preview2-shim automatically.
+//
+// The WIT world exports lint/format/parse/tokenize at the *root* (not nested in
+// an interface), so jco surfaces them as top-level named exports.
+//
+// Usage: node smoke.mjs
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { lint, format, parse } from "./dist/falco-component.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const td = join(here, "..", "..", "testdata");
+const clean = readFileSync(join(td, "sample.vcl"), "utf8");
+const bad = readFileSync(join(td, "lint-error.vcl"), "utf8");
+
+// --- lint a clean source ---------------------------------------------------
+const cleanReport = JSON.parse(lint(clean, ""));
+console.log("== lint(clean) summary ==");
+console.log(`Errors=${cleanReport.Errors} Warnings=${cleanReport.Warnings} Infos=${cleanReport.Infos}`);
+
+// --- lint a source with diagnostics (same instance) ------------------------
+const badReport = JSON.parse(lint(bad, ""));
+console.log("\n== lint(bad) LintErrors (native lint -json shape) ==");
+for (const [file, errs] of Object.entries(badReport.LintErrors)) {
+  for (const e of errs) {
+    console.log(`  [${e.Severity}] ${file}:${e.Token.Line}:${e.Token.Position} ${e.Message}`);
+    if (e.Reference) console.log(`     ref: ${e.Reference}`);
+  }
+}
+console.log(`  totals: Errors=${badReport.Errors} Warnings=${badReport.Warnings} Infos=${badReport.Infos}`);
+
+// --- format with config (same instance, repeated call) ---------------------
+console.log("\n== format(clean, tab indent) ==");
+console.log(format(clean, JSON.stringify({ indentStyle: "tab" })));
+
+// --- error path: parse maps result err -> thrown exception -----------------
+console.log("== error path (parse of invalid VCL throws) ==");
+try {
+  parse("sub vcl_recv { this is not valid");
+  console.log("  ERROR: expected a throw");
+  process.exit(1);
+} catch (e) {
+  console.log(`  threw as expected: ${String(e).slice(0, 80)}`);
+}
+
+// --- multi-file lint with a nested include --------------------------------
+// The component has no filesystem, so the host supplies include contents via
+// options.includes. Transitive includes are discovered by the component (main
+// -> mod_a -> mod_b); diagnostics are keyed by the real module name, not the
+// synthetic "input.vcl".
+console.log("\n== lint with nested includes (main -> mod_a -> mod_b) ==");
+const incMain = `include "mod_a";\n\nsub vcl_recv {\n#FASTLY RECV\n  set req.http.X-Main = "1";\n}\n`;
+const incModA = `include "mod_b";\n\nsub vcl_deliver {\n#FASTLY DELIVER\n  set resp.http.X-A = "a";\n}\n`;
+// mod_b (the deepest, transitively-included module) carries the lint error.
+const incModB = `sub vcl_fetch {\n#FASTLY FETCH\n  set bereq.http.X-Bad = undefined.variable;\n}\n`;
+const incReport = JSON.parse(
+  lint(incMain, JSON.stringify({ includes: { mod_a: incModA, mod_b: incModB } })),
+);
+const incKeys = Object.keys(incReport.LintErrors);
+console.log(`  LintErrors keys: ${JSON.stringify(incKeys)} totals: Errors=${incReport.Errors}`);
+for (const [file, errs] of Object.entries(incReport.LintErrors)) {
+  for (const e of errs) {
+    console.log(`  [${e.Severity}] ${file}:${e.Token.Line}:${e.Token.Position} ${e.Message} (Token.File=${e.Token.File})`);
+  }
+}
+// Assert the transitive include resolved and is keyed by its real module name.
+if (!incKeys.includes("mod_b")) {
+  throw new Error(`expected LintErrors keyed by "mod_b", got ${JSON.stringify(incKeys)}`);
+}
+if (incReport.LintErrors.mod_b.some((e) => e.Token.File !== "mod_b")) {
+  throw new Error("expected every mod_b error to carry Token.File == 'mod_b'");
+}
+if (incReport.Errors < 1) throw new Error("expected at least one error from the included module");
+// A bare include with no contents supplied must report an unresolved-include
+// error (not crash) -- the single-file path stays intact.
+const missing = JSON.parse(lint(`include "absent";\nsub vcl_recv {\n#FASTLY RECV\n}\n`, ""));
+if (missing.Errors < 1) throw new Error("expected an unresolved-include error when no contents supplied");
+console.log(`  unresolved include (no contents) -> Errors=${missing.Errors} (reported, not crashed)`);
+
+// --- stress: prove the reactor is durably reusable ------------------------
+// Regression for the preview1 adapter-State corruption that crashed the
+// instance after a few non-trivial calls (resetArena used to rewind the bump
+// arena over the adapter's persistent State). One instantiation must survive
+// many large format+lint calls interleaved with small ones.
+function buildLargeVCL(minBytes) {
+  let s = "sub vcl_recv {\n#FASTLY RECV\n";
+  for (let i = 0; s.length < minBytes; i++) {
+    s += `  set req.http.X-Hdr-${i} = "value-${i}-aaaaaaaaaaaaaaaaaaaa";\n`;
+    s += `  if (req.url ~ "^/path-${i}/segment") {\n    set req.http.X-Match-${i} = "1";\n  }\n`;
+  }
+  return s + "}\n";
+}
+const large = buildLargeVCL(100 * 1024);
+console.log(`\n== stress: ${Math.floor(large.length / 1024)} KiB VCL, repeated format+lint in one instance ==`);
+let stressCalls = 0;
+for (let i = 0; i < 6; i++) {
+  if (format(large, "").length === 0) throw new Error("stress: empty format output");
+  if (JSON.parse(lint(large, "")).Errors !== 0) throw new Error("stress: unexpected lint errors on clean large VCL");
+  // Interleave a small input so the arena high-water mark swings widely.
+  format(clean, "");
+  JSON.parse(lint(clean, ""));
+  stressCalls += 4;
+}
+console.log(`  survived ${stressCalls} calls (6 large format+lint pairs + small mix), no crash`);
+
+console.log("\nOK: lint + format + parse called repeatedly from one jco instantiation");

--- a/cmd/falco-component/hosts/python/smoke.py
+++ b/cmd/falco-component/hosts/python/smoke.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Python wasmtime host smoke test for the falco WASI component.
+
+Loads wasm/falco-component.wasm, instantiates it once (reactor style), and calls
+the `lint` and `format` exports repeatedly on a sample VCL string -- no temp
+files, no stdout capture, no per-call re-instantiation.
+
+Usage:
+    python smoke.py <component.wasm> <sample.vcl>
+"""
+import json
+import sys
+
+from wasmtime import Engine, Store, WasiConfig
+from wasmtime.component import Component, Linker
+
+
+def main() -> int:
+    component_path, vcl_path = sys.argv[1], sys.argv[2]
+    with open(vcl_path, encoding="utf-8") as f:
+        source = f.read()
+
+    engine = Engine()
+    store = Store(engine)
+    # The component imports preview2 wasi:cli/* (from the adapter); satisfy them.
+    wasi = WasiConfig()
+    wasi.inherit_stdout()
+    wasi.inherit_stderr()
+    store.set_wasi(wasi)
+
+    component = Component.from_file(engine, component_path)
+    linker = Linker(engine)
+    linker.add_wasip2()
+    instance = linker.instantiate(store, component)
+
+    # The world exports lint/format/parse/tokenize at the root, so they resolve
+    # as top-level world exports (no interface sub-instance to descend into).
+    def get(name):
+        idx = instance.get_export_index(store, name)
+        assert idx is not None, f"missing function {name}"
+        fn = instance.get_func(store, idx)
+        assert fn is not None, f"{name} is not a function"
+        return fn
+
+    lint, fmt = get("lint"), get("format")
+
+    # --- call 1: lint -------------------------------------------------------
+    res = lint(store, source, "")
+    if res.tag != "ok":
+        print("lint failed:", res.payload, file=sys.stderr)
+        return 1
+    report = json.loads(res.payload)
+    print("== lint (RunnerResult JSON) ==")
+    print(json.dumps(report, indent=2)[:800])
+    print(f"\nlint summary: Errors={report['Errors']} "
+          f"Warnings={report['Warnings']} Infos={report['Infos']}")
+
+    # --- call 2: format (same instance, no re-instantiation) ---------------
+    res = fmt(store, source, json.dumps({"indentWidth": 4, "indentStyle": "space"}))
+    if res.tag != "ok":
+        print("format failed:", res.payload, file=sys.stderr)
+        return 1
+    print("\n== format (4-space indent) ==")
+    print(res.payload)
+
+    # --- call 3: format again with different config, proving reuse ----------
+    res = fmt(store, source, "")
+    assert res.tag == "ok"
+    print("== format (defaults, reused instance) -- first line ==")
+    print(res.payload.splitlines()[0] if res.payload else "(empty)")
+
+    # --- stress: prove the reactor is durably reusable ---------------------
+    # Regression for the preview1 adapter-State corruption that crashed the
+    # instance after a few non-trivial calls (resetArena used to rewind the
+    # bump arena over the adapter's persistent State). One instantiation must
+    # survive many large format+lint calls interleaved with small ones.
+    def build_large_vcl(min_bytes: int) -> str:
+        parts = ["sub vcl_recv {\n#FASTLY RECV\n"]
+        total, i = len(parts[0]), 0
+        while total < min_bytes:
+            chunk = (f'  set req.http.X-Hdr-{i} = "value-{i}-aaaaaaaaaaaaaaaaaaaa";\n'
+                     f'  if (req.url ~ "^/path-{i}/segment") {{\n'
+                     f'    set req.http.X-Match-{i} = "1";\n  }}\n')
+            parts.append(chunk)
+            total += len(chunk)
+            i += 1
+        parts.append("}\n")
+        return "".join(parts)
+
+    large = build_large_vcl(100 * 1024)
+    print(f"\n== stress: {len(large) // 1024} KiB VCL, repeated format+lint in one instance ==")
+    stress_calls = 0
+    for _ in range(6):
+        f = fmt(store, large, "")
+        assert f.tag == "ok" and f.payload, "stress: format failed on large VCL"
+        r = lint(store, large, "")
+        assert r.tag == "ok" and json.loads(r.payload)["Errors"] == 0, "stress: lint failed on clean large VCL"
+        # Interleave a small input so the arena high-water mark swings widely.
+        assert fmt(store, source, "").tag == "ok"
+        assert lint(store, source, "").tag == "ok"
+        stress_calls += 4
+    print(f"  survived {stress_calls} calls (6 large format+lint pairs + small mix), no crash")
+
+    print("\nOK: lint + format called repeatedly from one instantiation")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cmd/falco-component/main.go
+++ b/cmd/falco-component/main.go
@@ -1,0 +1,400 @@
+//go:build wasip1 && wasm
+
+// Command falco-component is a WASI Component Model ("reactor") build of falco
+// exposing lint / format / parse / tokenize as typed WIT functions (wit/falco.wit).
+// It is string-in / string-out: the host instantiates it once and calls the
+// exports repeatedly.
+// The canonical-ABI glue lives in abi.go; this file holds the do* implementations.
+// See docs/wasm-component.md.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/ysugimoto/falco/v2/ast"
+	"github.com/ysugimoto/falco/v2/config"
+	"github.com/ysugimoto/falco/v2/formatter"
+	"github.com/ysugimoto/falco/v2/lexer"
+	"github.com/ysugimoto/falco/v2/linter"
+	lcontext "github.com/ysugimoto/falco/v2/linter/context"
+	"github.com/ysugimoto/falco/v2/parser"
+	"github.com/ysugimoto/falco/v2/resolver"
+	"github.com/ysugimoto/falco/v2/token"
+)
+
+// inputName is the synthetic file name used as the map key in output, standing
+// in for the absent filesystem so the RunnerResult JSON shape is preserved.
+const inputName = "input.vcl"
+
+// VCL mirrors cmd/falco.VCL so the serialized JSON shape is identical.
+type VCL struct {
+	File string
+	AST  *ast.VCL
+}
+
+// RunnerResult mirrors cmd/falco.RunnerResult (the struct `lint -json`
+// serializes) so the emitted JSON shape matches. Kept in sync with
+// cmd/falco/runner.go.
+type RunnerResult struct {
+	Infos    int
+	Warnings int
+	Errors   int
+
+	LintErrors  map[string][]*linter.LintError
+	ParseErrors map[string]*parser.ParseError
+
+	Vcl *VCL
+}
+
+// lintOptions is the JSON decoded from the WIT `options` argument of lint.
+// Includes/IncludePaths let the host resolve `include` statements without a
+// filesystem by supplying each reachable module's source up front; the
+// component discovers transitive includes itself.
+type lintOptions struct {
+	Scope        string            `json:"scope"`
+	Rules        map[string]string `json:"rules"`
+	Includes     map[string]string `json:"includes"`
+	IncludePaths []string          `json:"includePaths"`
+}
+
+// main never completes: this is a -buildmode=c-shared reactor, so the host runs
+// package init and then calls the //go:wasmexport functions in abi.go directly.
+func main() {}
+
+// recoverPanic converts a panic in a do* function into a WIT `err` so one
+// malformed request cannot trap and brick the reactor for later calls.
+func recoverPanic(out *string, err *error) {
+	if r := recover(); r != nil {
+		*out = ""
+		*err = fmt.Errorf("panic: %v", r)
+	}
+}
+
+// doLint lints source in-memory and returns the RunnerResult as JSON. A parse
+// error is reported through ParseErrors (matching native `lint -json`), so it
+// is a normal `ok` payload rather than a WIT `err`.
+func doLint(source, options string) (out string, err error) {
+	defer recoverPanic(&out, &err)
+	opts, err := decodeLintOptions(options)
+	if err != nil {
+		return "", err
+	}
+
+	result := &RunnerResult{
+		LintErrors:  map[string][]*linter.LintError{},
+		ParseErrors: map[string]*parser.ParseError{},
+	}
+
+	vcl, perr := parseSource(source)
+	if perr != nil {
+		var pe *parser.ParseError
+		if errors.As(perr, &pe) {
+			// Key by pe.Token.File, matching cmd/falco/runner.go.
+			result.ParseErrors[pe.Token.File] = pe
+			return marshal(result)
+		}
+		return "", perr
+	}
+
+	// An empty config produces the full diagnostic set; severity overrides are
+	// applied below via buildOverrides.
+	lc := &config.LinterConfig{}
+
+	// Resolve `include` statements against the host-supplied module map. With no
+	// includes this behaves like an empty resolver (an include fails to resolve).
+	ctx := lcontext.New(lcontext.WithResolver(
+		resolver.NewMapResolver(inputName, source, opts.Includes, opts.IncludePaths),
+	))
+	if opts.Scope != "" {
+		scope := parseScope(opts.Scope)
+		if scope == 0 {
+			return "", fmt.Errorf("unknown scope %q", opts.Scope)
+		}
+		ctx.Scope(scope)
+	}
+
+	lt := linter.New(lc)
+	lt.Lint(vcl, ctx)
+
+	if lt.FatalError != nil {
+		var pe *parser.ParseError
+		if errors.As(lt.FatalError.Error, &pe) {
+			result.ParseErrors[pe.Token.File] = pe
+			return marshal(result)
+		}
+		// Surface a non-parse fatal error as a WIT err so it stays visible to the
+		// host rather than returning an empty, clean-looking result.
+		return "", fmt.Errorf("lint failed: %w", lt.FatalError.Error)
+	}
+
+	overrides, err := buildOverrides(opts.Rules)
+	if err != nil {
+		return "", err
+	}
+	for _, le := range lt.Errors {
+		severity := le.Severity
+		if v, found := overrides[string(le.Rule)]; found {
+			severity = v
+		}
+		if severity == linter.IGNORE {
+			continue
+		}
+		if le.Token.File == "" {
+			le.Token.File = inputName
+		}
+		result.LintErrors[le.Token.File] = append(result.LintErrors[le.Token.File], le)
+		switch severity {
+		case linter.ERROR:
+			result.Errors++
+		case linter.WARNING:
+			result.Warnings++
+		case linter.INFO:
+			result.Infos++
+		}
+	}
+
+	result.Vcl = &VCL{File: inputName, AST: vcl}
+	return marshal(result)
+}
+
+// doFormat formats source and returns the formatted VCL string.
+func doFormat(source, confJSON string) (out string, err error) {
+	defer recoverPanic(&out, &err)
+	conf := defaultFormatConfig()
+	if err := applyFormatConfig(conf, confJSON); err != nil {
+		return "", err
+	}
+
+	vcl, perr := parseSource(source)
+	if perr != nil {
+		return "", fmt.Errorf("parse error: %w", perr)
+	}
+
+	reader := formatter.New(conf).Format(vcl)
+	if reader == nil {
+		return "", errors.New("format failed: unsupported AST structure")
+	}
+	formatted, err := io.ReadAll(reader)
+	if err != nil {
+		return "", fmt.Errorf("format error: %w", err)
+	}
+	return string(formatted), nil
+}
+
+// doParse parses source and returns the AST as JSON.
+func doParse(source string) (out string, err error) {
+	defer recoverPanic(&out, &err)
+	vcl, perr := parseSource(source)
+	if perr != nil {
+		return "", fmt.Errorf("parse error: %w", perr)
+	}
+	return marshal(vcl)
+}
+
+// Token mirrors ./cmd/wasm.Token so the per-token JSON shape matches the JS
+// build. Per wit/falco.wit, tokenize returns a bare JSON array (no envelope).
+type Token struct {
+	Type     string `json:"type"`
+	Literal  string `json:"literal"`
+	Line     int    `json:"line"`
+	Position int    `json:"position"`
+	Category string `json:"category"`
+}
+
+// doTokenize lexes source and returns the tokens as a JSON array.
+func doTokenize(source string) (out string, err error) {
+	defer recoverPanic(&out, &err)
+	lx := lexer.NewFromString(source, lexer.WithFile(inputName))
+	tokens := []Token{} // non-nil so empty input marshals to `[]`, not `null`
+	for {
+		tok := lx.NextToken()
+		if tok.Type == token.EOF {
+			break
+		}
+		tokens = append(tokens, Token{
+			Type:     string(tok.Type),
+			Literal:  tok.Literal,
+			Line:     tok.Line,
+			Position: tok.Position,
+			Category: token.Category(tok.Type),
+		})
+	}
+	return marshal(tokens)
+}
+
+func parseSource(source string) (*ast.VCL, error) {
+	lx := lexer.NewFromString(source, lexer.WithFile(inputName))
+	return parser.New(lx).ParseVCLOrSnippet()
+}
+
+func decodeLintOptions(s string) (lintOptions, error) {
+	var o lintOptions
+	if strings.TrimSpace(s) == "" {
+		return o, nil
+	}
+	if err := json.Unmarshal([]byte(s), &o); err != nil {
+		return o, fmt.Errorf("invalid lint options JSON: %w", err)
+	}
+	return o, nil
+}
+
+// buildOverrides maps JSON rule-severity strings to linter severities. An
+// unrecognized value errors out: the component has no stderr channel, so a
+// silently-ignored typo would leave a host's rule config a no-op with no signal.
+func buildOverrides(rules map[string]string) (map[string]linter.Severity, error) {
+	overrides := map[string]linter.Severity{}
+	for key, value := range rules {
+		switch strings.ToUpper(value) {
+		case "ERROR":
+			overrides[key] = linter.ERROR
+		case "WARNING":
+			overrides[key] = linter.WARNING
+		case "INFO":
+			overrides[key] = linter.INFO
+		case "IGNORE":
+			overrides[key] = linter.IGNORE
+		default:
+			return nil, fmt.Errorf("invalid severity %q for rule %q (want ERROR|WARNING|INFO|IGNORE)", value, key)
+		}
+	}
+	return overrides, nil
+}
+
+func marshal(v any) (string, error) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func parseScope(s string) int {
+	switch strings.ToLower(s) {
+	case "recv":
+		return lcontext.RECV
+	case "hash":
+		return lcontext.HASH
+	case "hit":
+		return lcontext.HIT
+	case "miss":
+		return lcontext.MISS
+	case "pass":
+		return lcontext.PASS
+	case "fetch":
+		return lcontext.FETCH
+	case "error":
+		return lcontext.ERROR
+	case "deliver":
+		return lcontext.DELIVER
+	case "log":
+		return lcontext.LOG
+	case "pipe":
+		return lcontext.PIPE
+	default:
+		return 0
+	}
+}
+
+func defaultFormatConfig() *config.FormatConfig {
+	return &config.FormatConfig{
+		IndentWidth:                2,
+		IndentStyle:                config.IndentStyleSpace,
+		TrailingCommentWidth:       1,
+		LineWidth:                  120,
+		ExplicitStringConcat:       true,
+		ReturnStatementParenthesis: true,
+		CommentStyle:               config.CommentStyleNone,
+		BreakCompoundConditions:    true,
+	}
+}
+
+// formatConfigJSON mirrors the FormatOptions field names accepted by ./cmd/wasm.
+type formatConfigJSON struct {
+	IndentWidth              *int    `json:"indentWidth"`
+	IndentStyle              *string `json:"indentStyle"`
+	LineWidth                *int    `json:"lineWidth"`
+	ExplicitStringConcat     *bool   `json:"explicitStringConcat"`
+	SortDeclarationProperty  *bool   `json:"sortDeclarationProperty"`
+	AlignDeclarationProperty *bool   `json:"alignDeclarationProperty"`
+	ElseIf                   *bool   `json:"elseIf"`
+	AlwaysNextLineElseIf     *bool   `json:"alwaysNextLineElseIf"`
+	ReturnStatementParen     *bool   `json:"returnStatementParen"`
+	SortDeclaration          *bool   `json:"sortDeclaration"`
+	AlignTrailingComment     *bool   `json:"alignTrailingComment"`
+	CommentStyle             *string `json:"commentStyle"`
+	ShouldUseUnset           *bool   `json:"shouldUseUnset"`
+	IndentCaseLabels         *bool   `json:"indentCaseLabels"`
+	BreakCompoundConditions  *bool   `json:"breakCompoundConditions"`
+}
+
+func applyFormatConfig(conf *config.FormatConfig, s string) error {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	var o formatConfigJSON
+	if err := json.Unmarshal([]byte(s), &o); err != nil {
+		return fmt.Errorf("invalid format config JSON: %w", err)
+	}
+	if o.IndentWidth != nil {
+		conf.IndentWidth = *o.IndentWidth
+	}
+	if o.IndentStyle != nil {
+		switch *o.IndentStyle {
+		case config.IndentStyleSpace, config.IndentStyleTab:
+			conf.IndentStyle = *o.IndentStyle
+		default:
+			return fmt.Errorf("invalid indentStyle %q (want %q or %q)",
+				*o.IndentStyle, config.IndentStyleSpace, config.IndentStyleTab)
+		}
+	}
+	if o.LineWidth != nil {
+		conf.LineWidth = *o.LineWidth
+	}
+	if o.ExplicitStringConcat != nil {
+		conf.ExplicitStringConcat = *o.ExplicitStringConcat
+	}
+	if o.SortDeclarationProperty != nil {
+		conf.SortDeclarationProperty = *o.SortDeclarationProperty
+	}
+	if o.AlignDeclarationProperty != nil {
+		conf.AlignDeclarationProperty = *o.AlignDeclarationProperty
+	}
+	if o.ElseIf != nil {
+		conf.ElseIf = *o.ElseIf
+	}
+	if o.AlwaysNextLineElseIf != nil {
+		conf.AlwaysNextLineElseIf = *o.AlwaysNextLineElseIf
+	}
+	if o.ReturnStatementParen != nil {
+		conf.ReturnStatementParenthesis = *o.ReturnStatementParen
+	}
+	if o.SortDeclaration != nil {
+		conf.SortDeclaration = *o.SortDeclaration
+	}
+	if o.AlignTrailingComment != nil {
+		conf.AlignTrailingComment = *o.AlignTrailingComment
+	}
+	if o.CommentStyle != nil {
+		switch *o.CommentStyle {
+		case config.CommentStyleNone, config.CommentStyleSlash, config.CommentStyleSharp:
+			conf.CommentStyle = *o.CommentStyle
+		default:
+			return fmt.Errorf("invalid commentStyle %q (want %q, %q or %q)", *o.CommentStyle,
+				config.CommentStyleNone, config.CommentStyleSlash, config.CommentStyleSharp)
+		}
+	}
+	if o.ShouldUseUnset != nil {
+		conf.ShouldUseUnset = *o.ShouldUseUnset
+	}
+	if o.IndentCaseLabels != nil {
+		conf.IndentCaseLabels = *o.IndentCaseLabels
+	}
+	if o.BreakCompoundConditions != nil {
+		conf.BreakCompoundConditions = *o.BreakCompoundConditions
+	}
+	return nil
+}

--- a/cmd/falco-component/main_test.go
+++ b/cmd/falco-component/main_test.go
@@ -1,0 +1,274 @@
+//go:build wasip1 && wasm
+
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/ysugimoto/falco/v2/config"
+	"github.com/ysugimoto/falco/v2/linter"
+	lcontext "github.com/ysugimoto/falco/v2/linter/context"
+	"github.com/ysugimoto/falco/v2/parser"
+)
+
+const cleanVCL = "sub vcl_recv {\n#FASTLY RECV\n  set req.http.X-Example = \"hello\";\n}\n"
+
+// testResult mirrors RunnerResult's diagnostic fields but keeps Vcl opaque
+// (its AST holds an interface that cannot be unmarshaled back from JSON). The
+// here we only assert diagnostics.
+type testResult struct {
+	Infos       int
+	Warnings    int
+	Errors      int
+	LintErrors  map[string][]*linter.LintError
+	ParseErrors map[string]*parser.ParseError
+	Vcl         json.RawMessage
+}
+
+// unmarshalResult decodes a doLint payload into a testResult.
+func unmarshalResult(t *testing.T, out string) testResult {
+	t.Helper()
+	var r testResult
+	if err := json.Unmarshal([]byte(out), &r); err != nil {
+		t.Fatalf("unmarshal RunnerResult: %v\npayload: %s", err, out)
+	}
+	return r
+}
+
+// TestDoLintClean lints a valid recv subroutine and expects an `ok` payload with
+// no parse errors and no error-severity diagnostics.
+func TestDoLintClean(t *testing.T) {
+	out, err := doLint(cleanVCL, "")
+	if err != nil {
+		t.Fatalf("doLint error: %v", err)
+	}
+	r := unmarshalResult(t, out)
+	if len(r.ParseErrors) != 0 {
+		t.Fatalf("unexpected parse errors: %+v", r.ParseErrors)
+	}
+	if r.Errors != 0 {
+		t.Fatalf("expected 0 errors on clean VCL, got %d", r.Errors)
+	}
+}
+
+// TestDoLintLintError keys lint diagnostics under the synthetic input name and
+// returns them as an `ok` payload (not a WIT err).
+func TestDoLintLintError(t *testing.T) {
+	src := "sub vcl_recv {\n#FASTLY RECV\n  set req.http.X-Bad = obj.does_not_exist;\n}\n"
+	out, err := doLint(src, "")
+	if err != nil {
+		t.Fatalf("doLint error: %v", err)
+	}
+	r := unmarshalResult(t, out)
+	if len(r.LintErrors[inputName]) == 0 {
+		t.Fatalf("expected lint diagnostics keyed by %q, got %+v", inputName, r.LintErrors)
+	}
+}
+
+// TestDoLintParseErrorIsOkPayload routes a parse error through ParseErrors as an
+// `ok` payload, matching native `lint -json`.
+func TestDoLintParseErrorIsOkPayload(t *testing.T) {
+	out, err := doLint("sub vcl_recv {", "")
+	if err != nil {
+		t.Fatalf("doLint should not WIT-err on a parse error: %v", err)
+	}
+	r := unmarshalResult(t, out)
+	if r.ParseErrors[inputName] == nil {
+		t.Fatalf("expected ParseErrors[%q], got %+v", inputName, r.ParseErrors)
+	}
+}
+
+// TestDoLintRuleOverride downgrades a diagnostic to IGNORE and confirms it is
+// dropped from the counts.
+func TestDoLintRuleOverride(t *testing.T) {
+	src := "sub vcl_recv {\n#FASTLY RECV\n  set req.http.X-Bad = obj.does_not_exist;\n}\n"
+	out, err := doLint(src, "")
+	if err != nil {
+		t.Fatalf("doLint error: %v", err)
+	}
+	base := unmarshalResult(t, out)
+	var rule string
+	for _, les := range base.LintErrors {
+		if len(les) > 0 {
+			rule = string(les[0].Rule)
+			break
+		}
+	}
+	if rule == "" {
+		t.Skip("no rule-tagged diagnostic to override")
+	}
+	opts := `{"rules":{"` + rule + `":"IGNORE"}}`
+	out2, err := doLint(src, opts)
+	if err != nil {
+		t.Fatalf("doLint (override) error: %v", err)
+	}
+	r2 := unmarshalResult(t, out2)
+	for _, le := range r2.LintErrors[inputName] {
+		if string(le.Rule) == rule {
+			t.Fatalf("rule %q should have been ignored, still present", rule)
+		}
+	}
+}
+
+// TestDoLintResolvesIncludeFromOptions resolves a top-level include against the
+// host-supplied includes map. A provided module resolves cleanly; a missing one
+// surfaces an in-band diagnostic (it does not trap or WIT-err).
+func TestDoLintResolvesIncludeFromOptions(t *testing.T) {
+	src := `include "sub_mod";`
+	opts := `{"includes":{"sub_mod":"sub vcl_recv {\n#FASTLY RECV\n}"}}`
+	out, err := doLint(src, opts)
+	if err != nil {
+		t.Fatalf("doLint with provided include should resolve: %v", err)
+	}
+	r := unmarshalResult(t, out)
+	if len(r.ParseErrors) != 0 {
+		t.Fatalf("provided include should not produce parse errors: %+v", r.ParseErrors)
+	}
+
+	out2, err := doLint(src, "")
+	if err != nil {
+		t.Fatalf("missing include should be in-band, not a WIT err: %v", err)
+	}
+	r2 := unmarshalResult(t, out2)
+	if len(r2.LintErrors) == 0 && len(r2.ParseErrors) == 0 {
+		t.Fatal("missing include should produce a diagnostic")
+	}
+}
+
+// TestDoLintRejectsUnknownScope surfaces an unknown scope as a WIT err.
+func TestDoLintRejectsUnknownScope(t *testing.T) {
+	if _, err := doLint(cleanVCL, `{"scope":"bogus"}`); err == nil {
+		t.Fatal("expected err for unknown scope")
+	}
+}
+
+// TestDoFormat formats valid VCL and rejects unparseable input.
+func TestDoFormat(t *testing.T) {
+	out, err := doFormat(cleanVCL, "")
+	if err != nil {
+		t.Fatalf("doFormat error: %v", err)
+	}
+	if !strings.Contains(out, "vcl_recv") {
+		t.Fatalf("formatted output missing subroutine: %q", out)
+	}
+	if _, err := doFormat("sub vcl_recv {", ""); err == nil {
+		t.Fatal("expected parse error from doFormat on invalid input")
+	}
+}
+
+// TestDoParse returns a JSON AST for valid input and errs on invalid input.
+func TestDoParse(t *testing.T) {
+	out, err := doParse(cleanVCL)
+	if err != nil {
+		t.Fatalf("doParse error: %v", err)
+	}
+	if !json.Valid([]byte(out)) {
+		t.Fatalf("doParse output is not valid JSON: %q", out)
+	}
+	if _, err := doParse("sub vcl_recv {"); err == nil {
+		t.Fatal("expected parse error from doParse on invalid input")
+	}
+}
+
+// TestDoTokenize returns a JSON token array, and `[]` (not null) for empty input.
+func TestDoTokenize(t *testing.T) {
+	out, err := doTokenize(cleanVCL)
+	if err != nil {
+		t.Fatalf("doTokenize error: %v", err)
+	}
+	var toks []Token
+	if err := json.Unmarshal([]byte(out), &toks); err != nil {
+		t.Fatalf("unmarshal tokens: %v", err)
+	}
+	if len(toks) == 0 {
+		t.Fatal("expected tokens for non-empty input")
+	}
+	// cleanVCL starts with `sub`; assert the shared token.Category mapping is
+	// applied (the field is otherwise never checked).
+	if toks[0].Category != "keyword" {
+		t.Fatalf("first token category = %q, want \"keyword\"", toks[0].Category)
+	}
+
+	empty, err := doTokenize("")
+	if err != nil {
+		t.Fatalf("doTokenize(\"\") error: %v", err)
+	}
+	if empty != "[]" {
+		t.Fatalf("empty input should tokenize to [], got %q", empty)
+	}
+}
+
+// TestDoLintRejectsInvalidRuleSeverity surfaces a typo'd rule severity as a WIT
+// err rather than silently ignoring it (the component has no stderr channel).
+func TestDoLintRejectsInvalidRuleSeverity(t *testing.T) {
+	if _, err := doLint(cleanVCL, `{"rules":{"some/rule":"warn"}}`); err == nil {
+		t.Fatal("expected err for invalid rule severity value")
+	}
+}
+
+// TestRecoverPanic verifies a panic in a do* function surfaces as a WIT err
+// instead of an unrecoverable reactor trap.
+func TestRecoverPanic(t *testing.T) {
+	out, err := func() (out string, err error) {
+		defer recoverPanic(&out, &err)
+		panic("boom")
+	}()
+	if err == nil {
+		t.Fatal("expected a recovered panic to surface as an error")
+	}
+	if !strings.Contains(err.Error(), "panic:") {
+		t.Fatalf("recovered error should be tagged as a panic, got %q", err.Error())
+	}
+	if out != "" {
+		t.Fatalf("out should be cleared on panic, got %q", out)
+	}
+}
+
+func TestParseScope(t *testing.T) {
+	if parseScope("recv") != lcontext.RECV {
+		t.Fatal("recv scope mismatch")
+	}
+	if parseScope("FETCH") != lcontext.FETCH {
+		t.Fatal("scope match should be case-insensitive")
+	}
+	if parseScope("bogus") != 0 {
+		t.Fatal("unknown scope should be 0")
+	}
+}
+
+func TestDecodeLintOptions(t *testing.T) {
+	if _, err := decodeLintOptions("   "); err != nil {
+		t.Fatalf("blank options should decode to zero value: %v", err)
+	}
+	o, err := decodeLintOptions(`{"scope":"recv","includePaths":["a","b"]}`)
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if o.Scope != "recv" || len(o.IncludePaths) != 2 {
+		t.Fatalf("unexpected options: %+v", o)
+	}
+	if _, err := decodeLintOptions("{not json"); err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestApplyFormatConfig(t *testing.T) {
+	conf := defaultFormatConfig()
+	if err := applyFormatConfig(conf, `{"indentWidth":4,"indentStyle":"tab"}`); err != nil {
+		t.Fatalf("applyFormatConfig error: %v", err)
+	}
+	if conf.IndentWidth != 4 || conf.IndentStyle != config.IndentStyleTab {
+		t.Fatalf("config not applied: %+v", conf)
+	}
+	if err := applyFormatConfig(conf, "{bad"); err == nil {
+		t.Fatal("expected error for invalid format config JSON")
+	}
+	if err := applyFormatConfig(defaultFormatConfig(), `{"indentStyle":"spaces"}`); err == nil {
+		t.Fatal("expected error for invalid indentStyle value")
+	}
+	if err := applyFormatConfig(defaultFormatConfig(), `{"commentStyle":"bogus"}`); err == nil {
+		t.Fatal("expected error for invalid commentStyle value")
+	}
+}

--- a/cmd/falco-component/testdata/lint-error.vcl
+++ b/cmd/falco-component/testdata/lint-error.vcl
@@ -1,0 +1,5 @@
+sub vcl_recv {
+#FASTLY RECV
+  set req.http.X-Bad = obj.does_not_exist;
+  call undefined_subroutine;
+}

--- a/cmd/falco-component/testdata/sample.vcl
+++ b/cmd/falco-component/testdata/sample.vcl
@@ -1,0 +1,7 @@
+sub vcl_recv {
+#FASTLY RECV
+  set req.http.X-Example = "hello";
+  if (req.url ~ "^/admin") {
+    set req.http.X-Admin = "1";
+  }
+}

--- a/cmd/wasm/api.go
+++ b/cmd/wasm/api.go
@@ -68,7 +68,7 @@ func tokenize(_ js.Value, args []js.Value) any {
 			Literal:  tok.Literal,
 			Line:     tok.Line,
 			Position: tok.Position,
-			Category: tokenCategory(tok.Type),
+			Category: token.Category(tok.Type),
 		})
 	}
 
@@ -190,67 +190,6 @@ func toJS(v any) any {
 		return js.Global().Get("JSON").Call("parse", `{"error":"JSON marshal failed"}`)
 	}
 	return js.Global().Get("JSON").Call("parse", string(data))
-}
-
-// tokenCategory maps token types to semantic categories for syntax highlighting.
-func tokenCategory(tt token.TokenType) string {
-	switch tt {
-	// Keywords
-	case token.ACL, token.BACKEND, token.DIRECTOR, token.TABLE, token.SUBROUTINE,
-		token.ADD, token.CALL, token.DECLARE, token.ERROR, token.ESI,
-		token.INCLUDE, token.IMPORT, token.LOG, token.REMOVE, token.RESTART,
-		token.RETURN, token.SET, token.SYNTHETIC, token.SYNTHETIC_BASE64, token.UNSET,
-		token.IF, token.ELSE, token.ELSEIF, token.ELSIF,
-		token.PENALTYBOX, token.RATECOUNTER, token.GOTO,
-		token.SWITCH, token.CASE, token.DEFAULT, token.BREAK, token.FALLTHROUGH,
-		token.PRAGMA:
-		return "keyword"
-
-	// Strings
-	case token.STRING, token.OPEN_LONG_STRING, token.CLOSE_LONG_STRING:
-		return "string"
-
-	// Numbers
-	case token.INT, token.FLOAT, token.RTIME:
-		return "number"
-
-	// Booleans
-	case token.TRUE, token.FALSE:
-		return "boolean"
-
-	// Identifiers
-	case token.IDENT:
-		return "variable"
-
-	// Operators
-	case token.EQUAL, token.NOT_EQUAL, token.REGEX_MATCH, token.NOT_REGEX_MATCH,
-		token.GREATER_THAN, token.LESS_THAN, token.GREATER_THAN_EQUAL, token.LESS_THAN_EQUAL,
-		token.AND, token.OR, token.NOT,
-		token.ASSIGN, token.ADDITION, token.SUBTRACTION, token.MULTIPLICATION,
-		token.DIVISION, token.REMAINDER,
-		token.BITWISE_OR, token.BITWISE_AND, token.BITWISE_XOR,
-		token.LEFT_SHIFT, token.RIGHT_SHIFT, token.LEFT_ROTATE, token.RIGHT_ROTATE,
-		token.LOGICAL_AND, token.LOGICAL_OR,
-		token.PLUS, token.MINUS, token.SLASH, token.PERCENT:
-		return "operator"
-
-	// Comments
-	case token.COMMENT:
-		return "comment"
-
-	// Punctuation
-	case token.LEFT_BRACE, token.RIGHT_BRACE, token.LEFT_PAREN, token.RIGHT_PAREN,
-		token.LEFT_BRACKET, token.RIGHT_BRACKET, token.COMMA, token.SEMICOLON,
-		token.DOT, token.COLON:
-		return "punctuation"
-
-	// Control
-	case token.FASTLY_CONTROL:
-		return "control"
-
-	default:
-		return "text"
-	}
 }
 
 // parseScope converts a scope string to the context scope constant.

--- a/config/config.go
+++ b/config/config.go
@@ -225,12 +225,14 @@ func findConfigFile() (string, error) {
 			}
 		}
 
-		cwd = filepath.Dir(cwd)
-		if cwd == "/" {
-			// find up to root directory, stop it
-			// @FIXME: on windows?
+		// Ascend to the parent and stop when we can no longer ascend. filepath.Dir
+		// is idempotent at a filesystem root and, under WASI, at "." too; breaking
+		// only on "/" would loop forever there.
+		parent := filepath.Dir(cwd)
+		if parent == cwd {
 			break
 		}
+		cwd = parent
 	}
 
 	// not found

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -112,3 +112,26 @@ func TestConfigFromEnv(t *testing.T) {
 		t.Errorf("Unmatched FastlyApiKey field, expect=%s, got=%s", "example_api_key", c.FastlyApiKey)
 	}
 }
+
+// TestFindConfigFileAscendsToRoot verifies the platform-agnostic ascent
+// termination (parent == cwd): from a temp dir with no config above it,
+// findConfigFile must ascend to the root, stop, and return ("", nil) — not hang.
+func TestFindConfigFileAscendsToRoot(t *testing.T) {
+	dir := t.TempDir()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+
+	got, err := findConfigFile()
+	if err != nil {
+		t.Fatalf("findConfigFile error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("expected no config file found, got %q", got)
+	}
+}

--- a/docs/wasm-component.md
+++ b/docs/wasm-component.md
@@ -1,0 +1,358 @@
+# A WIT / Component-Model build of falco (lint + format)
+
+Status: **supported build target.** This ships a real feature: a
+`make wasm-component` target, a stable WIT contract (`wit/falco.wit`), three host
+smoke tests, canonical-ABI unit tests, and the reference documentation below. It
+documents how falco ships as a single WebAssembly **component** with one WIT
+interface consumed by many hosts.
+
+## Host requirements (read before embedding)
+
+The canonical-ABI glue (`cmd/falco-component/abi.go`) relies on a single,
+synchronously-read return area and shared package-level state. Hosts MUST:
+
+- **Lift each result synchronously**, before issuing the next export call. There
+  is no `cabi_post`; the next call's `lowerResult` overwrites the return area and
+  the payload's backing string. A host that pipelines or defers the copy reads
+  corrupted bytes.
+- **Not share one instance across threads.** The reactor is single-threaded and
+  its arena/return-area globals are unsynchronized (no wasi-threads).
+- **Be prepared to re-instantiate** on a trap. Oversized input can exhaust the
+  16 MiB arena during the host's argument lowering, which traps the instance for
+  every subsequent call (see the `arenaSize` doc in `abi.go`).
+
+These also depend on Go's current non-moving GC (the return-area pointer is not
+relocated between an export's return and the host's lift); a future moving
+collector would break this.
+
+## Parse-error signal matrix
+
+The JSON *shape* of a `lint` result is identical across both remaining builds
+(native and the component), but the out-of-band signal for a
+JSON-mode parse error differs by design — do not assume parity:
+
+| Build              | JSON-mode parse error signal                      |
+| ------------------ | ------------------------------------------------- |
+| native `falco`     | exit 0 (parse errors do not increment `Errors`)   |
+| component (`lint`) | `ok` payload with `ParseErrors` populated; no exit |
+
+In every case the `ParseErrors` map carries the diagnostic, so a consumer that
+parses the payload sees the same data.
+
+
+## TL;DR recommendation
+
+Build the component from **standard Go** (`GOOS=wasip1 GOARCH=wasm`,
+`-buildmode=c-shared` reactor) plus **`wasm-tools component new`** with the
+`wasi_snapshot_preview1` reactor adapter. Hand-write the canonical-ABI glue
+(`cmd/falco-component/abi.go`); do **not** use TinyGo and do **not** rely on
+`wit-bindgen-go`'s generated wrappers.
+
+This produces a working, validated component (`wasm/falco-component.wasm`,
+~9.5 MB — comparable to the 9 MB `falco.wasm`) in the `falco` world
+exporting `lint`, `format`, `parse`, `tokenize` as **world-root** functions. It
+is proven callable, reactor-style (one instantiation, repeated calls, no temp
+files, no stdout capture), from three hosts:
+
+- **Python `wasmtime`** embedding (`cmd/falco-component/hosts/python/smoke.py`)
+- **JS via `jco transpile`** on Node (`cmd/falco-component/hosts/js/smoke.mjs`)
+- **Ruby `wasmtime` gem** (wasmtime-rb), the host that requires the root-export
+  shape — see *WIT design* below
+
+`make wasm-component` builds it. The existing `wasm` (js) build
+is untouched.
+
+## Why not the other paths — the deciding evidence
+
+The brief proposed two turn-key paths. **Both are blocked today**, so the
+viable route is standard Go with hand-rolled ABI glue.
+
+### TinyGo + wit-bindgen-go: cannot compile falco
+
+Empirically attempted (`tinygo 0.41.1`, `tinygo build -target=wasip1 ./cmd/falco-component`):
+
+```
+linter/types/types.go:23:25: cannot use 0x000000100000000 (untyped int
+  constant 4294967296) as Type value in constant declaration (overflows)
+... (continues for StringType .. RegexType)
+```
+
+`linter/types` defines `type Type int` with bit-flag constants up to
+`0x100000000100000` (≈ 7.2e16). Standard Go's `GOARCH=wasm` uses a **64-bit
+`int`**, so these compile. **TinyGo's wasm `int` is 32-bit**, so every constant
+above `2^32` overflows at compile time. This is a structural dependency on
+64-bit `int` across the linter's type system; supporting TinyGo would require
+changing `Type` to `uint64` and auditing all usages — a core change made solely
+to satisfy a toolchain.
+
+And that is only the *first* blocker. falco's regex support comes from
+`go.elara.ws/pcre` (replaced by `github.com/dip-proto/go-pcre`), whose non-JS
+build tag routes through `modernc.org/libc` — which TinyGo also does not
+support. The 64-bit-`int` failure halts the build before pcre is even reached.
+
+> TinyGo's `wasip2` target reports `GOOS=linux GOARCH=arm` (a TinyGo quirk), so
+> a `//go:build wasip1 && wasm` constraint excludes all files under it. Use
+> `-target=wasip1` to actually exercise compilation.
+
+### Standard Go + wit-bindgen-go: cannot emit the `result<>` cabi
+
+`wit-bindgen-go v0.7.0` generates cabi wrappers that **return `*cm.Result[...]`**.
+Standard Go's `//go:wasmexport` rejects pointer-to-struct results:
+
+```
+gen/.../vcl.wasm.go:13:6: go:wasmexport: unsupported result type
+  *cm.Result[string,string,string]
+```
+
+And even setting that aside, `wit-bindgen-go`'s own README warns:
+
+> Package `cm` and generated bindings ... may have compatibility issues with the
+> Go garbage collector ... In Go (but not TinyGo), the GC may detect ... a
+> non-pointer value in an area it expects to see a pointer. This is an area of
+> active development.
+
+So `wit-bindgen-go` targets TinyGo; its standard-Go support for `variant`/
+`result` types is not production-ready.
+
+### The viable path: standard Go + hand-rolled canonical ABI
+
+Standard Go compiles **all** of falco for `wasip1` in <1s (the component
+build itself does). And `//go:wasmexport` + `-buildmode=c-shared`
+produces a valid reactor. The only gap is the canonical-ABI lift/lower for
+strings and `result<string, string>`. We hand-write it in
+`cmd/falco-component/abi.go`:
+
+- Export `cabi_realloc`, plus `lint`, `format`, `parse`, `tokenize` under their
+  bare (world-root) names.
+- Each export takes `(ptr, len)` `uint32` pairs (the canonical lowering of
+  `string` params) and returns a `uint32` offset to a 12-byte return area
+  (`result<string,string>` = variant of two strings). `uint32` is a permitted
+  `//go:wasmexport` result type, sidestepping the pointer-return restriction.
+- We never touch `cm.Result`, so the GC variant/result issue does not apply.
+
+## Architecture / build pipeline
+
+```
+cmd/falco-component/        (//go:build wasip1 && wasm)
+  main.go   – do{Lint,Format,Parse,Tokenize}: in-memory, string-in, JSON-out
+  abi.go    – hand-rolled canonical-ABI glue (cabi_realloc + 4 wasmexports)
+  testdata/ – sample.vcl, lint-error.vcl
+  hosts/    – python/, js/, and ruby smoke tests (see hosts/README.md)
+wit/falco.wit               – the WIT contract (world `falco`, root func exports)
+```
+
+```
+GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared -o falco-core.wasm ./cmd/falco-component
+wasm-tools component embed wit --world falco falco-core.wasm -o falco-embedded.wasm
+wasm-tools component new  falco-embedded.wasm \
+    --adapt wasi_snapshot_preview1=wasi_snapshot_preview1.reactor.wasm \
+    -o wasm/falco-component.wasm
+wasm-tools validate --features component-model wasm/falco-component.wasm
+```
+
+`make wasm-component` runs exactly this and auto-downloads the preview1 reactor
+adapter (matching the `wasmtime` release) if absent.
+
+## WIT design
+
+See `wit/falco.wit`. All four functions are exported at the **world root**
+(directly under `world falco`, not nested inside an interface) and are
+string-in / string-out:
+
+```wit
+world falco {
+    export lint:     func(source: string, options: string) -> result<string, string>;
+    export format:   func(source: string, config:  string) -> result<string, string>;
+    export parse:    func(source: string)                  -> result<string, string>;
+    export tokenize: func(source: string)                  -> result<string, string>;
+}
+```
+
+### Why root exports, not an interface
+
+The functions originally lived inside an exported `vcl` interface
+(`export vcl;`), surfacing as the interface-qualified core export
+`falco:tools/vcl@0.1.0#lint` etc. That works for jco and the Python `wasmtime`
+embedding, but it is **unreachable from the Ruby `wasmtime` gem**
+(observed on wasmtime-rb 45; unchanged on 46.x). wasmtime-rb's `Wasmtime::Component::Instance` exposes only
+`get_func(name)` (arity 1), which resolves **root-level world exports only** and
+provides **no** export-index / sub-instance accessor to descend into an exported
+interface instance. Every name variant (`"falco:tools/vcl@0.1.0#lint"`,
+`"falco:tools/vcl#lint"`, `"lint"`, …) returned `nil`.
+
+Moving the four functions to world-root exports makes a bare
+`get_func("lint")` resolve in wasmtime-rb, while jco and Python keep working:
+world-root func exports surface as top-level named exports in jco
+(`import { lint } from "./component.js"`) and as top-level world exports in
+Python (`instance.get_export_index(store, "lint")`). The corresponding
+`//go:wasmexport` directives in `abi.go` use the bare core names (`lint`,
+`format`, `parse`, `tokenize`) that `wasm-tools component embed/new` expects for
+world-level func exports.
+
+**`result<_, string>`-wrapped JSON string** (the chosen encoding) was selected
+over native WIT records because it guarantees **zero shape drift**: `lint`'s
+`ok` payload is the *same* `RunnerResult` JSON that `falco lint -json` emits
+(`Infos`/`Warnings`/`Errors`, `LintErrors`/`ParseErrors` keyed by file, each
+error carrying `Severity`, `Message`, `Reference`, `Token.{Line,Position,File}`,
+`Rule`). The Go side reuses the real `linter.LintError` / `parser.ParseError`
+types, so the JSON is byte-shape-identical by construction — downstream
+consumers of the documented contract parse it unchanged. Host bindings map the
+WIT `result` idiomatically: Python returns a `Variant(tag, payload)`; jco
+returns the `ok` string or **throws** on `err`; Ruby returns a
+`Wasmtime::Component::Result` with `ok?`/`ok` and `error?`/`error` accessors
+(`ok` is the success payload string, `error` the failure message). Note that
+wasmtime-rb binds the `Store` when you obtain the func, so you call
+`func.call(arg1, arg2)` with no store argument.
+
+`parse`/`tokenize` are included (the JS build has them; the WASI command build
+does not) because the JSON-string encoding makes them nearly free.
+
+### Config reuse with no filesystem
+
+The component has no filesystem, so options are passed as JSON strings (pass
+`""` for defaults), not via `config.New`/`.falco.yaml`:
+
+- `lint` options: `{ "scope", "rules": {"<rule>":"ERROR|WARNING|INFO|IGNORE"},
+  "includes": {"<module>":"<source>"}, "includePaths": ["<prefix>", ...] }`.
+  Severity overrides reuse the same case-insensitive mapping as
+  `cmd/falco`. An unrecognized `scope` is rejected with `err`.
+- `format` config: the `FormatConfig` fields (`indentWidth`, `indentStyle`,
+  `explicitStringConcat`, `breakCompoundConditions`, `indentCaseLabels`, …),
+  same field names the `cmd/wasm` JS build accepts.
+
+### Include / module resolution
+
+`include` statements resolve against the host-supplied `options.includes` map
+(module-name → source), via `resolver.MapResolver` (a generalization of
+`resolver.StaticResolver`). The component has no filesystem, so the host (e.g. a
+VS Code LSP server, which has filesystem and open-document access) supplies the
+module sources up front; `MapResolver.Resolve` mirrors `FileResolver`'s search
+semantics (optional `.vcl` suffix, each `includePaths` entry tried as a prefix).
+
+**Transitive-include discovery is the component's job, not the host's.** The
+linter recurses through every `include` it parses, calling `Resolve` for each
+(including nested ones), so the host need only supply the *full set of reachable
+module contents* — it does not compute the include graph or ordering. A module
+whose source is missing from the map produces an in-band unresolved-include lint
+error (it does not trap), so omitting `includes` entirely keeps the single-file
+path byte-shape-identical to before.
+
+`LintErrors`/`ParseErrors` are keyed by — and each `Token.File` carries — the
+**real module name** (the matched `includes` key); diagnostics in the top-level
+source keep the synthetic `input.vcl` key.
+
+#### Why a content-map, not a WIT import callback
+
+The alternative — adding `import resolve-include: func(name) ->
+result<string,string>` to world `falco` and resolving lazily — is cleaner and
+fetches only what's needed, but **wasmtime-rb cannot supply a component import
+function**: its `Wasmtime::Component::LinkerInstance` exposes only `instance`
+and `module` (no `add_func`/`func_new`), so a host-defined import of
+`func(string) -> result<string,string>` is unimplementable from Ruby. (jco can
+supply imports, and wasmtime-py's `LinkerInstance` does have `add_func`, but the
+Ruby gap is decisive — Ruby is the same host that forced the world-root export
+shape above.) The content-map design also needs **no ABI/WIT signature change**
+and no import-side canonical-ABI glue in `abi.go`. The cost is that the entire
+include closure travels in one `lint` call's `options` argument; see the arena
+cap note under *Risks / limitations* (≈ 8 MiB combined source ceiling).
+
+## Host consumption
+
+Exact commands and observed output are in
+`cmd/falco-component/hosts/README.md`. All three call `lint` and `format` on the
+same instance repeatedly. jco is the documented JS path; **`node:wasi` is not
+viable** for a component — it implements preview1 *core modules* only and cannot
+instantiate a component.
+
+## Risks / limitations
+
+- **Toolchain maturity.** The clean turn-key paths (TinyGo, `wit-bindgen-go`
+  standard-Go) don't work for falco today. We depend on hand-written ABI glue;
+  if the WIT grows richer types (records, lists, resources) the hand-rolled
+  lift/lower grows too. Re-evaluate `wit-bindgen-go` standard-Go support as it
+  matures.
+- **`cabi_realloc` must avoid the Go heap.** The preview1→preview2 adapter calls
+  `cabi_realloc` **re-entrantly during `_initialize`** (on the runtime system
+  stack, g0). A Go heap allocation there trips `runtime.badsystemstack` and
+  crashes. `abi.go` backs `cabi_realloc` with a fixed **16 MiB static bump
+  arena** instead — which also caps a single call's combined argument size at
+  16 MiB. Oversized input returns a null allocation (a canonical-ABI trap). Bump
+  the constant if larger inputs are needed. **Note for include resolution:**
+  `lint`'s `options.includes` bundles the *entire* multi-file project (main +
+  all reachable modules), JSON-escaped, into one call's `options` string, so the
+  cap bounds the whole closure, not one file. The host's string lowering can
+  transiently double its buffer, so the practical ceiling is ≈ 8 MiB of combined
+  escaped source per `lint` — ample for the LSP use case (a service's full VCL
+  closure is typically well under a megabyte); raise `arenaSize` (BSS, zero file
+  cost) for larger workspaces.
+- **Reactor durability: the arena reset must preserve the adapter's `State`.**
+  This was a real bug. The component is a *reactor* (instantiate once, call
+  repeatedly), but it used to crash after a few non-trivial `format`/`lint`
+  calls in one instantiation. The failure was always inside the preview1 adapter
+  — `assertion failed at adapter line 2857` → `RuntimeError: unreachable` in
+  `wasi_snapshot_preview1::macros::assert_fail`, reached from `clock_time_get`
+  (and `poll_oneoff`) — not in falco code, and reproduced identically from
+  wasmtime and jco hosts. Consumption scaled with *input size × calls*, not pure
+  call count.
+
+  **Root cause (verified by reading the adapter, not by guessing):** the
+  resource exhausted was **not** the Go heap and **not** cumulative adapter-arena
+  growth. The adapter lazily allocates a ~64 KiB `State` struct (with a magic
+  canary `0x216F4F35` at its head and tail) by calling
+  `__main_module__.cabi_realloc` — i.e. **our** static bump arena — on the first
+  preview1 import, and caches a raw pointer to it, re-validating the canary on
+  every later `clock_time_get`/`poll_oneoff`. The old `resetArena()` rewound the
+  bump pointer to `0` after every export call, reclaiming the region holding
+  that persistent `State`. The next call's host-lowered input (written from
+  offset 0) overwrote the `State`, corrupting the canary, so the next clock
+  import tripped the adapter's assertion and trapped the whole instance. (The
+  prior `abi.go` comment explicitly assumed "no import retains a pointer into
+  that region across calls" — that assumption was wrong: the adapter's `State`
+  does.)
+
+  **Fix (chosen over the alternatives below):** `resolveReset`/`resetArena` now
+  latch a **floor** at the first call's high-water mark (which by then covers the
+  adapter's `State` plus that call's inputs) and rewind only to the floor on
+  every subsequent call. `State` is the adapter's *only* persistent
+  `cabi_realloc` allocation, so the floor never needs to grow. **Trade-off:** the
+  first call's input bytes are never reclaimed — a one-time leak bounded by a
+  single input's size (≤ a few MiB), negligible against the 16 MiB arena. The
+  pure `resolveReset` is unit-tested off-target in `abi_test.go`; both host smoke
+  tests gained a stress case (≥ 100 KiB VCL formatted+linted ≥ 5× plus a
+  large/small mix in one instantiation).
+
+  **Alternatives rejected.** (1) *TinyGo core* (the ideal — no preview1 adapter,
+  so the whole bug class disappears, and a far smaller artifact) remains blocked:
+  `modernc.org/memory` (under pcre → `modernc.org/libc`) selects
+  `mmap_linux_32.go`/`mmap_unix.go` on TinyGo's `wasip2` target and needs
+  `syscall.SYS_MMAP2`/`SYS_MUNMAP`, which TinyGo's wasm syscall layer does not
+  provide; standard Go `wasip1` instead compiles `memory.go`'s pure-Go fallback.
+  `linter/types` also overflows TinyGo's 32-bit `int` (see *Why not the other
+  paths*). (2) *Native `GOOS=wasip2`* on Go 1.25 still emits a `wasip1` core that
+  needs the adapter, so it would not avoid the adapter `State` either. The
+  adapter is already the newest release (v46.0.0); a version bump does not help.
+- **No `cabi_post`.** The return area is a static buffer the host reads
+  synchronously; we export no `cabi_post_*`, so there is no per-call free (and
+  no leak — the buffer is reused). Fine for a single-threaded reactor.
+- **`go vet` cosmetic warning.** `abi.go` triggers `possible misuse of
+  unsafe.Pointer` (the `uintptr(unsafe.Pointer(...))` ABI pattern). It is safe
+  here (Go's wasm GC is non-moving; globals keep payloads alive) and does **not**
+  affect `make lint`, since the `wasip1 && wasm` build tag excludes the package
+  from host-platform linting.
+- **Binary size.** ~9.5 MB, in line with `falco.wasm` (9 MB). No regression,
+  but not small.
+- **`wasmtime-go` lag.** Not used here (the Go *host* embedding for components
+  has historically lagged); the wasmtime *Python* and *Rust* embeddings and jco
+  are the mature consumers. The Go side is the *guest*, not a host.
+- **pcre on TinyGo.** Moot given the earlier 64-bit-`int` blocker, but recorded:
+  `modernc.org/libc` (the pcre backend for non-JS targets) is unsupported by
+  TinyGo, so even fixing `linter/types` would not unblock TinyGo.
+
+## Coexistence
+
+`cmd/wasm` (js) and its build are
+unchanged and still build. The component lives in a new `cmd/falco-component`
+package (build-tagged `wasip1 && wasm`, excluded from native `go build ./...`)
+with its own `make wasm-component` target. `go.mod` is unchanged (the temporary
+`go.bytecodealliance.org/cm` dependency was removed once the generated bindings
+were dropped in favor of hand-rolled glue).

--- a/resolver/map.go
+++ b/resolver/map.go
@@ -1,0 +1,106 @@
+package resolver
+
+import (
+	"maps"
+	"path"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/ysugimoto/falco/v2/ast"
+)
+
+// MapResolver resolves a main VCL and its include modules from an in-memory map
+// of module-name -> source, with no filesystem access.
+//
+// It is used by the WASI Component Model build (cmd/falco-component), where the
+// host supplies include contents up front. The component discovers the include
+// graph itself (the linter calls Resolve for every include it parses), so the
+// host need only provide every reachable module's source, keyed by the name
+// used in include statements. It generalizes StaticResolver to support includes.
+type MapResolver struct {
+	mainName     string
+	mainData     string
+	modules      map[string]string
+	includePaths []string
+}
+
+// NewMapResolver builds a MapResolver. modules maps the name used in `include`
+// statements (with or without a ".vcl" suffix, optionally under one of
+// includePaths) to that module's source. The map is copied to isolate it from
+// later caller mutation.
+func NewMapResolver(mainName, mainData string, modules map[string]string, includePaths []string) *MapResolver {
+	m := make(map[string]string, len(modules))
+	maps.Copy(m, modules)
+	return &MapResolver{
+		mainName:     mainName,
+		mainData:     mainData,
+		modules:      m,
+		includePaths: includePaths,
+	}
+}
+
+func (m *MapResolver) MainVCL() (*VCL, error) {
+	return &VCL{Name: m.mainName, Data: m.mainData}, nil
+}
+
+func (m *MapResolver) Name() string           { return m.mainName }
+func (m *MapResolver) IncludePaths() []string { return m.includePaths }
+
+// Resolve looks up an include's contents in the module map. The returned
+// VCL.Name is the matched map key, so diagnostics carry the real module name.
+// An empty module value is rejected, and a candidate equal to mainName is
+// skipped so a host module cannot shadow the synthetic main file.
+func (m *MapResolver) Resolve(stmt *ast.IncludeStatement) (*VCL, error) {
+	if stmt.Module.Value == "" {
+		return nil, errors.New("Failed to resolve include module: empty module name")
+	}
+	for _, key := range m.candidates(stmt.Module.Value) {
+		if key == m.mainName {
+			continue
+		}
+		if data, ok := m.modules[key]; ok {
+			return &VCL{Name: key, Data: data}, nil
+		}
+	}
+	return nil, errors.Errorf("Failed to resolve include module: %s", stmt.Module.Value)
+}
+
+// candidates enumerates the map keys to try, in priority order: the
+// ".vcl"-suffixed form first, then the value as written, each also joined under
+// every include path. Duplicates are removed while preserving order.
+//
+// Keys are matched as forward-slash path strings, so path.Join collapses ".."
+// segments into the flat key namespace. This is not a traversal risk (lookups
+// only hit the in-memory map), but hosts must key the map with the same
+// forward-slash names they use in `include` statements.
+func (m *MapResolver) candidates(module string) []string {
+	withExt := module
+	if !strings.HasSuffix(withExt, ".vcl") {
+		withExt += ".vcl"
+	}
+	bases := []string{withExt}
+	if module != withExt {
+		bases = append(bases, module)
+	}
+
+	seen := map[string]struct{}{}
+	var out []string
+	add := func(name string) {
+		if name == "" {
+			return
+		}
+		if _, dup := seen[name]; dup {
+			return
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+
+	for _, base := range bases {
+		add(base)
+		for _, p := range m.includePaths {
+			add(path.Join(p, base))
+		}
+	}
+	return out
+}

--- a/resolver/map_test.go
+++ b/resolver/map_test.go
@@ -1,0 +1,200 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/ysugimoto/falco/v2/ast"
+	"github.com/ysugimoto/falco/v2/token"
+)
+
+func includeStmt(module string) *ast.IncludeStatement {
+	return &ast.IncludeStatement{
+		Module: &ast.String{
+			Meta:  &ast.Meta{Token: token.Token{Type: token.STRING, Literal: module}},
+			Value: module,
+		},
+	}
+}
+
+func TestMapResolverMainVCL(t *testing.T) {
+	r := NewMapResolver("input.vcl", "sub vcl_recv {}", nil, nil)
+	main, err := r.MainVCL()
+	if err != nil {
+		t.Fatalf("MainVCL error: %v", err)
+	}
+	if main.Name != "input.vcl" || main.Data != "sub vcl_recv {}" {
+		t.Fatalf("unexpected main: %+v", main)
+	}
+}
+
+func TestMapResolverResolve(t *testing.T) {
+	modules := map[string]string{
+		"mod_a":         "// a", // keyed without extension
+		"mod_b.vcl":     "// b", // keyed with extension
+		"inc/mod_c.vcl": "// c", // keyed under an include path
+	}
+	r := NewMapResolver("input.vcl", "main", modules, []string{"inc"})
+
+	cases := []struct {
+		module   string
+		wantName string
+		wantData string
+	}{
+		{"mod_a", "mod_a", "// a"},         // extension optional, raw key
+		{"mod_b", "mod_b.vcl", "// b"},     // .vcl-suffixed key preferred
+		{"mod_b.vcl", "mod_b.vcl", "// b"}, // explicit extension
+		{"mod_c", "inc/mod_c.vcl", "// c"}, // found under include path
+	}
+	for _, c := range cases {
+		vcl, err := r.Resolve(includeStmt(c.module))
+		if err != nil {
+			t.Fatalf("Resolve(%q) error: %v", c.module, err)
+		}
+		if vcl.Name != c.wantName || vcl.Data != c.wantData {
+			t.Fatalf("Resolve(%q) = {%q, %q}, want {%q, %q}",
+				c.module, vcl.Name, vcl.Data, c.wantName, c.wantData)
+		}
+	}
+}
+
+func TestMapResolverResolveMissing(t *testing.T) {
+	r := NewMapResolver("input.vcl", "main", map[string]string{"mod_a": "// a"}, nil)
+	if _, err := r.Resolve(includeStmt("nope")); err == nil {
+		t.Fatal("expected error for missing module, got nil")
+	}
+}
+
+// TestMapResolverExtensionAsymmetry pins that a ".vcl"-suffixed module value is
+// not stripped, so it never matches a map keyed without the extension.
+func TestMapResolverExtensionAsymmetry(t *testing.T) {
+	r := NewMapResolver("input.vcl", "main", map[string]string{"mod_a": "// a"}, nil)
+	if _, err := r.Resolve(includeStmt("mod_a.vcl")); err == nil {
+		t.Fatal("include \"mod_a.vcl\" must not match a map keyed \"mod_a\" (no suffix stripping)")
+	}
+}
+
+// TestMapResolverDotDotNormalization documents that path.Join collapses ".."
+// segments into the flat key namespace: include "../secret" under include path
+// "inc" resolves to a top-level key "secret.vcl".
+func TestMapResolverDotDotNormalization(t *testing.T) {
+	r := NewMapResolver("input.vcl", "main", map[string]string{"secret.vcl": "// s"}, []string{"inc"})
+	vcl, err := r.Resolve(includeStmt("../secret"))
+	if err != nil {
+		t.Fatalf("Resolve(\"../secret\") error: %v", err)
+	}
+	if vcl.Name != "secret.vcl" || vcl.Data != "// s" {
+		t.Fatalf("want secret.vcl/// s, got %q/%q", vcl.Name, vcl.Data)
+	}
+}
+
+// TestMapResolverEmptyModule rejects an empty include value rather than
+// resolving it to a surprising key (".vcl", or an include-path name).
+func TestMapResolverEmptyModule(t *testing.T) {
+	r := NewMapResolver("input.vcl", "main", map[string]string{"inc": "// x"}, []string{"inc"})
+	if _, err := r.Resolve(includeStmt("")); err == nil {
+		t.Fatal("expected error for empty module value")
+	}
+}
+
+// TestMapResolverMainNameCollision ensures a host module keyed with the
+// synthetic main name cannot resolve as an include (which would shadow main).
+func TestMapResolverMainNameCollision(t *testing.T) {
+	r := NewMapResolver("input.vcl", "main", map[string]string{"input.vcl": "// shadow"}, nil)
+	if _, err := r.Resolve(includeStmt("input.vcl")); err == nil {
+		t.Fatal("a module keyed as the main name must not resolve as an include")
+	}
+}
+
+func TestMapResolverCopiesModules(t *testing.T) {
+	src := map[string]string{"mod_a": "// a"}
+	r := NewMapResolver("input.vcl", "main", src, nil)
+	// Mutating the caller's map after construction must not affect resolution.
+	delete(src, "mod_a")
+	src["mod_a"] = "tampered"
+	vcl, err := r.Resolve(includeStmt("mod_a"))
+	if err != nil {
+		t.Fatalf("Resolve error: %v", err)
+	}
+	if vcl.Data != "// a" {
+		t.Fatalf("module map not copied: got %q", vcl.Data)
+	}
+}
+
+// TestMapResolverPrecedence pins the documented candidate ordering: the
+// ".vcl"-suffixed key wins over the bare key, and a bare key wins over the same
+// base joined under an include path.
+func TestMapResolverPrecedence(t *testing.T) {
+	t.Run(".vcl suffix beats bare", func(t *testing.T) {
+		r := NewMapResolver("input.vcl", "main", map[string]string{
+			"dup":     "// bare",
+			"dup.vcl": "// ext",
+		}, nil)
+		vcl, err := r.Resolve(includeStmt("dup"))
+		if err != nil {
+			t.Fatalf("Resolve error: %v", err)
+		}
+		if vcl.Name != "dup.vcl" || vcl.Data != "// ext" {
+			t.Fatalf("want dup.vcl/// ext, got %q/%q", vcl.Name, vcl.Data)
+		}
+	})
+
+	t.Run("bare beats include-path join", func(t *testing.T) {
+		r := NewMapResolver("input.vcl", "main", map[string]string{
+			"mod.vcl":     "// bare",
+			"inc/mod.vcl": "// under inc",
+		}, []string{"inc"})
+		vcl, err := r.Resolve(includeStmt("mod"))
+		if err != nil {
+			t.Fatalf("Resolve error: %v", err)
+		}
+		if vcl.Name != "mod.vcl" || vcl.Data != "// bare" {
+			t.Fatalf("want bare mod.vcl, got %q/%q", vcl.Name, vcl.Data)
+		}
+	})
+}
+
+// TestMapResolverMultipleIncludePaths checks that include paths are tried in the
+// order given (first match wins).
+func TestMapResolverMultipleIncludePaths(t *testing.T) {
+	r := NewMapResolver("input.vcl", "main", map[string]string{
+		"a/mod.vcl": "// from a",
+		"b/mod.vcl": "// from b",
+	}, []string{"a", "b"})
+	vcl, err := r.Resolve(includeStmt("mod"))
+	if err != nil {
+		t.Fatalf("Resolve error: %v", err)
+	}
+	if vcl.Name != "a/mod.vcl" {
+		t.Fatalf("first include path should win: got %q", vcl.Name)
+	}
+
+	// With only the second path's module present, resolution falls through to it.
+	r2 := NewMapResolver("input.vcl", "main", map[string]string{
+		"b/mod.vcl": "// from b",
+	}, []string{"a", "b"})
+	vcl, err = r2.Resolve(includeStmt("mod"))
+	if err != nil {
+		t.Fatalf("Resolve error: %v", err)
+	}
+	if vcl.Name != "b/mod.vcl" {
+		t.Fatalf("second include path should resolve: got %q", vcl.Name)
+	}
+}
+
+// TestMapResolverGetters covers Name/IncludePaths and the empty-include-path
+// edge (path.Join("", base) must dedup against the bare base, not shadow it).
+func TestMapResolverGetters(t *testing.T) {
+	r := NewMapResolver("input.vcl", "main", map[string]string{"mod_a": "// a"}, []string{"inc"})
+	if r.Name() != "input.vcl" {
+		t.Fatalf("Name() = %q, want input.vcl", r.Name())
+	}
+	if ip := r.IncludePaths(); len(ip) != 1 || ip[0] != "inc" {
+		t.Fatalf("IncludePaths() = %v, want [inc]", ip)
+	}
+
+	// An empty include path entry must not break the bare lookup.
+	r2 := NewMapResolver("input.vcl", "main", map[string]string{"mod_a": "// a"}, []string{""})
+	if _, err := r2.Resolve(includeStmt("mod_a")); err != nil {
+		t.Fatalf("empty include path broke bare resolution: %v", err)
+	}
+}

--- a/token/category.go
+++ b/token/category.go
@@ -1,0 +1,64 @@
+package token
+
+// Category maps a token type to a coarse semantic category for syntax
+// highlighting. It is shared by the cmd/wasm and cmd/falco-component builds so
+// they cannot diverge.
+func Category(tt TokenType) string {
+	switch tt {
+	// Keywords
+	case ACL, BACKEND, DIRECTOR, TABLE, SUBROUTINE,
+		ADD, CALL, DECLARE, ERROR, ESI,
+		INCLUDE, IMPORT, LOG, REMOVE, RESTART,
+		RETURN, SET, SYNTHETIC, SYNTHETIC_BASE64, UNSET,
+		IF, ELSE, ELSEIF, ELSIF,
+		PENALTYBOX, RATECOUNTER, GOTO,
+		SWITCH, CASE, DEFAULT, BREAK, FALLTHROUGH,
+		PRAGMA:
+		return "keyword"
+
+	// Strings
+	case STRING, OPEN_LONG_STRING, CLOSE_LONG_STRING:
+		return "string"
+
+	// Numbers
+	case INT, FLOAT, RTIME:
+		return "number"
+
+	// Booleans
+	case TRUE, FALSE:
+		return "boolean"
+
+	// Identifiers
+	case IDENT:
+		return "variable"
+
+	// Operators
+	case EQUAL, NOT_EQUAL, REGEX_MATCH, NOT_REGEX_MATCH,
+		GREATER_THAN, LESS_THAN, GREATER_THAN_EQUAL, LESS_THAN_EQUAL,
+		AND, OR, NOT,
+		ASSIGN, ADDITION, SUBTRACTION, MULTIPLICATION,
+		DIVISION, REMAINDER,
+		BITWISE_OR, BITWISE_AND, BITWISE_XOR,
+		LEFT_SHIFT, RIGHT_SHIFT, LEFT_ROTATE, RIGHT_ROTATE,
+		LOGICAL_AND, LOGICAL_OR,
+		PLUS, MINUS, SLASH, PERCENT:
+		return "operator"
+
+	// Comments
+	case COMMENT:
+		return "comment"
+
+	// Punctuation
+	case LEFT_BRACE, RIGHT_BRACE, LEFT_PAREN, RIGHT_PAREN,
+		LEFT_BRACKET, RIGHT_BRACKET, COMMA, SEMICOLON,
+		DOT, COLON:
+		return "punctuation"
+
+	// Control
+	case FASTLY_CONTROL:
+		return "control"
+
+	default:
+		return "text"
+	}
+}

--- a/token/category_test.go
+++ b/token/category_test.go
@@ -1,0 +1,32 @@
+package token
+
+import "testing"
+
+// TestCategory pins the token-type -> highlighting-category mapping shared by
+// the cmd/wasm and cmd/falco-component builds.
+func TestCategory(t *testing.T) {
+	cases := []struct {
+		tt   TokenType
+		want string
+	}{
+		{SUBROUTINE, "keyword"},
+		{IF, "keyword"},
+		{STRING, "string"},
+		{OPEN_LONG_STRING, "string"},
+		{INT, "number"},
+		{RTIME, "number"},
+		{TRUE, "boolean"},
+		{IDENT, "variable"},
+		{EQUAL, "operator"},
+		{PLUS, "operator"},
+		{COMMENT, "comment"},
+		{SEMICOLON, "punctuation"},
+		{FASTLY_CONTROL, "control"},
+		{EOF, "text"},
+	}
+	for _, c := range cases {
+		if got := Category(c.tt); got != c.want {
+			t.Errorf("Category(%q) = %q, want %q", c.tt, got, c.want)
+		}
+	}
+}

--- a/wit/falco.wit
+++ b/wit/falco.wit
@@ -1,0 +1,61 @@
+package falco:tools@0.1.0;
+
+/// The `falco` world exposes falco's lint / format / parse / tokenize
+/// front-ends as typed, repeatedly-callable component functions.
+///
+/// Functions are exported at the *world root* (not nested in an interface) so
+/// hosts that resolve only root-level exports can reach them — notably the
+/// wasmtime Ruby gem, which cannot descend into an exported interface. jco and
+/// the Python wasmtime embedding surface root exports too, so the shape works
+/// everywhere.
+///
+/// Every function is string-in / string-out. Structured results are returned as
+/// a JSON string inside `result<string, string>`: `ok(json)` for success,
+/// `err(msg)` for a human-readable failure. The JSON payloads mirror the shapes
+/// the native `falco` binary emits, so existing consumers parse them unchanged.
+///
+/// Parse failures differ per function: `lint` reports them in-band via the
+/// RunnerResult `ParseErrors` map (an `ok` payload, matching native
+/// `lint -json`); `format`, `parse`, and `tokenize` return them as `err(msg)`.
+///
+/// Reactor-style world: instantiate once, call the exports repeatedly.
+world falco {
+    /// Lint a single VCL source string.
+    ///
+    /// `options` is a JSON object (pass "" for defaults) with optional fields:
+    ///   { "scope": "recv|hash|hit|miss|pass|fetch|error|deliver|log|pipe",
+    ///     "rules": { "<rule-name>": "ERROR|WARNING|INFO|IGNORE" },
+    ///     "includes": { "<module-name>": "<source>" },
+    ///     "includePaths": [ "<prefix>", ... ] }
+    /// An unrecognized "scope" value is rejected with `err`.
+    ///
+    /// `include` statements resolve against "includes" (the component has no
+    /// filesystem). The ".vcl" suffix is optional and each "includePaths" entry
+    /// is tried as a prefix; transitive includes are discovered automatically.
+    /// Diagnostics are keyed by the real module name; top-level source uses the
+    /// synthetic key "input.vcl".
+    ///
+    /// On `ok`, the payload is a RunnerResult JSON object identical in shape to
+    /// native `lint -json`.
+    export lint: func(source: string, options: string) -> result<string, string>;
+
+    /// Format a single VCL source string.
+    ///
+    /// `config` is a JSON object (pass "" for defaults) of FormatConfig fields
+    /// (e.g. "indentWidth", "indentStyle" ("space"|"tab"), "lineWidth",
+    /// "commentStyle" ("none"|"slash"|"sharp"), ...). The "indentStyle" and
+    /// "commentStyle" enums are validated: an unrecognized value is rejected
+    /// with `err`.
+    ///
+    /// On `ok`, the payload is the formatted VCL source string (raw, not JSON).
+    export format: func(source: string, config: string) -> result<string, string>;
+
+    /// Parse a single VCL source string into an AST.
+    /// On `ok`, the payload is the AST serialized as JSON.
+    export parse: func(source: string) -> result<string, string>;
+
+    /// Tokenize a single VCL source string.
+    /// On `ok`, the payload is a JSON array of tokens
+    /// ({ type, literal, line, position, category }).
+    export tokenize: func(source: string) -> result<string, string>;
+}


### PR DESCRIPTION
- Add cmd/falco-component: reactor build exporting lint/format/ parse/tokenize via wit/falco.wit with hand-rolled canonical ABI
- Add resolver.MapResolver and token category helpers for the filesystem-less, string-in/string-out component API
- Add make wasm-component and make test-wasm targets, pinning the WASI preview1 adapter with a verified SHA-256
- Build and test the component in CI and attach it to releases via a shared setup-wasm-toolchain composite action
- Add host smoke tests (Python/JS/Ruby) and docs/wasm-component.md