### PR TITLE
feat: support fetch_timeout backend property

### DIFF
--- a/interpreter/transport.go
+++ b/interpreter/transport.go
@@ -167,6 +167,16 @@ func (i *Interpreter) sendBackendRequest(backend *value.Backend) (*http.Response
 		timeout = value.Unwrap[*value.RTime](fbt).Value
 	}
 
+	// The backend "fetch_timeout" property bounds the entire response fetch,
+	// so prefer it over the first_byte_timeout-derived default when present.
+	ft, err := i.getBackendProperty(backend.Value.Properties, "fetch_timeout")
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if ft != nil {
+		timeout = value.Unwrap[*value.RTime](ft).Value
+	}
+
 	// Use bereq.fetch_timeout variable value if specified
 	if i.ctx.FetchTimeout != nil && i.ctx.FetchTimeout.Value > 0 {
 		timeout = i.ctx.FetchTimeout.Value

--- a/linter/declaration_linter_test.go
+++ b/linter/declaration_linter_test.go
@@ -47,6 +47,7 @@ backend foo {
   .connect_timeout = 1s;
   .dynamic = true;
   .port = "443";
+  .fetch_timeout = 120s;
   .first_byte_timeout = 20s;
   .max_connections = 500;
   .between_bytes_timeout = 20s;
@@ -82,6 +83,14 @@ backend foo-bar {
 		input := `
 backend foo {
   .host = 1s;
+}`
+		assertError(t, input)
+	})
+
+	t.Run("invalid fetch_timeout type", func(t *testing.T) {
+		input := `
+backend foo {
+  .fetch_timeout = "120";
 }`
 		assertError(t, input)
 	})

--- a/linter/helper.go
+++ b/linter/helper.go
@@ -223,6 +223,7 @@ var BackendPropertyTypes = map[string]types.Type{
 	"ssl_sni_hostname":         types.StringType,
 	"between_bytes_timeout":    types.RTimeType,
 	"connect_timeout":          types.RTimeType,
+	"fetch_timeout":            types.RTimeType,
 	"first_byte_timeout":       types.RTimeType,
 	"keepalive_time":           types.RTimeType,
 	"max_connections":          types.IntegerType,


### PR DESCRIPTION
- Register `fetch_timeout` (RTIME) in the linter's `BackendPropertyTypes` so backend declarations using it pass validation
- Honor the `.fetch_timeout` property in the interpreter, bounding the fetch and overriding the `first_byte_timeout` default; the `bereq.fetch_timeout` variable still takes precedence
- Add positive and negative (wrong-type) linter tests for the property