### PR TITLE
fix: return a `not set` string when referencing an undefined field in an HTTP header

### DIFF
--- a/cmd/falco/runner_test.go
+++ b/cmd/falco/runner_test.go
@@ -411,7 +411,7 @@ func TestTester(t *testing.T) {
 			name:   "header subfield dealing test",
 			main:   "../../examples/testing/subfield-header-dealing/default.vcl",
 			filter: "*default.test.vcl",
-			passes: 10,
+			passes: 24,
 		},
 		{
 			name:   "synthetic vs obj.response",

--- a/examples/testing/subfield-header-dealing/default.test.vcl
+++ b/examples/testing/subfield-header-dealing/default.test.vcl
@@ -78,3 +78,107 @@ sub test_recv {
     set req.http.VARS:VALUE = req.http.NULL;
     assert.equal(req.http.VARS, "VALUE");
 }
+
+// Reading a subfield distinguishes "not set" from a defined empty string.
+// Fastly only treats not-set strings as falsy, so an absent subfield of a
+// header that is itself defined must still read as not set.
+// All test cases referred to Fastly fiddle behaviors
+// see: https://fiddle.fastly.dev/fiddle/28404963
+
+// @scope: recv
+// @suite: GET UNDEFINED VARS VALUE FROM EMPTY VARS
+sub test_recv {
+    declare local var.state STRING;
+    set req.http.VARS = "";
+    if (req.http.VARS:VALUE) {
+        set var.state = "truthy";
+    } else {
+        set var.state = "falsy";
+    }
+    assert.equal(var.state, "falsy");
+    assert.is_notset(req.http.VARS:VALUE);
+}
+
+// @scope: recv
+// @suite: GET EMPTY VARS ITSELF
+sub test_recv {
+    declare local var.state STRING;
+    set req.http.VARS = "";
+    if (req.http.VARS) {
+        set var.state = "truthy";
+    } else {
+        set var.state = "falsy";
+    }
+    assert.equal(var.state, "truthy");
+    assert.equal(req.http.VARS, "");
+}
+
+// @scope: recv
+// @suite: GET VARS VALUE OF BARE KEY WITHOUT VALUE
+sub test_recv {
+    declare local var.state STRING;
+    set req.http.BARE = "VALUE";
+    if (req.http.BARE:VALUE) {
+        set var.state = "truthy";
+    } else {
+        set var.state = "falsy";
+    }
+    assert.equal(var.state, "truthy");
+    assert.equal(req.http.BARE:VALUE, "");
+}
+
+// @scope: recv
+// @suite: GET UNDEFINED VARS VALUE FROM NOT-INITIALIZED VARS
+sub test_recv {
+    declare local var.state STRING;
+    if (req.http.NOTSET:VALUE) {
+        set var.state = "truthy";
+    } else {
+        set var.state = "falsy";
+    }
+    assert.equal(var.state, "falsy");
+    assert.is_notset(req.http.NOTSET:VALUE);
+}
+
+// @scope: recv
+// @suite: GET UNDEFINED VARS VALUE WHEN ANOTHER KEY EXISTS
+sub test_recv {
+    declare local var.state STRING;
+    set req.http.OTHER = "OTHER=O";
+    if (req.http.OTHER:VALUE) {
+        set var.state = "truthy";
+    } else {
+        set var.state = "falsy";
+    }
+    assert.equal(var.state, "falsy");
+    assert.is_notset(req.http.OTHER:VALUE);
+}
+
+// @scope: recv
+// @suite: GET VARS VALUE WITH EXPLICIT EMPTY VALUE
+sub test_recv {
+    declare local var.state STRING;
+    set req.http.EMPTYVAL = "VALUE=";
+    if (req.http.EMPTYVAL:VALUE) {
+        set var.state = "truthy";
+    } else {
+        set var.state = "falsy";
+    }
+    assert.equal(var.state, "truthy");
+    assert.equal(req.http.EMPTYVAL:VALUE, "");
+}
+
+// @scope: recv
+// @suite: ASSIGN UNDEFINED VARS VALUE TO ANOTHER HEADER
+sub test_recv {
+    declare local var.state STRING;
+    set req.http.VARS = "";
+    set req.http.COPY = req.http.VARS:VALUE;
+    if (req.http.COPY) {
+        set var.state = "truthy";
+    } else {
+        set var.state = "falsy";
+    }
+    assert.equal(var.state, "falsy");
+    assert.is_notset(req.http.COPY);
+}

--- a/interpreter/variable/header.go
+++ b/interpreter/variable/header.go
@@ -58,11 +58,11 @@ func getRequestHeaderValue(r *http.Request, name string) *value.String {
 	var key string
 	name, key, _ = strings.Cut(name, ":")
 	v := r.Header.Get(name)
-	if v == "" {
-		return &value.String{IsNotSet: !r.IsAssigned(name)}
-	}
 
 	if key == "" {
+		if v == "" {
+			return &value.String{IsNotSet: !r.IsAssigned(name)}
+		}
 		return &value.String{Value: v}
 	}
 
@@ -83,11 +83,11 @@ func getResponseHeaderValue(r *http.Response, name string) *value.String {
 	var key string
 	name, key, _ = strings.Cut(name, ":")
 	v := r.Header.Get(name)
-	if v == "" {
-		return &value.String{IsNotSet: !r.IsAssigned(name)}
-	}
 
 	if key == "" {
+		if v == "" {
+			return &value.String{IsNotSet: !r.IsAssigned(name)}
+		}
 		return &value.String{Value: v}
 	}
 

--- a/interpreter/variable/header_test.go
+++ b/interpreter/variable/header_test.go
@@ -38,6 +38,54 @@ func TestGetRequestHeaderValue(t *testing.T) {
 	}
 
 }
+
+func TestGetRequestHeaderValueEmptyHeaderFields(t *testing.T) {
+	tests := []struct {
+		name   string
+		setup  func(*http.Request)
+		target string
+		expect *value.String
+	}{
+		{
+			name: "unset field in assigned empty header",
+			setup: func(req *http.Request) {
+				setRequestHeaderValue(req, "Input", &value.String{Value: ""})
+			},
+			target: "Input:field-key",
+			expect: &value.String{IsNotSet: true},
+		},
+		{
+			name: "assigned empty header",
+			setup: func(req *http.Request) {
+				setRequestHeaderValue(req, "Input", &value.String{Value: ""})
+			},
+			target: "Input",
+			expect: &value.String{Value: ""},
+		},
+		{
+			name: "empty field in assigned header",
+			setup: func(req *http.Request) {
+				setRequestHeaderValue(req, "Input", &value.String{Value: ""})
+				setRequestHeaderValue(req, "Input:field-key", &value.String{Value: ""})
+			},
+			target: "Input:field-key",
+			expect: &value.String{Value: ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := http.WrapRequest(
+				httptest.NewRequest(ghttp.MethodGet, "http://localhost", nil),
+			)
+			tt.setup(req)
+			if diff := cmp.Diff(tt.expect, getRequestHeaderValue(req, tt.target)); diff != "" {
+				t.Errorf("Return value unmatch, diff=%s", diff)
+			}
+		})
+	}
+}
+
 func TestGetReponseHeaderValue(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -62,6 +110,51 @@ func TestGetReponseHeaderValue(t *testing.T) {
 		}
 	}
 
+}
+
+func TestGetResponseHeaderValueEmptyHeaderFields(t *testing.T) {
+	tests := []struct {
+		name   string
+		setup  func(*http.Response)
+		target string
+		expect *value.String
+	}{
+		{
+			name: "unset field in assigned empty header",
+			setup: func(resp *http.Response) {
+				setResponseHeaderValue(resp, "Input", &value.String{Value: ""})
+			},
+			target: "Input:field-key",
+			expect: &value.String{IsNotSet: true},
+		},
+		{
+			name: "assigned empty header",
+			setup: func(resp *http.Response) {
+				setResponseHeaderValue(resp, "Input", &value.String{Value: ""})
+			},
+			target: "Input",
+			expect: &value.String{Value: ""},
+		},
+		{
+			name: "empty field in assigned header",
+			setup: func(resp *http.Response) {
+				setResponseHeaderValue(resp, "Input", &value.String{Value: ""})
+				setResponseHeaderValue(resp, "Input:field-key", &value.String{Value: ""})
+			},
+			target: "Input:field-key",
+			expect: &value.String{Value: ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := http.WrapResponse(&ghttp.Response{Header: ghttp.Header{}})
+			tt.setup(resp)
+			if diff := cmp.Diff(tt.expect, getResponseHeaderValue(resp, tt.target)); diff != "" {
+				t.Errorf("Return value unmatch, diff=%s", diff)
+			}
+		})
+	}
 }
 func TestSetRequestHeaderValue(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

This change fixes an issue where an undefined HTTP header field was treated as a defined empty string.

Fastly VCL handles string-to-boolean conversion differently from many programming languages. Only strings that are not set are falsy; a defined empty string is truthy.

Reference: [Fastly VCL best practices](https://www.fastly.com/documentation/guides/full-site-delivery/fastly-vcl/vcl-best-practices/)

## Problematic case

This means that VCL must distinguish between an HTTP header that is explicitly defined as an empty string and a field that is not defined within that header.

For example, when an unset field is read from an empty parent header, `req.http.Input:field-key` should be falsy:

```vcl
# https://fiddle.fastly.dev/fiddle/76847460

set req.http.Input = "";

# Expected: "field-key is not set" is logged
if (req.http.Input:field-key) {
  log "field-key is set";
} else {
  log "field-key is not set";
}
```

Before this fix, Falco treated `req.http.Input:field-key` as a defined empty string. Since defined empty strings are truthy, the condition evaluated to true.

On the other hand, the following case should return `true`, because the field itself is set even though its value is empty. Its boolean value should therefore be truthy:

```vcl
# https://fiddle.fastly.dev/fiddle/29a1b3b4

set req.http.Input = "field-key";

# Expected: "field-key is set to an empty string" is logged
if (req.http.Input:field-key) {
  log "field-key is set to an empty string";
} else {
  log "field-key is not set";
}
```

## Root cause

In the current Falco implementation, an empty HTTP header value is always handled first.

Falco checks whether the header itself is unset, then returns the empty value.

This also happens when Falco reads a field value from the HTTP header.

As a result, when the header value is explicitly defined as an empty string, an undefined field was also returned as a defined empty string.

In Fastly VCL, an undefined field must be returned as an unset string.

## Changes

The code now separates whole-header lookups from field-value lookups.

Whole-header lookups are used when no field key is specified.

Field-value lookups always call `GetField()`.

This produces the intended behavior for empty header values.
