### PR TITLE
feat: support week (w) RTIME unit

### DIFF
--- a/formatter/statement_format_test.go
+++ b/formatter/statement_format_test.go
@@ -215,6 +215,18 @@ func TestFormatSetStatement(t *testing.T) {
 				ExplicitStringConcat: true,
 			},
 		},
+		{
+			name: "set with RTIME week unit",
+			input: `sub vcl_fetch {
+  set beresp.stale_if_error = 8w;
+}`,
+			expect: "sub vcl_fetch {\n  set beresp.stale_if_error = 8w;\n}\n",
+			conf: &config.FormatConfig{
+				IndentWidth: 2,
+				IndentStyle: "space",
+				LineWidth:   120,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/interpreter/expression.go
+++ b/interpreter/expression.go
@@ -95,6 +95,13 @@ func (i *Interpreter) processExpression(exp ast.Expression, opt *ExpressionOptio
 				return nil, exception.Runtime(&exp.GetMeta().Token, "Failed to parse duration: %s", err)
 			}
 			val *= 24
+		case strings.HasSuffix(t.Value, "w"):
+			num := strings.TrimSuffix(t.Value, "w")
+			val, err = time.ParseDuration(num + "h")
+			if err != nil {
+				return nil, exception.Runtime(&exp.GetMeta().Token, "Failed to parse duration: %s", err)
+			}
+			val *= 24 * 7
 		case strings.HasSuffix(t.Value, "y"):
 			num := strings.TrimSuffix(t.Value, "y")
 			val, err = time.ParseDuration(num + "h")

--- a/interpreter/expression_test.go
+++ b/interpreter/expression_test.go
@@ -455,6 +455,18 @@ func TestProcessStringConcat(t *testing.T) {
 			},
 		},
 		{
+			name: "RTIME week unit",
+			vcl: `sub vcl_recv {
+				declare local var.R RTIME;
+				set var.R = 8w;
+				set req.http.Foo = "foo" + var.R;
+			}`,
+			assertions: map[string]value.Value{
+				// 8 weeks = 8 * 7 * 86400 = 4838400 seconds
+				"req.http.Foo": &value.String{Value: "foo4838400.000"},
+			},
+		},
+		{
 			name: "TIME concatenation",
 			vcl:  `sub vcl_recv { set req.http.Foo = "foo" + now; }`,
 			assertions: map[string]value.Value{

--- a/interpreter/function/builtin/table_lookup_rtime.go
+++ b/interpreter/function/builtin/table_lookup_rtime.go
@@ -72,6 +72,10 @@ func Table_lookup_rtime(ctx *context.Context, args ...value.Value) (value.Value,
 			num := strings.TrimSuffix(v.Value, "d")
 			val, _ = time.ParseDuration(num + "h")
 			val *= 24
+		case strings.HasSuffix(v.Value, "w"):
+			num := strings.TrimSuffix(v.Value, "w")
+			val, _ = time.ParseDuration(num + "h")
+			val *= 24 * 7
 		case strings.HasSuffix(v.Value, "y"):
 			num := strings.TrimSuffix(v.Value, "y")
 			val, _ = time.ParseDuration(num + "h")

--- a/interpreter/function/builtin/table_lookup_rtime_test.go
+++ b/interpreter/function/builtin/table_lookup_rtime_test.go
@@ -31,6 +31,15 @@ func Test_Table_lookup_rtime(t *testing.T) {
 						},
 					},
 				},
+				{
+					Key: &ast.String{Value: "week"},
+					Value: &ast.RTime{
+						Value: "8w",
+						Meta: &ast.Meta{
+							Token: token.Token{Offset: 0},
+						},
+					},
+				},
 			},
 		},
 	}
