### PR TITLE
fix: narrow {NAME} filter to match only .http.{NAME} variables

### DIFF
--- a/cmd/documentation-checker/html.go
+++ b/cmd/documentation-checker/html.go
@@ -53,7 +53,7 @@ func fetchFastlyDocument(ctx context.Context, url string, m *sync.Map) error {
 			}
 			name := a.FirstChild.Data
 			if name == ignoreFunctionIf ||
-				strings.Contains(name, ignoreHTTPHeaderRelatedSignaure) ||
+				strings.Contains(name, ".http."+ignoreHTTPHeaderRelatedSignaure) ||
 				strings.Contains(name, ignoreRegexCapturedNumber) {
 
 				continue

--- a/cmd/documentation-checker/html.go
+++ b/cmd/documentation-checker/html.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	fastlyDocColumnWrapperClassPrefix = "columns-list-module--columnList2"
-	ignoreHTTPHeaderRelatedSignaure   = "{NAME}"
+	ignoreHTTPHeaderRelatedSignature  = "{NAME}"
 	ignoreRegexCapturedNumber         = "{N}"
 	ignoreFunctionIf                  = "if"
 )
@@ -53,7 +53,7 @@ func fetchFastlyDocument(ctx context.Context, url string, m *sync.Map) error {
 			}
 			name := a.FirstChild.Data
 			if name == ignoreFunctionIf ||
-				strings.Contains(name, ".http."+ignoreHTTPHeaderRelatedSignaure) ||
+				strings.Contains(name, ".http."+ignoreHTTPHeaderRelatedSignature) ||
 				strings.Contains(name, ignoreRegexCapturedNumber) {
 
 				continue


### PR DESCRIPTION
The documentation checker skips every variable containing `{NAME}` anywhere in its name. This was meant to filter only HTTP header variables (`req.http.{NAME}`, `bereq.http.{NAME}`, etc.) since Fastly docs use `{NAME}` as a placeholder but `predefined.yml` defines them as `req.http.%any%`. But `strings.Contains(name, "{NAME}")` also matches non-header variables like `backend.{NAME}.healthy`, which should be checked, not skipped.

Changed the filter to `strings.Contains(name, ".http.{NAME}")`. Every HTTP header variable in `predefined.yml` follows the `*.http.%any%` pattern, so requiring `.http.` before `{NAME}` still skips all five header groups (`req.http`, `bereq.http`, `beresp.http`, `obj.http`, `resp.http`) while non-header `{NAME}` variables now pass through.

Closes #287

