### PR TITLE
Fix parse_time_delta parser

### DIFF
--- a/interpreter/function/builtin/parse_time_delta.go
+++ b/interpreter/function/builtin/parse_time_delta.go
@@ -3,6 +3,7 @@
 package builtin
 
 import (
+	"math"
 	"strconv"
 
 	"github.com/ysugimoto/falco/v2/interpreter/context"
@@ -36,44 +37,43 @@ func Parse_time_delta(ctx *context.Context, args ...value.Value) (value.Value, e
 		return value.Null, err
 	}
 
-	specifier := value.Unwrap[*value.String](args[0])
-	var delta int64
-	var stack []byte
+	spec := value.Unwrap[*value.String](args[0]).Value
 
-	// Golang's time.ParseDuration does not recognize "d" and "D", date duration so we need to parse manually
-	for _, s := range []byte(specifier.Value) {
-		switch s {
-		case 0x64, 0x44: // "d" or "D"
-			v, err := strconv.ParseInt(string(stack), 10, 64)
-			if err != nil {
-				return value.Null, errors.New(Parse_time_delta_Name, "Failed to parse dates as int: %s", string(stack))
-			}
-			delta += v * 24 * 60 * 60
-		case 0x68, 0x48: // "h" or "H"
-			v, err := strconv.ParseInt(string(stack), 10, 64)
-			if err != nil {
-				return value.Null, errors.New(Parse_time_delta_Name, "Failed to parse hours as int: %s", string(stack))
-			}
-			delta += v * 60 * 60
-		case 0x6D, 0x4D: // "m" or "M"
-			v, err := strconv.ParseInt(string(stack), 10, 64)
-			if err != nil {
-				return value.Null, errors.New(Parse_time_delta_Name, "Failed to parse minutes as int: %s", string(stack))
-			}
-			delta += v * 60
-		case 0x73, 0x53: // "s" or "S"
-			v, err := strconv.ParseInt(string(stack), 10, 64)
-			if err != nil {
-				return value.Null, errors.New(Parse_time_delta_Name, "Failed to parse seconds as int: %s", string(stack))
-			}
-			delta += v
-		default:
-			if s < 0x30 || s > 0x39 {
-				return value.Null, errors.New(Parse_time_delta_Name, "Invalid character found: %s", string([]byte{s}))
-			}
-			stack = append(stack, s)
+	var i int
+	for i < len(spec) {
+		if c := spec[i]; c != ' ' && c != '\t' && c != '\n' && c != '\v' && c != '\f' && c != '\r' {
+			break
 		}
+		i++
+	}
+	start := i
+	if i < len(spec) && (spec[i] == '+' || spec[i] == '-') {
+		i++
+	}
+	if i == len(spec) || spec[i] < '0' || spec[i] > '9' {
+		return &value.Integer{Value: -1}, nil
+	}
+	for i < len(spec) && spec[i] >= '0' && spec[i] <= '9' {
+		i++
+	}
+	v, err := strconv.ParseInt(spec[start:i], 10, 64)
+	if err != nil || v < 0 {
+		return &value.Integer{Value: -1}, nil
 	}
 
-	return &value.Integer{Value: delta}, nil
+	var unit int64 = 1
+	if i < len(spec) {
+		switch spec[i] {
+		case 'd', 'D':
+			unit = 24 * 3600
+		case 'h', 'H':
+			unit = 3600
+		case 'm', 'M':
+			unit = 60
+		}
+	}
+	if v > math.MaxInt64/unit {
+		return &value.Integer{Value: -1}, nil
+	}
+	return &value.Integer{Value: v * unit}, nil
 }

--- a/interpreter/function/builtin/parse_time_delta_test.go
+++ b/interpreter/function/builtin/parse_time_delta_test.go
@@ -27,6 +27,25 @@ func Test_Parse_time_delta(t *testing.T) {
 		{input: &value.String{Value: "1M"}, expect: &value.Integer{Value: 60}},
 		{input: &value.String{Value: "10s"}, expect: &value.Integer{Value: 10}},
 		{input: &value.String{Value: "10S"}, expect: &value.Integer{Value: 10}},
+		// Only the first number and unit are read; the rest of the string is ignored
+		{input: &value.String{Value: "1d2h"}, expect: &value.Integer{Value: 86400}},
+		{input: &value.String{Value: "5m30s"}, expect: &value.Integer{Value: 300}},
+		// A missing or unrecognized unit means seconds
+		{input: &value.String{Value: "30"}, expect: &value.Integer{Value: 30}},
+		{input: &value.String{Value: "2x"}, expect: &value.Integer{Value: 2}},
+		{input: &value.String{Value: "5 d"}, expect: &value.Integer{Value: 5}},
+		// strtoll semantics: leading whitespace and an explicit sign are accepted
+		{input: &value.String{Value: " 10s"}, expect: &value.Integer{Value: 10}},
+		{input: &value.String{Value: "+2h"}, expect: &value.Integer{Value: 7200}},
+		// Unparseable, negative, or overflowing input yields -1
+		{input: &value.String{Value: ""}, expect: &value.Integer{Value: -1}},
+		{input: &value.String{Value: "abc"}, expect: &value.Integer{Value: -1}},
+		{input: &value.String{Value: "d"}, expect: &value.Integer{Value: -1}},
+		{input: &value.String{Value: "-5d"}, expect: &value.Integer{Value: -1}},
+		{input: &value.String{Value: "99999999999999999999"}, expect: &value.Integer{Value: -1}},
+		{input: &value.String{Value: "9223372036854775807"}, expect: &value.Integer{Value: 9223372036854775807}},
+		{input: &value.String{Value: "106751991167300d"}, expect: &value.Integer{Value: 106751991167300 * 86400}},
+		{input: &value.String{Value: "106751991167301d"}, expect: &value.Integer{Value: -1}},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
The parser was quite broken, for example 1d2h was parsed as 1 day + 12 hours.

We could fix it to return 1 day + 2 hours, but on Fastly servers, what follows the unit is silently ignored.

So, 1d2h parses fine, but returns the same duration as 1d.

So... do the same thing.