### PR TITLE
Feat: Add Terraform support for `fastly_service_dynamic_snippet_content`

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -69,3 +69,29 @@ You MUST include Fastly Provider planned result in output either root module or 
 ### Note
 
 You can define multiple custom VCLs in `vcl` field in `fastly_service_vcl` resource, but falco treats only the main module which is defined with `main = true` initially, and will not evaluate other vcl definitions until they are included by a `include` statement in main VCL.
+
+## Dynamic Snippet Support
+
+`falco terraform` supports
+`fastly_service_dynamic_snippet_content` resources
+alongside inline `dynamicsnippet` blocks within
+`fastly_service_vcl`. The inline block declares
+snippet metadata (`name`, `type`, `priority`,
+`snippet_id`), while the external resource provides
+the `content`, linked by `snippet_id` and
+`service_id`.
+
+Dynamic snippets flow through the same pipeline as
+regular VCL snippets, so all `falco terraform`
+actions (`lint`, `test`, `simulate`, `stats`) evaluate
+them automatically.
+
+### Known limitation
+
+When a `dynamicsnippet` block is newly created in the
+same Terraform plan, `snippet_id` may be marked as
+`(known after apply)` and appear as an empty string in
+the plan JSON. In this case, the content join will
+silently fail and the dynamic snippet will not be
+evaluated. This is expected — the snippet does not yet
+exist on the service, so there is nothing to lint.

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -88,10 +88,8 @@ them automatically.
 
 ### Known limitation
 
-When a `dynamicsnippet` block is newly created in the
-same Terraform plan, `snippet_id` may be marked as
-`(known after apply)` and appear as an empty string in
-the plan JSON. In this case, the content join will
-silently fail and the dynamic snippet will not be
-evaluated. This is expected — the snippet does not yet
-exist on the service, so there is nothing to lint.
+Content is linked to its snippet by `snippet_id`. For
+snippets created in the same plan, `snippet_id` is `(known
+after apply)`, so the link cannot be made and the snippet
+is skipped. It will be linted once a later plan assigns a
+concrete `snippet_id`.

--- a/snippet/terraform/data/terraform-dynamic-snippet.json
+++ b/snippet/terraform/data/terraform-dynamic-snippet.json
@@ -19,8 +19,7 @@
                 "name": "My Dynamic Snippet",
                 "type": "recv",
                 "priority": 110,
-                "snippet_id": "abc123",
-                "content": ""
+                "snippet_id": "abc123"
               }
             ],
             "vcl": [

--- a/snippet/terraform/data/terraform-dynamic-snippet.json
+++ b/snippet/terraform/data/terraform-dynamic-snippet.json
@@ -1,0 +1,48 @@
+{
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "type": "fastly_service_vcl",
+          "provider_name": "registry.terraform.io/fastly/fastly",
+          "values": {
+            "id": "testServiceId",
+            "name": "dynamicSnippetTest",
+            "backend": [
+              {
+                "address": "example.com",
+                "name": "example_backend"
+              }
+            ],
+            "dynamicsnippet": [
+              {
+                "name": "My Dynamic Snippet",
+                "type": "recv",
+                "priority": 110,
+                "snippet_id": "abc123",
+                "content": ""
+              }
+            ],
+            "vcl": [
+              {
+                "content": "sub vcl_recv {\n  #FASTLY recv\n}\n",
+                "main": true,
+                "name": "main.vcl"
+              }
+            ]
+          }
+        },
+        {
+          "type": "fastly_service_dynamic_snippet_content",
+          "provider_name": "registry.terraform.io/fastly/fastly",
+          "values": {
+            "service_id": "testServiceId",
+            "snippet_id": "abc123",
+            "content": "set req.http.X-Dynamic = \"1\";",
+            "manage_snippets": false
+          }
+        }
+      ]
+    }
+  }
+}

--- a/snippet/terraform/fastly.go
+++ b/snippet/terraform/fastly.go
@@ -38,6 +38,14 @@ type Snippet struct {
 	Priority int64  `json:"priority"`
 }
 
+type DynamicSnippet struct {
+	Name      string `json:"name"`
+	Type      string `json:"type"`
+	Content   string `json:"content"`
+	Priority  int64  `json:"priority"`
+	SnippetID string `json:"snippet_id"`
+}
+
 type LoggingEndpoint struct {
 	Name string `json:"name"`
 }