@@ -43,6 +52,7 @@ func Test_Table_lookup_rtime(t *testing.T) {
 	}{
 		{input: "doesnotexist", key: "foo", isError: true},
 		{input: "example", key: "foo", expect: &value.RTime{Value: 10 * time.Second}},
+		{input: "example", key: "week", expect: &value.RTime{Value: 8 * 7 * 24 * time.Hour}},
 		{input: "example", key: "other", expect: &value.RTime{Value: time.Second}},
 	}
 

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -418,7 +418,7 @@ func (l *Lexer) NextToken() token.Token {
 			num := l.readNumber()
 			// VCL has special type of "RTIME", it indicates relative-time.
 			// To parse it, we look up unit string after digit Literal
-			// and if "ms", "m", "s", "d", "y" character is found, it deals with RTIME token.
+			// and if "ms", "s", "m", "h", "d", "w", "y" character is found, it deals with RTIME token.
 			// https://developer.fastly.com/reference/vcl/types/rtime/
 			switch l.char {
 			case 'm':
@@ -428,9 +428,9 @@ func (l *Lexer) NextToken() token.Token {
 					t.Literal = num + "ms" // millisecond
 				} else {
 					t = newToken(token.RTIME, l.char, line, index)
-					t.Literal = num + "m" // month
+					t.Literal = num + "m" // minute
 				}
-			case 's', 'h', 'd', 'y': // second, hour, day, year
+			case 's', 'h', 'd', 'w', 'y': // second, hour, day, week, year
 				t = newToken(token.RTIME, l.char, line, index)
 				t.Literal = num + string(l.char)
 			default:

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -794,3 +794,33 @@ func TestFastlyControlSyntaxes(t *testing.T) {
 		}
 	})
 }
+
+func TestRTimeUnits(t *testing.T) {
+	// All RTIME unit suffixes accepted by Fastly.
+	// https://www.fastly.com/documentation/reference/vcl/types/rtime/
+	tests := []struct {
+		input   string
+		literal string
+	}{
+		{input: "100ms", literal: "100ms"},
+		{input: "5s", literal: "5s"},
+		{input: "5m", literal: "5m"},
+		{input: "6h", literal: "6h"},
+		{input: "3d", literal: "3d"},
+		{input: "8w", literal: "8w"},
+		{input: "1y", literal: "1y"},
+		{input: "5.3d", literal: "5.3d"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			l := NewFromString(tt.input)
+			tok := l.NextToken()
+			if tok.Type != token.RTIME {
+				t.Errorf("expected RTIME token, got %s (%q)", tok.Type, tok.Literal)
+			}
+			if tok.Literal != tt.literal {
+				t.Errorf("expected literal %q, got %q", tt.literal, tok.Literal)
+			}
+		})
+	}
+}

--- a/parser/vcl_type_parser.go
+++ b/parser/vcl_type_parser.go
@@ -139,6 +139,8 @@ func (p *Parser) ParseRTime() (*ast.RTime, error) {
 		value = strings.TrimSuffix(literal, "h")
 	case strings.HasSuffix(literal, "d"):
 		value = strings.TrimSuffix(literal, "d")
+	case strings.HasSuffix(literal, "w"):
+		value = strings.TrimSuffix(literal, "w")
 	case strings.HasSuffix(literal, "y"):
 		value = strings.TrimSuffix(literal, "y")
 	default:

--- a/parser/vcl_type_parser_test.go
+++ b/parser/vcl_type_parser_test.go
@@ -324,3 +324,22 @@ func TestParseRTime(t *testing.T) {
 		t.Errorf("ast mismatch, diff=%s", diff)
 	}
 }
+
+func TestParseRTimeUnits(t *testing.T) {
+	// All RTIME unit suffixes accepted by Fastly, including week ("w").
+	// https://www.fastly.com/documentation/reference/vcl/types/rtime/
+	inputs := []string{"100ms", "5s", "5m", "6h", "3d", "8w", "1y", "5.3d"}
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			p := New(lexer.NewFromString(input))
+			r, err := p.ParseRTime()
+			if err != nil {
+				t.Errorf("unexpected rtime parse error for %q: %s", input, err)
+				return
+			}
+			if r.Value != input {
+				t.Errorf("expected value %q, got %q", input, r.Value)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Add `'w'` to the lexer's RTIME unit switch so `8w` lexes as a single RTIME token instead of `INT` + `IDENT`
- Handle `w` suffix in `ParseRTime` and in the interpreter (week = 24 × 7 hours), including `table.lookup_rtime`
- Fix misleading lexer comment: `m` is minute, not month
- Add lexer, parser, interpreter, and formatter tests covering RTIME units including week

Reference:
https://www.fastly.com/documentation/reference/vcl/types/rtime/