### PR TITLE
feat(linter): surface regex/uncaptured-variable rule for re.group.N reads

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -913,6 +913,23 @@ if (req.http.Host) {
 }
 ```
 
+## regex/uncaptured-variable
+
+A `re.group.N` variable is read without a preceding regex match (`~` or `!~`) in the current subroutine scope.
+
+`re.group.N` is subroutine-global in Fastly and its value can leak across `call` boundaries. Reading it before any match in the current subroutine means the value depends on a regex match performed by a caller (or is unset), which is a common source of subtle bugs. Falco reports this as a WARNING.
+
+```vcl
+sub foo {
+  // WARNING: re.group.1 read before any regex match in foo
+  set req.http.x = re.group.1;
+  if (req.http.test ~ "([^.]+)") {}
+  set req.http.y = re.group.1; // OK: preceded by a match
+}
+```
+
+To silence this warning for a specific line, use `# falco-ignore-next-line regex/uncaptured-variable`.
+
 ## disallow-empty-return
 
 A `return` statement in state-machine subroutine like `vcl_recv` must have the next state.

--- a/linter/errors.go
+++ b/linter/errors.go
@@ -429,11 +429,11 @@ func UncapturedRegexVariable(name string, m *ast.Meta) *LintError {
 		Severity: WARNING,
 		Token:    m.Token,
 		Message: fmt.Sprintf(
-			`Regex captured variable "%s" is uncaptured or reset on previous regular expression matching`,
+			`Regex captured variable "%s" is read without a preceding regex match in the current subroutine; its value may be unset or leaked from a caller scope`,
 			name,
 		),
 	}
-	return err.Match(DEPRECATED)
+	return err.Match(UNCAPTURED_REGEX_VARIABLE)
 }
 
 func CapturedRegexVariableOverridden(name string, m *ast.Meta) *LintError {

--- a/linter/rules.go
+++ b/linter/rules.go
@@ -112,4 +112,5 @@ var references = map[Rule]string{
 	UNRECOGNIZE_CALL_SCOPE:           "https://github.com/ysugimoto/falco/blob/main/docs/linter.md#user-defined-subroutine",
 	SUBROUTINE_RECURSIVE_CALL:        "https://www.fastly.com/documentation/reference/vcl/subroutines/#recursion",
 	FORBIDDEN_BACKWARD_JUMP:          "https://fiddle.fastly.dev/fiddle/4814c144",
+	UNCAPTURED_REGEX_VARIABLE:        "https://github.com/ysugimoto/falco/issues/297",
 }

--- a/linter/statement_linter_test.go
+++ b/linter/statement_linter_test.go
@@ -868,6 +868,52 @@ sub foo {
 	}
 }
 
+func TestRegexGroupedVariablesCrossSubroutine(t *testing.T) {
+	// #297 bug pattern: a subroutine reads re.group.N before any match in its own
+	// scope, relying on a leaked value from a caller. Should WARN.
+	t.Run("read before match warns (leak pattern)", func(t *testing.T) {
+		input := `
+sub foo {
+  set req.http.foo1 = re.group.1;
+  if (req.http.test ~ "([^.]+)") {}
+  set req.http.foo2 = re.group.1;
+}
+
+sub bar {
+  set req.http.bar1 = re.group.1;
+  if (req.http.test ~ "(.*)") {}
+  set req.http.bar2 = re.group.1;
+  call foo;
+  set req.http.bar3 = re.group.1;
+}`
+		assertErrorWithSeverity(t, input, WARNING)
+	})
+
+	// Callee has its own match before the read: no warning.
+	t.Run("callee with own match does not warn", func(t *testing.T) {
+		input := `
+sub foo {
+  if (req.http.test ~ "([^.]+)") {}
+  set req.http.foo1 = re.group.1;
+}
+sub bar {
+  call foo;
+}`
+		assertNoError(t, input)
+	})
+
+	// Match precedes the read in the same subroutine: no warning (subroutine-global
+	// scope semantics — a match anywhere in the sub makes re.group.N available).
+	t.Run("match before read in same subroutine does not warn", func(t *testing.T) {
+		input := `
+sub foo {
+  if (req.http.test ~ "(.*)") {}
+  set req.http.foo1 = re.group.1;
+}`
+		assertNoError(t, input)
+	})
+}
+
 func TestGroupedExpressionInStatement(t *testing.T) {
 	tests := []string{
 		`


### PR DESCRIPTION
Resolves the **linter portion** of #297.

## Background

Per @ysugimoto's agreement in #297 (April 2024): the interpreter should follow Fastly semantics (regex groups persist across `call`), but the linter should WARN because relying on cross-subroutine scope leakage is a potential bug pattern. The interpreter side was already implemented by the maintainer in #412 (merged Feb 2025). This PR addresses the linter side, which was never completed.

## What I found

The `UncapturedRegexVariable` WARNING was **already functionally firing** — each subroutine is linted with a fresh regex-group state (`ResetRegexVariables()` on scope entry), so any `re.group.N` read before a match in that subroutine triggers the warning. This is exactly the cross-subroutine leak pattern from #297.

However, it had four gaps:

1. **Wrong rule name (bug):** the warning was matched to the `deprecated` rule via `err.Match(DEPRECATED)` instead of the dedicated `UNCAPTURED_REGEX_VARIABLE` rule (`regex/uncaptured-variable`) that already existed in `rules.go` but was unused. This made the warning mislabelled in output and un-ignorable by its proper name.
2. **No reference URL** for `UNCAPTURED_REGEX_VARIABLE` in the `references` map.
3. **No test coverage** for the #297 cross-subroutine `call` scenario (existing tests were single-subroutine only).
4. **No docs entry** for `regex/uncaptured-variable`.

## Changes

- **`linter/errors.go`** — Fix the rule mapping: `DEPRECATED` → `UNCAPTURED_REGEX_VARIABLE`. Improve the message to explicitly call out the cross-subroutine leak concern.
- **`linter/rules.go`** — Add reference URL pointing to issue #297 in the `references` map.
- **`linter/statement_linter_test.go`** — Add `TestRegexGroupedVariablesCrossSubroutine` covering the #297 `call` scenario:
  - `re.group.N` read before any match in a subroutine → WARNING (leak pattern)
  - Callee with its own match before the read → no warning
  - Match before read in the same subroutine → no warning
- **`docs/rules.md`** — Document the `regex/uncaptured-variable` rule with a VCL example and the `falco-ignore-next-line` silencing instruction.

## User-visible behavior change

The only breaking-ish aspect: anyone who previously silenced this WARNING via `# falco-ignore-next-line deprecated` (or `-ignore deprecated`) will now need `regex/uncaptured-variable`. This is an **intended** fix — the old `deprecated` mapping was a bug (it shared a rule with `DeprecatedVariable()`, making it impossible to selectively ignore the regex warning). The new dedicated rule name is the correct behavior.

No change to **when** the warning fires (verified conservative — no new false positives; matches in `if`/`else` branches correctly do not warn thanks to subroutine-global scope semantics).

Refs #297.