@@ -95,9 +103,10 @@ type RequestSetting struct {
 }
 
 type FastlyResources struct {
-	Services        map[string]*FastlyService
-	AclEntries      []*fastlyAclEntryValues
-	DictionaryItems []*fastlyDictionaryItems
+	Services               map[string]*FastlyService
+	AclEntries             []*fastlyAclEntryValues
+	DictionaryItems        []*fastlyDictionaryItems
+	DynamicSnippetContents []*fastlyDynamicSnippetContent
 }
 
 type FastlyService struct {
@@ -108,6 +117,7 @@ type FastlyService struct {
 	Dictionaries     []*Dictionary
 	Directors        []*Director
 	Snippets         []*Snippet
+	DynamicSnippets  []*DynamicSnippet
 	Conditions       []*Condition
 	Headers          []*Header
 	ResponseObjects  []*ResponseObject
@@ -124,6 +134,7 @@ type fastlyServiceValues struct {
 	Director        []*Director       `json:"director"`
 	Dictionary      []*Dictionary     `json:"dictionary"`
 	Snippets        []*Snippet        `json:"snippet"`
+	DynamicSnippets []*DynamicSnippet `json:"dynamicsnippet"`
 	Conditions      []*Condition      `json:"condition"`
 	Headers         []*Header         `json:"header"`
 	ResponseObjects []*ResponseObject `json:"response_object"`
@@ -172,4 +183,11 @@ type fastlyDictionaryItems struct {
 	ServiceId string `json:"service_id"`
 	Index     string
 	Items     map[string]string `json:"items"`
+}
+
+type fastlyDynamicSnippetContent struct {
+	ServiceID      string `json:"service_id"`
+	SnippetID      string `json:"snippet_id"`
+	Content        string `json:"content"`
+	ManageSnippets bool   `json:"manage_snippets"`
 }

--- a/snippet/terraform/fastly.go
+++ b/snippet/terraform/fastly.go
@@ -189,5 +189,5 @@ type fastlyDynamicSnippetContent struct {
 	ServiceID      string `json:"service_id"`
 	SnippetID      string `json:"snippet_id"`
 	Content        string `json:"content"`
-	ManageSnippets bool   `json:"manage_snippets"`
+	ManageSnippets bool   `json:"manage_snippets"` // reserved; not currently used by the linter.
 }

--- a/snippet/terraform/fetcher.go
+++ b/snippet/terraform/fetcher.go
@@ -215,12 +215,25 @@ func (f *TerraformFetcher) Directors() ([]*snippet.Director, error) {
 func (f *TerraformFetcher) Snippets() ([]*snippet.VCLSnippet, error) {
 	var v []*snippet.VCLSnippet
 	for _, s := range f.filterService() {
+		// Existing inline snippets
 		for _, vcl := range s.Snippets {
 			v = append(v, &snippet.VCLSnippet{
 				Name:     vcl.Name,
 				Type:     vcl.Type,
 				Content:  vcl.Content,
 				Priority: vcl.Priority,
+			})
+		}
+		// Dynamic snippets with resolved content
+		for _, ds := range s.DynamicSnippets {
+			if ds.Content == "" {
+				continue
+			}
+			v = append(v, &snippet.VCLSnippet{
+				Name:     ds.Name,
+				Type:     ds.Type,
+				Content:  ds.Content,
+				Priority: ds.Priority,
 			})
 		}
 	}

--- a/snippet/terraform/terraform.go
+++ b/snippet/terraform/terraform.go
@@ -299,6 +299,12 @@ func collectServices(r *FastlyResources) []*FastlyService {
 		if !ok {
 			continue
 		}
+		// snippet_id may be empty (known after apply) for snippets created in
+		// the same plan. Skip empty IDs to avoid joining content onto the wrong
+		// snippet via an empty-string match.
+		if dsc.SnippetID == "" {
+			continue
+		}
 		for _, ds := range svc.DynamicSnippets {
 			if ds.SnippetID == dsc.SnippetID {
 				ds.Content = dsc.Content

--- a/snippet/terraform/terraform.go
+++ b/snippet/terraform/terraform.go
@@ -10,11 +10,12 @@ import (
 )
 
 const (
-	fastlyTerraformProviderName      = "registry.terraform.io/fastly/fastly"
-	fastlyVCLServiceType             = "fastly_service_vcl"
-	fastlyVCLServiceTypeV1           = "fastly_service_v1"
-	fastlyServiceAclEntriesType      = "fastly_service_acl_entries"
-	fastlyServiceDictionaryItemsType = "fastly_service_dictionary_items"
+	fastlyTerraformProviderName            = "registry.terraform.io/fastly/fastly"
+	fastlyVCLServiceType                   = "fastly_service_vcl"
+	fastlyVCLServiceTypeV1                 = "fastly_service_v1"
+	fastlyServiceAclEntriesType            = "fastly_service_acl_entries"
+	fastlyServiceDictionaryItemsType       = "fastly_service_dictionary_items"
+	fastlyServiceDynamicSnippetContentType = "fastly_service_dynamic_snippet_content"
 )
 
 type TerraformPlannedResource struct {
@@ -66,6 +67,7 @@ func findFastlyServicesInTerraformModule(mod *TerraformModule) (*FastlyResources
 	services := make(map[string]*FastlyService)
 	var aclEntries []*fastlyAclEntryValues
 	var dictionaryItems []*fastlyDictionaryItems
+	var dynamicSnippetContents []*fastlyDynamicSnippetContent
 
 	// Find services in module resources
 	if len(mod.Resources) > 0 {
@@ -86,6 +88,7 @@ func findFastlyServicesInTerraformModule(mod *TerraformModule) (*FastlyResources
 					Dictionaries:     s.Dictionary,
 					Directors:        s.Director,
 					Snippets:         s.Snippets,
+					DynamicSnippets:  s.DynamicSnippets,
 					Conditions:       s.Conditions,
 					Headers:          s.Headers,
 					ResponseObjects:  s.ResponseObjects,
@@ -107,6 +110,13 @@ func findFastlyServicesInTerraformModule(mod *TerraformModule) (*FastlyResources
 				}
 				d.Index = v.Index
 				dictionaryItems = append(dictionaryItems, d)
+
+			case isFastlyServiceDynamicSnippetContent(v):
+				var d *fastlyDynamicSnippetContent
+				if err := json.Unmarshal(v.Values, &d); err != nil {
+					return nil, errors.Wrap(err, "Failed to unmarshal fastly_service_dynamic_snippet_content values")
+				}
+				dynamicSnippetContents = append(dynamicSnippetContents, d)
 			}
 		}
 	}
@@ -114,9 +124,10 @@ func findFastlyServicesInTerraformModule(mod *TerraformModule) (*FastlyResources
 	// Check child_modules existence and return found services if not found
 	if len(mod.ChildModules) == 0 {
 		return &FastlyResources{
-			Services:        services,
-			AclEntries:      aclEntries,
-			DictionaryItems: dictionaryItems,
+			Services:               services,
+			AclEntries:             aclEntries,
+			DictionaryItems:        dictionaryItems,
+			DynamicSnippetContents: dynamicSnippetContents,
 		}, nil
 	}
 	// If module has child_modules, find Fastly service recursively
@@ -132,12 +143,14 @@ func findFastlyServicesInTerraformModule(mod *TerraformModule) (*FastlyResources
 
 		aclEntries = append(aclEntries, childResource.AclEntries...)
 		dictionaryItems = append(dictionaryItems, childResource.DictionaryItems...)
+		dynamicSnippetContents = append(dynamicSnippetContents, childResource.DynamicSnippetContents...)
 	}
 
 	return &FastlyResources{
-		Services:        services,
-		AclEntries:      aclEntries,
-		DictionaryItems: dictionaryItems,
+		Services:               services,
+		AclEntries:             aclEntries,
+		DictionaryItems:        dictionaryItems,
+		DynamicSnippetContents: dynamicSnippetContents,
 	}, nil
 }
 
@@ -151,6 +164,10 @@ func isFastlyServiceAclEntryResource(r *TerraformPlannedResource) bool {
 }
 func isFastlyServiceDictionaryItem(r *TerraformPlannedResource) bool {
 	return r.ProviderName == fastlyTerraformProviderName && r.Type == fastlyServiceDictionaryItemsType
+}
+
+func isFastlyServiceDynamicSnippetContent(r *TerraformPlannedResource) bool {
+	return r.ProviderName == fastlyTerraformProviderName && r.Type == fastlyServiceDynamicSnippetContentType
 }
 
 func factoryLoggingEndpoints(values *fastlyServiceValues) []string {
@@ -273,6 +290,19 @@ func collectServices(r *FastlyResources) []*FastlyService {
 					Key:   keys[i],
 					Value: item.Items[keys[i]],
 				})
+			}
+		}
+	}
+
+	for _, dsc := range r.DynamicSnippetContents {
+		svc, ok := r.Services[dsc.ServiceID]
+		if !ok {
+			continue
+		}
+		for _, ds := range svc.DynamicSnippets {
+			if ds.SnippetID == dsc.SnippetID {
+				ds.Content = dsc.Content
+				break
 			}
 		}
 	}

--- a/snippet/terraform/terraform_test.go
+++ b/snippet/terraform/terraform_test.go
@@ -250,3 +250,74 @@ func TestUnmarshalWithRequestSetting(t *testing.T) {
 		t.Errorf("Unmarshalled request settings mismatch, diff=%s", diff)
 	}
 }
+
+func TestUnmarshalWithDynamicSnippetContent(t *testing.T) {
+	fileName := "./data/terraform-dynamic-snippet.json"
+	buf, err := os.ReadFile(fileName)
+
+	if err != nil {
+		t.Fatalf("Unexpected error %s reading file %s", err, fileName)
+	}
+
+	services, err := unmarshalTerraformPlannedInput(buf)
+	if err != nil {
+		t.Fatalf("Unexpected error %s unmarshalling %s", err, fileName)
+	}
+
+	if len(services) != 1 {
+		t.Fatalf("Expected 1 service, got %d", len(services))
+	}
+
+	svc := services[0]
+	if len(svc.DynamicSnippets) != 1 {
+		t.Fatalf("Expected 1 dynamic snippet, got %d", len(svc.DynamicSnippets))
+	}
+
+	ds := svc.DynamicSnippets[0]
+	if ds.Name != "My Dynamic Snippet" {
+		t.Errorf("Dynamic snippet name: want %q, got %q", "My Dynamic Snippet", ds.Name)
+	}
+	if ds.Type != "recv" {
+		t.Errorf("Dynamic snippet type: want %q, got %q", "recv", ds.Type)
+	}
+	expectedContent := `set req.http.X-Dynamic = "1";`
+	if ds.Content != expectedContent {
+		t.Errorf("Dynamic snippet content: want %q, got %q", expectedContent, ds.Content)
+	}
+}
+
+func TestTerraformFetcherIncludesDynamicSnippets(t *testing.T) {
+	fileName := "./data/terraform-dynamic-snippet.json"
+	buf, err := os.ReadFile(fileName)
+	if err != nil {
+		t.Fatalf("Failed to read %s: %s", fileName, err)
+	}
+
+	services, err := unmarshalTerraformPlannedInput(buf)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal: %s", err)
+	}
+
+	fetcher := NewTerraformFetcher(services)
+	snippets, err := fetcher.Snippets()
+	if err != nil {
+		t.Fatalf("Snippets() returned error: %s", err)
+	}
+
+	found := false
+	for _, s := range snippets {
+		if s.Name == "My Dynamic Snippet" {
+			found = true
+			if s.Type != "recv" {
+				t.Errorf("Type: want %q, got %q", "recv", s.Type)
+			}
+			expectedContent := `set req.http.X-Dynamic = "1";`
+			if s.Content != expectedContent {
+				t.Errorf("Content: want %q, got %q", expectedContent, s.Content)
+			}
+		}
+	}
+	if !found {
+		t.Error("Dynamic snippet not found in fetcher.Snippets() output")
+	}
+}

--- a/snippet/terraform/terraform_test.go
+++ b/snippet/terraform/terraform_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/ysugimoto/falco/v2/snippet"
 )
 
 func TestUnmarshallValidTfJson(t *testing.T) {
@@ -273,16 +274,15 @@ func TestUnmarshalWithDynamicSnippetContent(t *testing.T) {
 		t.Fatalf("Expected 1 dynamic snippet, got %d", len(svc.DynamicSnippets))
 	}
 
-	ds := svc.DynamicSnippets[0]
-	if ds.Name != "My Dynamic Snippet" {
-		t.Errorf("Dynamic snippet name: want %q, got %q", "My Dynamic Snippet", ds.Name)
+	expected := &DynamicSnippet{
+		Name:      "My Dynamic Snippet",
+		Type:      "recv",
+		Content:   `set req.http.X-Dynamic = "1";`,
+		Priority:  110,
+		SnippetID: "abc123",
 	}
-	if ds.Type != "recv" {
-		t.Errorf("Dynamic snippet type: want %q, got %q", "recv", ds.Type)
-	}
-	expectedContent := `set req.http.X-Dynamic = "1";`
-	if ds.Content != expectedContent {
-		t.Errorf("Dynamic snippet content: want %q, got %q", expectedContent, ds.Content)
+	if diff := cmp.Diff(expected, svc.DynamicSnippets[0]); diff != "" {
+		t.Errorf("Unmarshalled dynamic snippet mismatch, diff=%s", diff)
 	}
 }
 
@@ -304,21 +304,16 @@ func TestTerraformFetcherIncludesDynamicSnippets(t *testing.T) {
 		t.Fatalf("Snippets() returned error: %s", err)
 	}
 
-	found := false
-	for _, s := range snippets {
-		if s.Name == "My Dynamic Snippet" {
-			found = true
-			if s.Type != "recv" {
-				t.Errorf("Type: want %q, got %q", "recv", s.Type)
-			}
-			expectedContent := `set req.http.X-Dynamic = "1";`
-			if s.Content != expectedContent {
-				t.Errorf("Content: want %q, got %q", expectedContent, s.Content)
-			}
-		}
+	expected := []*snippet.VCLSnippet{
+		{
+			Name:     "My Dynamic Snippet",
+			Type:     "recv",
+			Content:  `set req.http.X-Dynamic = "1";`,
+			Priority: 110,
+		},
 	}
-	if !found {
-		t.Error("Dynamic snippet not found in fetcher.Snippets() output")
+	if diff := cmp.Diff(expected, snippets); diff != "" {
+		t.Errorf("Fetcher Snippets() mismatch, diff=%s", diff)
 	}
 }
 
@@ -365,8 +360,14 @@ func TestDynamicSnippetEmptySnippetIDNotJoined(t *testing.T) {
 	if len(services[0].DynamicSnippets) != 1 {
 		t.Fatalf("Expected 1 dynamic snippet, got %d", len(services[0].DynamicSnippets))
 	}
-	if got := services[0].DynamicSnippets[0].Content; got != "" {
-		t.Errorf("Expected empty content for unmatched empty snippet_id, got %q", got)
+
+	expected := &DynamicSnippet{
+		Name:     "ds",
+		Type:     "recv",
+		Priority: 10,
+	}
+	if diff := cmp.Diff(expected, services[0].DynamicSnippets[0]); diff != "" {
+		t.Errorf("Dynamic snippet should not receive content via empty snippet_id, diff=%s", diff)
 	}
 }
 
@@ -410,7 +411,13 @@ func TestDynamicSnippetContentUnknownServiceID(t *testing.T) {
 	if len(services) != 1 {
 		t.Fatalf("Expected 1 service, got %d", len(services))
 	}
-	if got := services[0].DynamicSnippets[0].Content; got != "" {
-		t.Errorf("Expected empty content for unknown service_id, got %q", got)
+	expected := &DynamicSnippet{
+		Name:      "ds",
+		Type:      "recv",
+		Priority:  10,
+		SnippetID: "abc123",
+	}
+	if diff := cmp.Diff(expected, services[0].DynamicSnippets[0]); diff != "" {
+		t.Errorf("Dynamic snippet should not receive content for unknown service_id, diff=%s", diff)
 	}
 }

--- a/snippet/terraform/terraform_test.go
+++ b/snippet/terraform/terraform_test.go
@@ -321,3 +321,96 @@ func TestTerraformFetcherIncludesDynamicSnippets(t *testing.T) {
 		t.Error("Dynamic snippet not found in fetcher.Snippets() output")
 	}
 }
+
+func TestDynamicSnippetEmptySnippetIDNotJoined(t *testing.T) {
+	// When snippet_id is "known after apply", it appears as an empty string in
+	// the plan JSON for both the inline block and the content resource. The
+	// content must not be joined onto the snippet via an empty-string match.
+	jsonData := `{
+      "planned_values": {
+        "root_module": {
+          "resources": [
+            {
+              "type": "fastly_service_vcl",
+              "provider_name": "registry.terraform.io/fastly/fastly",
+              "values": {
+                "id": "svc1",
+                "name": "emptySnippetIDTest",
+                "dynamicsnippet": [
+                  {"name": "ds", "type": "recv", "priority": 10, "snippet_id": ""}
+                ],
+                "vcl": [
+                  {"content": "sub vcl_recv {\n  #FASTLY recv\n}\n", "main": true, "name": "main.vcl"}
+                ]
+              }
+            },
+            {
+              "type": "fastly_service_dynamic_snippet_content",
+              "provider_name": "registry.terraform.io/fastly/fastly",
+              "values": {"service_id": "svc1", "snippet_id": "", "content": "# should not be joined"}
+            }
+          ]
+        }
+      }
+    }`
+
+	services, err := unmarshalTerraformPlannedInput([]byte(jsonData))
+	if err != nil {
+		t.Fatalf("Unexpected error unmarshalling: %s", err)
+	}
+
+	if len(services) != 1 {
+		t.Fatalf("Expected 1 service, got %d", len(services))
+	}
+	if len(services[0].DynamicSnippets) != 1 {
+		t.Fatalf("Expected 1 dynamic snippet, got %d", len(services[0].DynamicSnippets))
+	}
+	if got := services[0].DynamicSnippets[0].Content; got != "" {
+		t.Errorf("Expected empty content for unmatched empty snippet_id, got %q", got)
+	}
+}
+
+func TestDynamicSnippetContentUnknownServiceID(t *testing.T) {
+	// A fastly_service_dynamic_snippet_content resource may reference a
+	// service_id that is not present in the plan. This must be ignored
+	// gracefully without affecting existing services.
+	jsonData := `{
+      "planned_values": {
+        "root_module": {
+          "resources": [
+            {
+              "type": "fastly_service_vcl",
+              "provider_name": "registry.terraform.io/fastly/fastly",
+              "values": {
+                "id": "svc1",
+                "name": "unknownServiceTest",
+                "dynamicsnippet": [
+                  {"name": "ds", "type": "recv", "priority": 10, "snippet_id": "abc123"}
+                ],
+                "vcl": [
+                  {"content": "sub vcl_recv {\n  #FASTLY recv\n}\n", "main": true, "name": "main.vcl"}
+                ]
+              }
+            },
+            {
+              "type": "fastly_service_dynamic_snippet_content",
+              "provider_name": "registry.terraform.io/fastly/fastly",
+              "values": {"service_id": "does-not-exist", "snippet_id": "abc123", "content": "# orphaned"}
+            }
+          ]
+        }
+      }
+    }`
+
+	services, err := unmarshalTerraformPlannedInput([]byte(jsonData))
+	if err != nil {
+		t.Fatalf("Unexpected error unmarshalling: %s", err)
+	}
+
+	if len(services) != 1 {
+		t.Fatalf("Expected 1 service, got %d", len(services))
+	}
+	if got := services[0].DynamicSnippets[0].Content; got != "" {
+		t.Errorf("Expected empty content for unknown service_id, got %q", got)
+	}
+}


### PR DESCRIPTION
# Description
This feat is to add support for `fastly_service_dynamic_snippet_content`  in `falco terraform` commands. It parses the `fastly_service_dynamic_snippet_content` resource, links each one to its inline `dynamicsnippet` block inside
`fastly_service_vcl`, and feeds the resolved content through the same pipeline used for regular VCL snippets. As a result, all `falco terraform` actions (`lint`, `test`, `simulate`, `stats`) now evaluate dynamic snippets automatically.

## Changes

- Add `DynamicSnippet` model and wire it into `FastlyService` and the
  service value parsing (`snippet/terraform/fastly.go`).
- Add `fastlyDynamicSnippetContent` to map the external resource, plus a
  `DynamicSnippetContents` slice on `FastlyResources`.
- Recognise the new resource type via
  `fastlyServiceDynamicSnippetContentType` and an
  `isFastlyServiceDynamicSnippetContent` predicate, including recursion
  through child modules (`snippet/terraform/terraform.go`).
- Join content onto the matching snippet by `service_id` + `snippet_id`
  in `collectServices`.
- Emit dynamic snippets (with resolved content) from
  `TerraformFetcher.Snippets` so they reach the linter/simulator
  (`snippet/terraform/fetcher.go`).
- Document the feature and its known limitation
  (`docs/terraform.md`).

# Ticket
closes #621 


## Checklist

- [x] Tests added and passing
- [x] `go vet` clean
- [x] Documentation updated
- [ ] Reviewed by a maintainer