### PR TITLE
fix: align querystring builtin behaviour

### DIFF
--- a/__generator__/builtin.yml
+++ b/__generator__/builtin.yml
@@ -776,6 +776,7 @@ querystring.sort:
   reference: "https://developer.fastly.com/reference/vcl/functions/query-string/querystring-sort/"
   on: [RECV, HASH, HIT, MISS, PASS, FETCH, ERROR, DELIVER, LOG]
   arguments:
+    - [STRING, BOOL]
     - [STRING]
   return: STRING
 

--- a/interpreter/function/builtin/querystring_add.go
+++ b/interpreter/function/builtin/querystring_add.go
@@ -39,12 +39,7 @@ func Querystring_add(ctx *context.Context, args ...value.Value) (value.Value, er
 	name := value.Unwrap[*value.String](args[1])
 	val := value.Unwrap[*value.String](args[2])
 
-	query, err := shared.ParseQuery(u.Value)
-	if err != nil {
-		return value.Null, errors.New(
-			Querystring_add_Name, "Failed to parse querystring: %s, error: %s", u.Value, err.Error(),
-		)
-	}
+	query := shared.ParseQuery(u.Value)
 
 	query.Add(name.Value, val.Value)
 	return &value.String{Value: query.String()}, nil

--- a/interpreter/function/builtin/querystring_clean.go
+++ b/interpreter/function/builtin/querystring_clean.go
@@ -37,12 +37,7 @@ func Querystring_clean(ctx *context.Context, args ...value.Value) (value.Value, 
 
 	v := value.Unwrap[*value.String](args[0])
 
-	query, err := shared.ParseQuery(v.Value)
-	if err != nil {
-		return value.Null, errors.New(
-			Querystring_clean_Name, "Failed to parse url: %s, error: %s", v.Value, err.Error(),
-		)
-	}
+	query := shared.ParseQuery(v.Value)
 
 	query.Clean()
 	return &value.String{Value: query.String()}, nil

--- a/interpreter/function/builtin/querystring_edge_corpus_test.go
+++ b/interpreter/function/builtin/querystring_edge_corpus_test.go
@@ -1,0 +1,167 @@
+package builtin
+
+import (
+	"testing"
+
+	"github.com/ysugimoto/falco/v2/interpreter/context"
+	"github.com/ysugimoto/falco/v2/interpreter/value"
+)
+
+// Test_QuerystringEdgeCorpus covers shared query string behavior across the builtin family.
+func Test_QuerystringEdgeCorpus(t *testing.T) {
+	s := func(v string) *value.String { return &value.String{Value: v} }
+	b := func(v bool) *value.Boolean { return &value.Boolean{Value: v} }
+	ctx := &context.Context{}
+
+	tests := []struct {
+		name   string
+		call   func() (value.Value, error)
+		expect string
+	}{
+		{
+			name:   "get does not decode",
+			call:   func() (value.Value, error) { return Querystring_get(ctx, s("/q?a=%41&b=2"), s("a")) },
+			expect: "%41",
+		},
+		{
+			name:   "get returns the first duplicate",
+			call:   func() (value.Value, error) { return Querystring_get(ctx, s("/q?a=1&a=2"), s("a")) },
+			expect: "1",
+		},
+		{
+			name:   "get skips a valueless match and keeps searching",
+			call:   func() (value.Value, error) { return Querystring_get(ctx, s("/q?a&a=1"), s("a")) },
+			expect: "1",
+		},
+		{
+			name:   "sort orders whole tokens",
+			call:   func() (value.Value, error) { return Querystring_sort(ctx, s("/q?b=2&b=1&a=0")) },
+			expect: "/q?a=0&b=1&b=2",
+		},
+		{
+			name:   "sort compares values bytewise",
+			call:   func() (value.Value, error) { return Querystring_sort(ctx, s("/q?b=9&b=10&a=0")) },
+			expect: "/q?a=0&b=10&b=9",
+		},
+		{
+			name:   "sort leaves 32 parameters alone",
+			call:   func() (value.Value, error) { return Querystring_sort(ctx, s(descendingParams(32))) },
+			expect: descendingParams(32),
+		},
+		{
+			name:   "sort keeps a bare question mark",
+			call:   func() (value.Value, error) { return Querystring_sort(ctx, s("/foo?")) },
+			expect: "/foo?",
+		},
+		{
+			name:   "only_unique_keys keeps the first occurrence",
+			call:   func() (value.Value, error) { return Querystring_sort(ctx, s("/test?a=7&a=2&a=1&b=5&b=3"), b(true)) },
+			expect: "/test?a=7&b=5",
+		},
+		{
+			name:   "clean keeps duplicates in place",
+			call:   func() (value.Value, error) { return Querystring_clean(ctx, s("/q?b=1&a=2&b=3")) },
+			expect: "/q?b=1&a=2&b=3",
+		},
+		{
+			name:   "clean preserves encoding",
+			call:   func() (value.Value, error) { return Querystring_clean(ctx, s("/q?a=%41&b=x%20y&c=p/q")) },
+			expect: "/q?a=%41&b=x%20y&c=p/q",
+		},
+		{
+			name:   "clean keeps a valueless parameter distinct from a same-named valued one",
+			call:   func() (value.Value, error) { return Querystring_clean(ctx, s("/q?b&b=1")) },
+			expect: "/q?b&b=1",
+		},
+		{
+			name:   "filter preserves encoding",
+			call:   func() (value.Value, error) { return Querystring_filter(ctx, s("/q?a=%41&b=2"), s("b")) },
+			expect: "/q?a=%41",
+		},
+		{
+			name:   "filter_except drops an empty-named parameter and anything not kept",
+			call:   func() (value.Value, error) { return Querystring_filter_except(ctx, s("/q?=v&a=1&b=2"), s("a")) },
+			expect: "/q?a=1",
+		},
+		{
+			name:   "filter_except leaves the url unchanged for an empty keep-list",
+			call:   func() (value.Value, error) { return Querystring_filter_except(ctx, s("/q?a=1&b=2"), s("")) },
+			expect: "/q?a=1&b=2",
+		},
+
+		// Empty names are discarded before evaluating each filter predicate.
+		{
+			name:   "filter drops an empty-named parameter absent from the remove-list",
+			call:   func() (value.Value, error) { return Querystring_filter(ctx, s("/q?=v&a=1&b=2"), s("b")) },
+			expect: "/q?a=1",
+		},
+		{
+			name: "filter_except drops an empty-named parameter that is on the keep-list",
+			call: func() (value.Value, error) {
+				return Querystring_filter_except(ctx, s("/q?=v&a=1&b=2"), s("a\xff"))
+			},
+			expect: "/q?a=1",
+		},
+		{
+			name:   "globfilter drops an empty-named parameter the glob does not match",
+			call:   func() (value.Value, error) { return Querystring_globfilter(ctx, s("/q?=v&a=1&b=2"), s("b*")) },
+			expect: "/q?a=1",
+		},
+		{
+			name: "globfilter_except drops an empty-named parameter matched by a catch-all glob",
+			call: func() (value.Value, error) {
+				return Querystring_globfilter_except(ctx, s("/q?=v&a=1&b=2"), s("*"))
+			},
+			expect: "/q?a=1&b=2",
+		},
+		{
+			name:   "regfilter drops an empty-named parameter the regexp does not match",
+			call:   func() (value.Value, error) { return Querystring_regfilter(ctx, s("/q?=v&a=1&b=2"), s("^b$")) },
+			expect: "/q?a=1",
+		},
+		{
+			name: "regfilter_except drops an empty-named parameter matched by the regexp",
+			call: func() (value.Value, error) {
+				return Querystring_regfilter_except(ctx, s("/q?=v&a=1&b=2"), s("^(|a)$"))
+			},
+			expect: "/q?a=1",
+		},
+		{
+			name:   "add writes a space as %20",
+			call:   func() (value.Value, error) { return Querystring_add(ctx, s("/q?x=1"), s("y"), s("a b")) },
+			expect: "/q?x=1&y=a%20b",
+		},
+		{
+			name:   "add escapes the name too",
+			call:   func() (value.Value, error) { return Querystring_add(ctx, s("/q?x=1"), s("a b"), s("v")) },
+			expect: "/q?x=1&a%20b=v",
+		},
+		{
+			name:   "add is a no-op for an empty value",
+			call:   func() (value.Value, error) { return Querystring_add(ctx, s("/q?x=1"), s("y"), s("")) },
+			expect: "/q?x=1",
+		},
+		{
+			name:   "set replaces in place and drops later duplicates",
+			call:   func() (value.Value, error) { return Querystring_set(ctx, s("/q?a=1&b=2&a=3"), s("a"), s("9")) },
+			expect: "/q?a=9&b=2",
+		},
+		{
+			name:   "set is a no-op for an empty value",
+			call:   func() (value.Value, error) { return Querystring_set(ctx, s("/q?x=1"), s("x"), s("")) },
+			expect: "/q?x=1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ret, err := tt.call()
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if got := value.Unwrap[*value.String](ret).Value; got != tt.expect {
+				t.Errorf("expected %q, got %q", tt.expect, got)
+			}
+		})
+	}
+}

--- a/interpreter/function/builtin/querystring_filter.go
+++ b/interpreter/function/builtin/querystring_filter.go
@@ -40,12 +40,7 @@ func Querystring_filter(ctx *context.Context, args ...value.Value) (value.Value,
 	v := value.Unwrap[*value.String](args[0])
 	names := value.Unwrap[*value.String](args[1])
 
-	query, err := shared.ParseQuery(v.Value)
-	if err != nil {
-		return value.Null, errors.New(
-			Querystring_filter_Name, "Failed to parse query: %s, error: %s", v.Value, err.Error(),
-		)
-	}
+	query := shared.ParseQuery(v.Value)
 	filterMap := make(map[string]struct{})
 	for f := range bytes.SplitSeq([]byte(names.Value), Querystring_filtersep_Sign) {
 		filterMap[string(f)] = struct{}{}

--- a/interpreter/function/builtin/querystring_filter_except.go
+++ b/interpreter/function/builtin/querystring_filter_except.go
@@ -40,12 +40,12 @@ func Querystring_filter_except(ctx *context.Context, args ...value.Value) (value
 	v := value.Unwrap[*value.String](args[0])
 	names := value.Unwrap[*value.String](args[1])
 
-	query, err := shared.ParseQuery(v.Value)
-	if err != nil {
-		return value.Null, errors.New(
-			Querystring_filter_except_Name, "Failed to parse query: %s, error: %s", v.Value, err.Error(),
-		)
+	// An empty allowlist leaves the URL unchanged.
+	if names.Value == "" {
+		return &value.String{Value: v.Value}, nil
 	}
+
+	query := shared.ParseQuery(v.Value)
 	filterMap := make(map[string]struct{})
 	for f := range bytes.SplitSeq([]byte(names.Value), Querystring_filtersep_Sign) {
 		filterMap[string(f)] = struct{}{}

--- a/interpreter/function/builtin/querystring_filter_except_test.go
+++ b/interpreter/function/builtin/querystring_filter_except_test.go
@@ -42,3 +42,17 @@ func Test_Querystring_filter_except(t *testing.T) {
 		}
 	}
 }
+
+func Test_Querystring_filter_except_emptyNameList(t *testing.T) {
+	ret, err := Querystring_filter_except(
+		&context.Context{},
+		&value.String{Value: "/q?a=1&b=2"},
+		&value.String{Value: ""},
+	)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	if got := value.Unwrap[*value.String](ret).Value; got != "/q?a=1&b=2" {
+		t.Errorf("expected the url unchanged, got %q", got)
+	}
+}

--- a/interpreter/function/builtin/querystring_globfilter.go
+++ b/interpreter/function/builtin/querystring_globfilter.go
@@ -39,12 +39,7 @@ func Querystring_globfilter(ctx *context.Context, args ...value.Value) (value.Va
 	v := value.Unwrap[*value.String](args[0])
 	name := value.Unwrap[*value.String](args[1])
 
-	query, err := shared.ParseQuery(v.Value)
-	if err != nil {
-		return value.Null, errors.New(
-			Querystring_globfilter_Name, "Failed to parse query: %s, error: %s", v.Value, err.Error(),
-		)
-	}
+	query := shared.ParseQuery(v.Value)
 
 	pattern, err := glob.Compile(name.Value)
 	if err != nil {

--- a/interpreter/function/builtin/querystring_globfilter_except.go
+++ b/interpreter/function/builtin/querystring_globfilter_except.go
@@ -39,12 +39,12 @@ func Querystring_globfilter_except(ctx *context.Context, args ...value.Value) (v
 	v := value.Unwrap[*value.String](args[0])
 	name := value.Unwrap[*value.String](args[1])
 
-	query, err := shared.ParseQuery(v.Value)
-	if err != nil {
-		return value.Null, errors.New(
-			Querystring_globfilter_except_Name, "Failed to parse query: %s, error: %s", v.Value, err.Error(),
-		)
+	// An empty pattern leaves the URL unchanged.
+	if name.Value == "" {
+		return &value.String{Value: v.Value}, nil
 	}
+
+	query := shared.ParseQuery(v.Value)
 
 	pattern, err := glob.Compile(name.Value)
 	if err != nil {

--- a/interpreter/function/builtin/querystring_globfilter_except_test.go
+++ b/interpreter/function/builtin/querystring_globfilter_except_test.go
@@ -41,3 +41,17 @@ func Test_Querystring_globfilter_except(t *testing.T) {
 		}
 	}
 }
+
+func Test_Querystring_globfilter_except_emptyPattern(t *testing.T) {
+	ret, err := Querystring_globfilter_except(
+		&context.Context{},
+		&value.String{Value: "/q?a=1&b=2"},
+		&value.String{Value: ""},
+	)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	if got := value.Unwrap[*value.String](ret).Value; got != "/q?a=1&b=2" {
+		t.Errorf("expected the url unchanged, got %q", got)
+	}
+}

--- a/interpreter/function/builtin/querystring_regfilter.go
+++ b/interpreter/function/builtin/querystring_regfilter.go
@@ -39,12 +39,7 @@ func Querystring_regfilter(ctx *context.Context, args ...value.Value) (value.Val
 	v := value.Unwrap[*value.String](args[0])
 	name := value.Unwrap[*value.String](args[1])
 
-	query, err := shared.ParseQuery(v.Value)
-	if err != nil {
-		return value.Null, errors.New(
-			Querystring_regfilter_Name, "Failed to parse query: %s, error: %s", v.Value, err.Error(),
-		)
-	}
+	query := shared.ParseQuery(v.Value)
 
 	re, err := regexp.Compile(name.Value)
 	if err != nil {

--- a/interpreter/function/builtin/querystring_regfilter_except.go
+++ b/interpreter/function/builtin/querystring_regfilter_except.go
@@ -39,12 +39,12 @@ func Querystring_regfilter_except(ctx *context.Context, args ...value.Value) (va
 	v := value.Unwrap[*value.String](args[0])
 	name := value.Unwrap[*value.String](args[1])
 
-	query, err := shared.ParseQuery(v.Value)
-	if err != nil {
-		return value.Null, errors.New(
-			Querystring_regfilter_except_Name, "Failed to parse query: %s, error: %s", v.Value, err.Error(),
-		)
+	// An empty pattern leaves the URL unchanged.
+	if name.Value == "" {
+		return &value.String{Value: v.Value}, nil
 	}
+
+	query := shared.ParseQuery(v.Value)
 
 	re, err := regexp.Compile(name.Value)
 	if err != nil {

--- a/interpreter/function/builtin/querystring_regfilter_except_test.go
+++ b/interpreter/function/builtin/querystring_regfilter_except_test.go
@@ -41,3 +41,17 @@ func Test_Querystring_regfilter_except(t *testing.T) {
 		}
 	}
 }
+
+func Test_Querystring_regfilter_except_emptyPattern(t *testing.T) {
+	ret, err := Querystring_regfilter_except(
+		&context.Context{},
+		&value.String{Value: "/q?a=1&b=2"},
+		&value.String{Value: ""},
+	)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	if got := value.Unwrap[*value.String](ret).Value; got != "/q?a=1&b=2" {
+		t.Errorf("expected the url unchanged, got %q", got)
+	}
+}

--- a/interpreter/function/builtin/querystring_set.go
+++ b/interpreter/function/builtin/querystring_set.go
@@ -39,12 +39,7 @@ func Querystring_set(ctx *context.Context, args ...value.Value) (value.Value, er
 	name := value.Unwrap[*value.String](args[1])
 	val := value.Unwrap[*value.String](args[2])
 
-	query, err := shared.ParseQuery(u.Value)
-	if err != nil {
-		return value.Null, errors.New(
-			Querystring_set_Name, "Failed to parse urquery: %s, error: %s", u.Value, err.Error(),
-		)
-	}
+	query := shared.ParseQuery(u.Value)
 
 	query.Set(name.Value, val.Value)
 	return &value.String{Value: query.String()}, nil

--- a/interpreter/function/builtin/querystring_sort.go
+++ b/interpreter/function/builtin/querystring_sort.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ysugimoto/falco/v2/interpreter/context"
 	"github.com/ysugimoto/falco/v2/interpreter/function/errors"
-	"github.com/ysugimoto/falco/v2/interpreter/function/shared"
 	"github.com/ysugimoto/falco/v2/interpreter/value"
 )
 
@@ -17,6 +16,21 @@ const Querystring_sort_Name = "querystring.sort"
 // parameters, so neither the sort nor only_unique_keys is applied. Empty
 // parameters count toward the limit.
 const Querystring_sort_ParameterLimit = 32
+
+// qsToken preserves whether a query parameter ended the original input.
+type qsToken struct {
+	s       string
+	isFinal bool
+}
+
+func qsScan(query string) []qsToken {
+	parts := strings.Split(query, "&")
+	tokens := make([]qsToken, len(parts))
+	for i, p := range parts {
+		tokens[i] = qsToken{s: p, isFinal: i == len(parts)-1}
+	}
+	return tokens
+}
 
 var Querystring_sort_ArgumentTypes = []value.Type{value.StringType, value.BooleanType}
 
@@ -43,28 +57,128 @@ func Querystring_sort(ctx *context.Context, args ...value.Value) (value.Value, e
 		return value.Null, err
 	}
 
-	u := value.Unwrap[*value.String](args[0])
+	input := value.Unwrap[*value.String](args[0]).Value
+	uniqueKeys := len(args) > 1 && value.Unwrap[*value.Boolean](args[1]).Value
 
-	if idx := strings.Index(u.Value, "?"); idx != -1 {
-		if strings.Count(u.Value[idx+1:], "&")+1 >= Querystring_sort_ParameterLimit {
-			return &value.String{Value: u.Value}, nil
+	return &value.String{Value: querystringSort(input, uniqueKeys)}, nil
+}
+
+func querystringSort(input string, uniqueKeys bool) string {
+	idx := strings.Index(input, "?")
+	if idx == -1 {
+		return input
+	}
+
+	tokens := qsScan(input[idx+1:])
+
+	// The parameter limit includes empty tokens and bypasses deduplication.
+	if len(tokens) >= Querystring_sort_ParameterLimit {
+		return input
+	}
+	// Single-token query strings are returned byte-for-byte.
+	if len(tokens) == 1 {
+		return input
+	}
+
+	if uniqueKeys {
+		tokens = qsUnique(tokens)
+	}
+
+	return qsEmit(input[:idx], qsSortTokens(tokens))
+}
+
+// qsUnique keeps the first token for each distinct name.
+func qsUnique(tokens []qsToken) []qsToken {
+	unique := make([]qsToken, 0, len(tokens))
+	for _, tok := range tokens {
+		duplicate := false
+		for _, kept := range unique {
+			if qsSameName(tok, kept) {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			unique = append(unique, tok)
 		}
 	}
+	return unique
+}
 
-	query, err := shared.ParseQuery(u.Value)
-	if err != nil {
-		return value.Null, errors.New(
-			Querystring_sort_Name, "Failed to parse urquery: %s, error: %s", u.Value, err.Error(),
-		)
+// qsEnds reports whether c terminates a token.
+func qsEnds(c byte) bool { return c == '&' || c == 0x00 }
+
+// qsTerminatorsEqual treats separators and end-of-input markers equivalently.
+func qsTerminatorsEqual(a, b byte) bool {
+	return a == b || (a == 0x00 && b == '&') || (a == '&' && b == 0x00)
+}
+
+// qsByteAt returns a token byte or its original terminator.
+func qsByteAt(t qsToken, i int) byte {
+	if i < len(t.s) {
+		return t.s[i]
 	}
-
-	// The optional only_unique_keys argument filters out repeated keys.
-	// Fastly keeps the first occurrence in input order, so this must run
-	// before sorting.
-	if len(args) > 1 && value.Unwrap[*value.Boolean](args[1]).Value {
-		query.Unique()
+	if t.isFinal {
+		return 0x00
 	}
+	return '&'
+}
 
-	query.Sort(shared.SortAsc)
-	return &value.String{Value: query.String()}, nil
+// qsCompare applies signed byte ordering with the original terminator context.
+func qsCompare(a, b qsToken) int {
+	for i := 0; ; i++ {
+		ca, cb := qsByteAt(a, i), qsByteAt(b, i)
+		if !qsTerminatorsEqual(ca, cb) {
+			return int(int8(ca)) - int(int8(cb))
+		}
+		if qsEnds(ca) {
+			return 0
+		}
+	}
+}
+
+// qsSameName distinguishes valued and valueless forms of the same name.
+func qsSameName(a, b qsToken) bool {
+	for i := 0; ; i++ {
+		ca, cb := qsByteAt(a, i), qsByteAt(b, i)
+		aStop, bStop := qsEnds(ca) || ca == '=', qsEnds(cb) || cb == '='
+		if aStop || bStop {
+			return (qsEnds(ca) && qsEnds(cb)) || (ca == '=' && cb == '=')
+		}
+		if ca != cb {
+			return false
+		}
+	}
+}
+
+// qsSortTokens performs a stable insertion sort.
+func qsSortTokens(tokens []qsToken) []qsToken {
+	sorted := make([]qsToken, 0, len(tokens))
+	for _, tok := range tokens {
+		p := 0
+		for ; p < len(sorted); p++ {
+			if qsCompare(tok, sorted[p]) < 0 {
+				break
+			}
+		}
+		sorted = append(sorted, qsToken{})
+		copy(sorted[p+1:], sorted[p:])
+		sorted[p] = tok
+	}
+	return sorted
+}
+
+// qsEmit joins tokens after removing only leading empty entries.
+func qsEmit(prefix string, tokens []qsToken) string {
+	p := 0
+	for ; p < len(tokens)-1; p++ {
+		if tokens[p].s != "" {
+			break
+		}
+	}
+	parts := make([]string, 0, len(tokens)-p)
+	for _, tok := range tokens[p:] {
+		parts = append(parts, tok.s)
+	}
+	return prefix + "?" + strings.Join(parts, "&")
 }

--- a/interpreter/function/builtin/querystring_sort.go
+++ b/interpreter/function/builtin/querystring_sort.go
@@ -11,11 +11,11 @@ import (
 
 const Querystring_sort_Name = "querystring.sort"
 
-var Querystring_sort_ArgumentTypes = []value.Type{value.StringType}
+var Querystring_sort_ArgumentTypes = []value.Type{value.StringType, value.BooleanType}
 
 func Querystring_sort_Validate(args []value.Value) error {
-	if len(args) != 1 {
-		return errors.ArgumentNotEnough(Querystring_sort_Name, 1, args)
+	if len(args) < 1 || len(args) > 2 {
+		return errors.ArgumentNotInRange(Querystring_sort_Name, 1, 2, args)
 	}
 	for i := range args {
 		if args[i].Type() != Querystring_sort_ArgumentTypes[i] {
@@ -27,6 +27,7 @@ func Querystring_sort_Validate(args []value.Value) error {
 
 // Fastly built-in function implementation of querystring.sort
 // Arguments may be:
+// - STRING, BOOL
 // - STRING
 // Reference: https://developer.fastly.com/reference/vcl/functions/query-string/querystring-sort/
 func Querystring_sort(ctx *context.Context, args ...value.Value) (value.Value, error) {
@@ -41,6 +42,13 @@ func Querystring_sort(ctx *context.Context, args ...value.Value) (value.Value, e
 		return value.Null, errors.New(
 			Querystring_sort_Name, "Failed to parse urquery: %s, error: %s", u.Value, err.Error(),
 		)
+	}
+
+	// The optional only_unique_keys argument filters out repeated keys.
+	// Fastly keeps the first occurrence in input order, so this must run
+	// before sorting.
+	if len(args) > 1 && value.Unwrap[*value.Boolean](args[1]).Value {
+		query.Unique()
 	}
 
 	query.Sort(shared.SortAsc)

--- a/interpreter/function/builtin/querystring_sort.go
+++ b/interpreter/function/builtin/querystring_sort.go
@@ -64,12 +64,12 @@ func Querystring_sort(ctx *context.Context, args ...value.Value) (value.Value, e
 }
 
 func querystringSort(input string, uniqueKeys bool) string {
-	idx := strings.Index(input, "?")
-	if idx == -1 {
+	prefix, query, found := strings.Cut(input, "?")
+	if !found {
 		return input
 	}
 
-	tokens := qsScan(input[idx+1:])
+	tokens := qsScan(query)
 
 	// The parameter limit includes empty tokens and bypasses deduplication.
 	if len(tokens) >= Querystring_sort_ParameterLimit {
@@ -84,7 +84,7 @@ func querystringSort(input string, uniqueKeys bool) string {
 		tokens = qsUnique(tokens)
 	}
 
-	return qsEmit(input[:idx], qsSortTokens(tokens))
+	return qsEmit(prefix, qsSortTokens(tokens))
 }
 
 // qsUnique keeps the first token for each distinct name.

--- a/interpreter/function/builtin/querystring_sort.go
+++ b/interpreter/function/builtin/querystring_sort.go
@@ -3,6 +3,8 @@
 package builtin
 
 import (
+	"strings"
+
 	"github.com/ysugimoto/falco/v2/interpreter/context"
 	"github.com/ysugimoto/falco/v2/interpreter/function/errors"
 	"github.com/ysugimoto/falco/v2/interpreter/function/shared"
@@ -10,6 +12,11 @@ import (
 )
 
 const Querystring_sort_Name = "querystring.sort"
+
+// Fastly returns the URL untouched once its query string holds this many
+// parameters, so neither the sort nor only_unique_keys is applied. Empty
+// parameters count toward the limit.
+const Querystring_sort_ParameterLimit = 32
 
 var Querystring_sort_ArgumentTypes = []value.Type{value.StringType, value.BooleanType}
 
@@ -37,6 +44,13 @@ func Querystring_sort(ctx *context.Context, args ...value.Value) (value.Value, e
 	}
 
 	u := value.Unwrap[*value.String](args[0])
+
+	if idx := strings.Index(u.Value, "?"); idx != -1 {
+		if strings.Count(u.Value[idx+1:], "&")+1 >= Querystring_sort_ParameterLimit {
+			return &value.String{Value: u.Value}, nil
+		}
+	}
+
 	query, err := shared.ParseQuery(u.Value)
 	if err != nil {
 		return value.Null, errors.New(

--- a/interpreter/function/builtin/querystring_sort_test.go
+++ b/interpreter/function/builtin/querystring_sort_test.go
@@ -12,30 +12,91 @@ import (
 
 // Fastly built-in function testing implementation of querystring.sort
 // Arguments may be:
+// - STRING, BOOL
 // - STRING
 // Reference: https://developer.fastly.com/reference/vcl/functions/query-string/querystring-sort/
 func Test_Querystring_sort(t *testing.T) {
 	tests := []struct {
-		input  *value.String
+		name   string
+		args   []value.Value
 		expect *value.String
 	}{
-		{input: &value.String{Value: "foo?b=1&a=2"}, expect: &value.String{Value: "foo?a=2&b=1"}},
+		{
+			name:   "sorts parameters by name",
+			args:   []value.Value{&value.String{Value: "foo?b=1&a=2"}},
+			expect: &value.String{Value: "foo?a=2&b=1"},
+		},
+		{
+			name: "only_unique_keys=false behaves like the single argument form",
+			args: []value.Value{
+				&value.String{Value: "foo?b=1&a=2"},
+				&value.Boolean{Value: false},
+			},
+			expect: &value.String{Value: "foo?a=2&b=1"},
+		},
+		{
+			name: "only_unique_keys drops repeated keys",
+			args: []value.Value{
+				&value.String{Value: "/test?a=7&a=2&a=1&b=5&b=3"},
+				&value.Boolean{Value: true},
+			},
+			expect: &value.String{Value: "/test?a=7&b=5"},
+		},
+		{
+			name: "only_unique_keys keeps the first occurrence in input order",
+			args: []value.Value{
+				&value.String{Value: "/foo?a=2&a=1"},
+				&value.Boolean{Value: true},
+			},
+			expect: &value.String{Value: "/foo?a=2"},
+		},
+		{
+			name: "only_unique_keys dedupes before sorting",
+			args: []value.Value{
+				&value.String{Value: "/foo?b=1&a=2&b=3"},
+				&value.Boolean{Value: true},
+			},
+			expect: &value.String{Value: "/foo?a=2&b=1"},
+		},
+		{
+			name: "only_unique_keys collapses repeated valueless parameters",
+			args: []value.Value{
+				&value.String{Value: "/foo?b&b&a=2"},
+				&value.Boolean{Value: true},
+			},
+			expect: &value.String{Value: "/foo?a=2&b"},
+		},
+		{
+			name: "only_unique_keys dedupes the empty key",
+			args: []value.Value{
+				&value.String{Value: "/foo?=1&=2&a=3"},
+				&value.Boolean{Value: true},
+			},
+			expect: &value.String{Value: "/foo?=1&a=3"},
+		},
+		{
+			name: "only_unique_keys is case sensitive",
+			args: []value.Value{
+				&value.String{Value: "/foo?A=1&a=2"},
+				&value.Boolean{Value: true},
+			},
+			expect: &value.String{Value: "/foo?A=1&a=2"},
+		},
 	}
 
-	for i, tt := range tests {
-		ret, err := Querystring_sort(
-			&context.Context{},
-			tt.input,
-		)
-		if err != nil {
-			t.Errorf("[%d] Unexpected error: %s", i, err)
-		}
-		if ret.Type() != value.StringType {
-			t.Errorf("[%d] Unexpected return type, expect=STRING, got=%s", i, ret.Type())
-		}
-		v := value.Unwrap[*value.String](ret)
-		if diff := cmp.Diff(v, tt.expect); diff != "" {
-			t.Errorf("[%d] Return value unmatch, diff: %s", i, diff)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ret, err := Querystring_sort(&context.Context{}, tt.args...)
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
+			if ret.Type() != value.StringType {
+				t.Errorf("Unexpected return type, expect=STRING, got=%s", ret.Type())
+			}
+			v := value.Unwrap[*value.String](ret)
+			if diff := cmp.Diff(v, tt.expect); diff != "" {
+				t.Errorf("Return value unmatch, diff: %s", diff)
+			}
+		})
 	}
 }

--- a/interpreter/function/builtin/querystring_sort_test.go
+++ b/interpreter/function/builtin/querystring_sort_test.go
@@ -42,6 +42,46 @@ func repeatedKeys() string {
 	return "/q?" + strings.Join(tokens, "&")
 }
 
+func Test_qsScan(t *testing.T) {
+	tests := []struct {
+		name   string
+		query  string
+		expect []qsToken
+	}{
+		{
+			name:   "single token is final",
+			query:  "a=1",
+			expect: []qsToken{{s: "a=1", isFinal: true}},
+		},
+		{
+			name:  "only the last token is final",
+			query: "b=1&a=2",
+			expect: []qsToken{
+				{s: "b=1"}, {s: "a=2", isFinal: true},
+			},
+		},
+		{
+			name:  "empty tokens are preserved",
+			query: "a=1&&b=2",
+			expect: []qsToken{
+				{s: "a=1"}, {s: ""}, {s: "b=2", isFinal: true},
+			},
+		},
+		{
+			name:   "empty query yields one empty final token",
+			query:  "",
+			expect: []qsToken{{s: "", isFinal: true}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := cmp.Diff(tt.expect, qsScan(tt.query), cmp.AllowUnexported(qsToken{})); diff != "" {
+				t.Errorf("unmatch: %s", diff)
+			}
+		})
+	}
+}
+
 // Fastly built-in function testing implementation of querystring.sort
 // Arguments may be:
 // - STRING, BOOL
@@ -137,6 +177,61 @@ func Test_Querystring_sort(t *testing.T) {
 			},
 			expect: &value.String{Value: repeatedKeys()},
 		},
+		{
+			name:   "preserves percent-encoding in values",
+			args:   []value.Value{&value.String{Value: "/foo?b=%41&a=1"}},
+			expect: &value.String{Value: "/foo?a=1&b=%41"},
+		},
+		{
+			name:   "preserves percent-encoding in names",
+			args:   []value.Value{&value.String{Value: "/foo?a%20b=1&z=2"}},
+			expect: &value.String{Value: "/foo?a%20b=1&z=2"},
+		},
+		{
+			name:   "does not escape a slash",
+			args:   []value.Value{&value.String{Value: "/foo?b=a/b&a=1"}},
+			expect: &value.String{Value: "/foo?a=1&b=a/b"},
+		},
+		{
+			name:   "leaves a fragment alone",
+			args:   []value.Value{&value.String{Value: "/foo?b=2&a=1#frag"}},
+			expect: &value.String{Value: "/foo?a=1#frag&b=2"},
+		},
+		{
+			name:   "orders by whole token not by name",
+			args:   []value.Value{&value.String{Value: "/foo?b=2&b=1&a=0"}},
+			expect: &value.String{Value: "/foo?a=0&b=1&b=2"},
+		},
+		{
+			name:   "compares values bytewise",
+			args:   []value.Value{&value.String{Value: "/foo?b=9&b=10&a=0"}},
+			expect: &value.String{Value: "/foo?a=0&b=10&b=9"},
+		},
+		{
+			name:   "sorts a high byte before ascii",
+			args:   []value.Value{&value.String{Value: "/q?b=1&\xc3\xa9=2"}},
+			expect: &value.String{Value: "/q?\xc3\xa9=2&b=1"},
+		},
+		{
+			name:   "drops a leading empty token",
+			args:   []value.Value{&value.String{Value: "/foo?a=1&&b=2"}},
+			expect: &value.String{Value: "/foo?a=1&b=2"},
+		},
+		{
+			name:   "keeps an empty token that is not leading",
+			args:   []value.Value{&value.String{Value: "/q?!a=1&&b=2"}},
+			expect: &value.String{Value: "/q?!a=1&&b=2"},
+		},
+		{
+			name:   "leaves a query string with no separator alone",
+			args:   []value.Value{&value.String{Value: "/foo?"}},
+			expect: &value.String{Value: "/foo?"},
+		},
+		{
+			name:   "returns a url with no query string unchanged",
+			args:   []value.Value{&value.String{Value: "/foo"}},
+			expect: &value.String{Value: "/foo"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -151,6 +246,128 @@ func Test_Querystring_sort(t *testing.T) {
 			v := value.Unwrap[*value.String](ret)
 			if diff := cmp.Diff(v, tt.expect); diff != "" {
 				t.Errorf("Return value unmatch, diff: %s", diff)
+			}
+		})
+	}
+}
+
+func Test_qsCompare(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b qsToken
+		want string // "lt", "gt", or "eq"
+	}{
+		{name: "plain ascii", a: qsToken{s: "a=1"}, b: qsToken{s: "b=1"}, want: "lt"},
+		{name: "uppercase before lowercase", a: qsToken{s: "B=1"}, b: qsToken{s: "a=1"}, want: "lt"},
+		{name: "compares whole token not name", a: qsToken{s: "b=1"}, b: qsToken{s: "b=2"}, want: "lt"},
+		{name: "bytewise not numeric", a: qsToken{s: "b=10"}, b: qsToken{s: "b=9"}, want: "lt"},
+		{
+			name: "high byte sorts before ascii",
+			a:    qsToken{s: "\xc3\xa9=2"}, b: qsToken{s: "b=1"}, want: "lt",
+		},
+		{
+			name: "prefix token that is input-final sorts before",
+			a:    qsToken{s: "a", isFinal: true}, b: qsToken{s: "a!b=1"}, want: "lt",
+		},
+		{
+			name: "prefix token that is not input-final sorts after",
+			a:    qsToken{s: "a"}, b: qsToken{s: "a!b=1"}, want: "gt",
+		},
+		{
+			name: "terminators are equivalent",
+			a:    qsToken{s: "a"}, b: qsToken{s: "a", isFinal: true}, want: "eq",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := qsCompare(tt.a, tt.b)
+			switch tt.want {
+			case "lt":
+				if got >= 0 {
+					t.Errorf("expected < 0, got %d", got)
+				}
+			case "gt":
+				if got <= 0 {
+					t.Errorf("expected > 0, got %d", got)
+				}
+			case "eq":
+				if got != 0 {
+					t.Errorf("expected 0, got %d", got)
+				}
+			}
+		})
+	}
+}
+
+func Test_qsSameName(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b qsToken
+		want bool
+	}{
+		{name: "same name different values", a: qsToken{s: "a=1"}, b: qsToken{s: "a=2"}, want: true},
+		{name: "empty value still matches", a: qsToken{s: "a="}, b: qsToken{s: "a=1"}, want: true},
+		{name: "two valueless copies match", a: qsToken{s: "a"}, b: qsToken{s: "a", isFinal: true}, want: true},
+		{name: "valueless does not match valued", a: qsToken{s: "a"}, b: qsToken{s: "a=1"}, want: false},
+		{name: "different names", a: qsToken{s: "ab=1"}, b: qsToken{s: "a=1"}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := qsSameName(tt.a, tt.b); got != tt.want {
+				t.Errorf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+func Test_qsSortTokens_isStable(t *testing.T) {
+	in := []qsToken{{s: "a=2"}, {s: "a=1"}, {s: "a=1", isFinal: true}}
+	got := qsSortTokens(in)
+	want := []qsToken{{s: "a=1"}, {s: "a=1", isFinal: true}, {s: "a=2"}}
+	if diff := cmp.Diff(want, got, cmp.AllowUnexported(qsToken{})); diff != "" {
+		t.Errorf("unmatch: %s", diff)
+	}
+}
+
+// Prefix ordering retains original terminators, so repeated sorting may oscillate.
+func Test_Querystring_sort_isNotIdempotent(t *testing.T) {
+	const first = "/q?a!b=1&a"
+	const second = "/q?a&a!b=1"
+
+	if got := querystringSort(first, false); got != second {
+		t.Errorf("first pass: expected %q, got %q", second, got)
+	}
+	if got := querystringSort(second, false); got != first {
+		t.Errorf("second pass: expected %q, got %q", first, got)
+	}
+}
+
+func Test_qsEmit(t *testing.T) {
+	tests := []struct {
+		name   string
+		tokens []qsToken
+		expect string
+	}{
+		{
+			name:   "drops a leading run of empty tokens",
+			tokens: []qsToken{{s: ""}, {s: "a=1"}, {s: "b=2", isFinal: true}},
+			expect: "/q?a=1&b=2",
+		},
+		{
+			name:   "keeps an empty token that is not leading",
+			tokens: []qsToken{{s: "!a=1"}, {s: ""}, {s: "b=2", isFinal: true}},
+			expect: "/q?!a=1&&b=2",
+		},
+		{
+			name:   "always keeps the last token even when empty",
+			tokens: []qsToken{{s: ""}, {s: ""}, {s: "", isFinal: true}},
+			expect: "/q?",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := qsEmit("/q", tt.tokens); got != tt.expect {
+				t.Errorf("expected %q, got %q", tt.expect, got)
 			}
 		})
 	}

--- a/interpreter/function/builtin/querystring_sort_test.go
+++ b/interpreter/function/builtin/querystring_sort_test.go
@@ -3,12 +3,44 @@
 package builtin
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/ysugimoto/falco/v2/interpreter/context"
 	"github.com/ysugimoto/falco/v2/interpreter/value"
 )
+
+// descendingParams builds "/q?pNN=1&...&p01=1" so that sorting is observable.
+func descendingParams(n int) string {
+	params := make([]string, n)
+	for i := range params {
+		params[i] = fmt.Sprintf("p%02d=1", n-i)
+	}
+	return "/q?" + strings.Join(params, "&")
+}
+
+func ascendingParams(n int) string {
+	params := make([]string, n)
+	for i := range params {
+		params[i] = fmt.Sprintf("p%02d=1", i+1)
+	}
+	return "/q?" + strings.Join(params, "&")
+}
+
+// repeatedKeys builds 33 tokens: three keys repeated eleven times each.
+func repeatedKeys() string {
+	var tokens []string
+	for i := range 11 {
+		tokens = append(tokens,
+			fmt.Sprintf("c=%02d", i*3+1),
+			fmt.Sprintf("b=%02d", i*3+2),
+			fmt.Sprintf("a=%02d", i*3+3),
+		)
+	}
+	return "/q?" + strings.Join(tokens, "&")
+}
 
 // Fastly built-in function testing implementation of querystring.sort
 // Arguments may be:
@@ -81,6 +113,29 @@ func Test_Querystring_sort(t *testing.T) {
 				&value.Boolean{Value: true},
 			},
 			expect: &value.String{Value: "/foo?A=1&a=2"},
+		},
+		{
+			name:   "sorts up to 31 parameters",
+			args:   []value.Value{&value.String{Value: descendingParams(31)}},
+			expect: &value.String{Value: ascendingParams(31)},
+		},
+		{
+			name:   "leaves 32 or more parameters untouched",
+			args:   []value.Value{&value.String{Value: descendingParams(32)}},
+			expect: &value.String{Value: descendingParams(32)},
+		},
+		{
+			name:   "counts empty tokens toward the parameter limit",
+			args:   []value.Value{&value.String{Value: descendingParams(30) + "&&"}},
+			expect: &value.String{Value: descendingParams(30) + "&&"},
+		},
+		{
+			name: "does not apply only_unique_keys over the parameter limit",
+			args: []value.Value{
+				&value.String{Value: repeatedKeys()},
+				&value.Boolean{Value: true},
+			},
+			expect: &value.String{Value: repeatedKeys()},
 		},
 	}
 

--- a/interpreter/function/shared/querystring.go
+++ b/interpreter/function/shared/querystring.go
@@ -19,12 +19,12 @@ type QueryStrings struct {
 }
 
 func ParseQuery(qs string) *QueryStrings {
-	idx := strings.Index(qs, "?")
-	if idx == -1 {
+	prefix, query, found := strings.Cut(qs, "?")
+	if !found {
 		return &QueryStrings{Prefix: qs}
 	}
-	ret := &QueryStrings{Prefix: qs[0:idx]}
-	for _, token := range strings.Split(qs[idx+1:], "&") {
+	ret := &QueryStrings{Prefix: prefix}
+	for token := range strings.SplitSeq(query, "&") {
 		if name, val, found := strings.Cut(token, "="); found {
 			ret.Params = append(ret.Params, Param{Name: name, Value: val, HasValue: true})
 		} else {

--- a/interpreter/function/shared/querystring.go
+++ b/interpreter/function/shared/querystring.go
@@ -2,185 +2,114 @@ package shared
 
 import (
 	"net/url"
-	"sort"
 	"strings"
 )
 
-type QueryString struct {
-	Key   string
-	Value []string // nil indicates not set in VCL
+// Param stores one raw query string parameter.
+type Param struct {
+	Name     string
+	Value    string
+	HasValue bool // distinguishes "a=" from "a"
 }
 
-// We implement original querytring struct in order to maname URL queries keeping its order.
-// url.Values are useful in Golang but Encode() result does not care its order because it is managed in map
-// and always sort by query name. On VCL, we need to keep query raw-order as present, this struct solved them.
+// QueryStrings preserves parameter encoding, order, and duplicates.
 type QueryStrings struct {
-	Prefix string // protocol, host, port, path
-	Items  []*QueryString
+	Prefix string
+	Params []Param
 }
 
-func ParseQuery(qs string) (*QueryStrings, error) {
-	// Find querystring sign
+func ParseQuery(qs string) *QueryStrings {
 	idx := strings.Index(qs, "?")
 	if idx == -1 {
-		return &QueryStrings{Prefix: qs}, nil
+		return &QueryStrings{Prefix: qs}
 	}
-
-	ret := &QueryStrings{
-		Prefix: qs[0:idx],
+	ret := &QueryStrings{Prefix: qs[0:idx]}
+	for _, token := range strings.Split(qs[idx+1:], "&") {
+		if name, val, found := strings.Cut(token, "="); found {
+			ret.Params = append(ret.Params, Param{Name: name, Value: val, HasValue: true})
+		} else {
+			ret.Params = append(ret.Params, Param{Name: name})
+		}
 	}
-	qs = qs[idx+1:]
-	for q := range strings.SplitSeq(qs, "&") {
-		sp := strings.SplitN(q, "=", 2)
-		if len(sp) == 0 {
-			continue
-		}
-		key, err := url.QueryUnescape(sp[0])
-		if err != nil {
-			return nil, err
-		}
-		if len(sp) == 1 {
-			// e.g ?foo -- equal sign is not preset
-			ret.Items = append(ret.Items, &QueryString{Key: key, Value: nil})
-			continue
-		}
-		val, err := url.QueryUnescape(sp[1])
-		if err != nil {
-			return nil, err
-		}
-		ret.Add(key, val)
-	}
-	return ret, nil
+	return ret
 }
 
-func (q *QueryStrings) Set(name, val string) {
-	for i := range q.Items {
-		if q.Items[i].Key != name {
-			continue
-		}
-		q.Items[i].Value = []string{val}
-		return
-	}
-
-	// set new
-	q.Items = append(q.Items, &QueryString{Key: name, Value: []string{val}})
-}
-
+// Add appends an escaped, non-empty name-value pair.
 func (q *QueryStrings) Add(name, val string) {
-	for i := range q.Items {
-		if q.Items[i].Key != name {
-			continue
-		}
-		if q.Items[i].Value == nil {
-			q.Items[i].Value = []string{}
-		}
-		q.Items[i].Value = append(q.Items[i].Value, val)
+	if name == "" || val == "" {
 		return
 	}
-
-	// append new
-	q.Items = append(q.Items, &QueryString{Key: name, Value: []string{val}})
+	q.Params = append(q.Params, Param{Name: Escape(name), Value: Escape(val), HasValue: true})
 }
 
-func (q *QueryStrings) Get(name string) *string {
-	for i := range q.Items {
-		if q.Items[i].Key != name {
+// Set replaces or appends a non-empty pair while removing later duplicates.
+func (q *QueryStrings) Set(name, val string) {
+	if name == "" || val == "" {
+		return
+	}
+	escaped, replaced := Escape(name), false
+	kept := make([]Param, 0, len(q.Params))
+	for _, p := range q.Params {
+		if p.Name != escaped {
+			kept = append(kept, p)
 			continue
 		}
-		if q.Items[i].Value == nil {
-			return nil // nil returns not set string in VCL
+		if !replaced {
+			replaced = true
+			kept = append(kept, Param{Name: escaped, Value: Escape(val), HasValue: true})
 		}
-		return &q.Items[i].Value[0]
 	}
-	return nil
+	q.Params = kept
+	if !replaced {
+		q.Params = append(q.Params, Param{Name: escaped, Value: Escape(val), HasValue: true})
+	}
 }
 
+// Clean removes parameters with empty names.
 func (q *QueryStrings) Clean() {
-	var cleaned []*QueryString
-	for _, v := range q.Items {
-		if v.Key == "" {
+	var cleaned []Param
+	for _, v := range q.Params {
+		if v.Name == "" {
 			continue
 		}
 		cleaned = append(cleaned, v)
 	}
-	q.Items = cleaned
+	q.Params = cleaned
 }
 
-// Unique keeps only the first parameter for each name, which is how Fastly
-// implements the only_unique_keys argument of querystring.sort.
-//
-// A name that carries a value and the same name with no value at all are
-// separate parameters and neither displaces the other, so "b=1&b" keeps both.
-// Two valueless copies of a name are duplicates of each other though, so
-// "b&b" collapses to one.
-func (q *QueryStrings) Unique() {
-	seen := make(map[string]struct{})
-	var unique []*QueryString
-	for _, v := range q.Items {
-		if v.Value == nil {
-			if _, ok := seen[v.Key]; ok {
-				continue
-			}
-			seen[v.Key] = struct{}{}
-		} else if len(v.Value) > 1 {
-			v.Value = v.Value[:1]
-		}
-		unique = append(unique, v)
-	}
-	q.Items = unique
-}
-
-func (q *QueryStrings) Filter(filter func(name string) bool) {
-	var filtered []*QueryString
-	for _, v := range q.Items {
-		if !filter(v.Key) {
+// Filter keeps matching parameters with non-empty raw names.
+func (q *QueryStrings) Filter(keep func(name string) bool) {
+	var filtered []Param
+	for _, v := range q.Params {
+		if v.Name == "" || !keep(v.Name) {
 			continue
 		}
 		filtered = append(filtered, v)
 	}
-	q.Items = filtered
-}
-
-type SortMode string
-
-const (
-	SortAsc  SortMode = "asc"
-	SortDesc SortMode = "desc"
-)
-
-func (q *QueryStrings) Sort(mode SortMode) {
-	sort.Slice(q.Items, func(i, j int) bool {
-		v := q.Items[i].Key > q.Items[j].Key
-		if mode == SortAsc {
-			return !v
-		}
-		return v
-	})
+	q.Params = filtered
 }
 
 func (q *QueryStrings) String() string {
+	if len(q.Params) == 0 {
+		return q.Prefix
+	}
 	var buf strings.Builder
-	for i, v := range q.Items {
-		key := q.Items[i].Key
-		if v.Value == nil {
-			buf.WriteString(key)
-		} else {
-			for j := range v.Value {
-				buf.WriteString(key)
-				buf.WriteString("=")
-				buf.WriteString(url.QueryEscape(v.Value[j]))
-				if j != len(v.Value)-1 {
-					buf.WriteString("&")
-				}
-			}
-		}
-		if i != len(q.Items)-1 {
+	buf.WriteString(q.Prefix)
+	buf.WriteString("?")
+	for i, p := range q.Params {
+		if i > 0 {
 			buf.WriteString("&")
 		}
+		buf.WriteString(p.Name)
+		if p.HasValue {
+			buf.WriteString("=")
+			buf.WriteString(p.Value)
+		}
 	}
-	var sign string
-	if buf.Len() > 0 {
-		sign = "?"
-	}
-	return q.Prefix + sign + buf.String()
+	return buf.String()
+}
+
+// Escape encodes a query component with spaces represented as %20.
+func Escape(s string) string {
+	return strings.ReplaceAll(url.QueryEscape(s), "+", "%20")
 }

--- a/interpreter/function/shared/querystring.go
+++ b/interpreter/function/shared/querystring.go
@@ -106,6 +106,30 @@ func (q *QueryStrings) Clean() {
 	q.Items = cleaned
 }
 
+// Unique keeps only the first parameter for each name, which is how Fastly
+// implements the only_unique_keys argument of querystring.sort.
+//
+// A name that carries a value and the same name with no value at all are
+// separate parameters and neither displaces the other, so "b=1&b" keeps both.
+// Two valueless copies of a name are duplicates of each other though, so
+// "b&b" collapses to one.
+func (q *QueryStrings) Unique() {
+	seen := make(map[string]struct{})
+	var unique []*QueryString
+	for _, v := range q.Items {
+		if v.Value == nil {
+			if _, ok := seen[v.Key]; ok {
+				continue
+			}
+			seen[v.Key] = struct{}{}
+		} else if len(v.Value) > 1 {
+			v.Value = v.Value[:1]
+		}
+		unique = append(unique, v)
+	}
+	q.Items = unique
+}
+
 func (q *QueryStrings) Filter(filter func(name string) bool) {
 	var filtered []*QueryString
 	for _, v := range q.Items {

--- a/interpreter/function/shared/querystring_test.go
+++ b/interpreter/function/shared/querystring_test.go
@@ -234,6 +234,95 @@ func TestQueryStringsClean(t *testing.T) {
 	}
 }
 
+func TestQueryStringsUnique(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect *QueryStrings
+	}{
+		{
+			name:  "keeps the first occurrence of each repeated key",
+			input: "/?a=7&a=2&a=1&b=5&b=3",
+			expect: &QueryStrings{
+				Prefix: "/",
+				Items: []*QueryString{
+					{Key: "a", Value: []string{"7"}},
+					{Key: "b", Value: []string{"5"}},
+				},
+			},
+		},
+		{
+			name:  "leaves already-unique keys untouched",
+			input: "/?b=1&a=2",
+			expect: &QueryStrings{
+				Prefix: "/",
+				Items: []*QueryString{
+					{Key: "b", Value: []string{"1"}},
+					{Key: "a", Value: []string{"2"}},
+				},
+			},
+		},
+		{
+			name:  "a valueless parameter does not collide with a valued one",
+			input: "/?b=1&b&a=2",
+			expect: &QueryStrings{
+				Prefix: "/",
+				Items: []*QueryString{
+					{Key: "b", Value: []string{"1"}},
+					{Key: "b", Value: nil},
+					{Key: "a", Value: []string{"2"}},
+				},
+			},
+		},
+		{
+			name:  "repeated valueless parameters collapse to one",
+			input: "/?b&b&a=2",
+			expect: &QueryStrings{
+				Prefix: "/",
+				Items: []*QueryString{
+					{Key: "b", Value: nil},
+					{Key: "a", Value: []string{"2"}},
+				},
+			},
+		},
+		{
+			name:  "the empty key is deduplicated too",
+			input: "/?=1&=2&a=3",
+			expect: &QueryStrings{
+				Prefix: "/",
+				Items: []*QueryString{
+					{Key: "", Value: []string{"1"}},
+					{Key: "a", Value: []string{"3"}},
+				},
+			},
+		},
+		{
+			name:  "deduplication is case sensitive",
+			input: "/?A=1&a=2",
+			expect: &QueryStrings{
+				Prefix: "/",
+				Items: []*QueryString{
+					{Key: "A", Value: []string{"1"}},
+					{Key: "a", Value: []string{"2"}},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q, err := ParseQuery(tt.input)
+			if err != nil {
+				t.Fatalf("Unexpected parse query error: %s", err.Error())
+			}
+			q.Unique()
+			if diff := cmp.Diff(tt.expect, q); diff != "" {
+				t.Errorf("Result unmatch: diff=: %s", diff)
+			}
+		})
+	}
+}
+
 func TestQueryStringsSort(t *testing.T) {
 	tests := []struct {
 		input  string

--- a/interpreter/function/shared/querystring_test.go
+++ b/interpreter/function/shared/querystring_test.go
@@ -6,373 +6,219 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestQueryStringsParse(t *testing.T) {
-	tests := []struct {
-		input  string
-		expect *QueryStrings
-	}{
-		{
-			input: "/?foo=",
-			expect: &QueryStrings{
-				Prefix: "/",
-				Items: []*QueryString{
-					{
-						Key:   "foo",
-						Value: []string{""},
-					},
-				},
-			},
-		},
-		{
-			input: "/?foo",
-			expect: &QueryStrings{
-				Prefix: "/",
-				Items: []*QueryString{
-					{
-						Key:   "foo",
-						Value: nil,
-					},
-				},
-			},
-		},
-		{
-			input: "/?a=1&b=2&c=3&d=4&b=5",
-			expect: &QueryStrings{
-				Prefix: "/",
-				Items: []*QueryString{
-					{
-						Key:   "a",
-						Value: []string{"1"},
-					},
-					{
-						Key:   "b",
-						Value: []string{"2", "5"},
-					},
-					{
-						Key:   "c",
-						Value: []string{"3"},
-					},
-					{
-						Key:   "d",
-						Value: []string{"4"},
-					},
-				},
-			},
-		},
-	}
-
-	for i, tt := range tests {
-		q, err := ParseQuery(tt.input)
-		if err != nil {
-			t.Errorf("[%d] Unexpected parse query error: %s", i, err.Error())
-		}
-		if diff := cmp.Diff(tt.expect, q); diff != "" {
-			t.Errorf("[%d] Result unmatch: diff=: %s", i, diff)
-		}
-	}
-}
-
-func TestQueryStringsAdd(t *testing.T) {
-	tests := []struct {
-		input  string
-		name   string
-		value  string
-		expect *QueryStrings
-	}{
-		{
-			input: "/?foo",
-			name:  "foo",
-			value: "bar",
-			expect: &QueryStrings{
-				Prefix: "/",
-				Items: []*QueryString{
-					{
-						Key:   "foo",
-						Value: []string{"bar"},
-					},
-				},
-			},
-		},
-		{
-			input: "/?foo=bar",
-			name:  "foo",
-			value: "baz",
-			expect: &QueryStrings{
-				Prefix: "/",
-				Items: []*QueryString{
-					{
-						Key:   "foo",
-						Value: []string{"bar", "baz"},
-					},
-				},
-			},
-		},
-	}
-
-	for i, tt := range tests {
-		q, err := ParseQuery(tt.input)
-		if err != nil {
-			t.Errorf("[%d] Unexpected parse query error: %s", i, err.Error())
-		}
-		q.Add(tt.name, tt.value)
-		if diff := cmp.Diff(tt.expect, q); diff != "" {
-			t.Errorf("[%d] Result unmatch: diff=: %s", i, diff)
-		}
-	}
-}
-
-func TestQueryStringsGet(t *testing.T) {
-	tests := []struct {
-		input  string
-		name   string
-		expect *string
-	}{
-		{
-			input:  "/?foo",
-			name:   "foo",
-			expect: nil,
-		},
-		{
-			input: "/?foo=bar",
-			name:  "foo",
-			expect: func() *string {
-				s := "bar"
-				return &s
-			}(),
-		},
-	}
-
-	for i, tt := range tests {
-		q, err := ParseQuery(tt.input)
-		if err != nil {
-			t.Errorf("[%d] Unexpected parse query error: %s", i, err.Error())
-		}
-		v := q.Get(tt.name)
-		if diff := cmp.Diff(tt.expect, v); diff != "" {
-			t.Errorf("[%d] Result unmatch: diff=: %s", i, diff)
-		}
-	}
-}
-
-func TestQueryStringsSet(t *testing.T) {
-	tests := []struct {
-		input  string
-		name   string
-		value  string
-		expect *QueryStrings
-	}{
-		{
-			input: "/?foo",
-			name:  "foo",
-			value: "bar",
-			expect: &QueryStrings{
-				Prefix: "/",
-				Items: []*QueryString{
-					{
-						Key:   "foo",
-						Value: []string{"bar"},
-					},
-				},
-			},
-		},
-		{
-			input: "/?foo=bar",
-			name:  "foo",
-			value: "baz",
-			expect: &QueryStrings{
-				Prefix: "/",
-				Items: []*QueryString{
-					{
-						Key:   "foo",
-						Value: []string{"baz"},
-					},
-				},
-			},
-		},
-	}
-
-	for i, tt := range tests {
-		q, err := ParseQuery(tt.input)
-		if err != nil {
-			t.Errorf("[%d] Unexpected parse query error: %s", i, err.Error())
-		}
-		q.Set(tt.name, tt.value)
-		if diff := cmp.Diff(tt.expect, q); diff != "" {
-			t.Errorf("[%d] Result unmatch: diff=: %s", i, diff)
-		}
-	}
-}
-
-func TestQueryStringsClean(t *testing.T) {
-	tests := []struct {
-		input  string
-		expect *QueryStrings
-	}{
-		{
-			input: "/?foo=bar&&=value-only",
-			expect: &QueryStrings{
-				Prefix: "/",
-				Items: []*QueryString{
-					{
-						Key:   "foo",
-						Value: []string{"bar"},
-					},
-				},
-			},
-		},
-	}
-
-	for i, tt := range tests {
-		q, err := ParseQuery(tt.input)
-		if err != nil {
-			t.Errorf("[%d] Unexpected parse query error: %s", i, err.Error())
-		}
-		q.Clean()
-		if diff := cmp.Diff(tt.expect, q); diff != "" {
-			t.Errorf("[%d] Result unmatch: diff=: %s", i, diff)
-		}
-	}
-}
-
-func TestQueryStringsUnique(t *testing.T) {
+func TestParseQuery(t *testing.T) {
 	tests := []struct {
 		name   string
 		input  string
 		expect *QueryStrings
 	}{
 		{
-			name:  "keeps the first occurrence of each repeated key",
-			input: "/?a=7&a=2&a=1&b=5&b=3",
-			expect: &QueryStrings{
-				Prefix: "/",
-				Items: []*QueryString{
-					{Key: "a", Value: []string{"7"}},
-					{Key: "b", Value: []string{"5"}},
-				},
-			},
+			name:   "no query string",
+			input:  "/foo",
+			expect: &QueryStrings{Prefix: "/foo"},
 		},
 		{
-			name:  "leaves already-unique keys untouched",
-			input: "/?b=1&a=2",
-			expect: &QueryStrings{
-				Prefix: "/",
-				Items: []*QueryString{
-					{Key: "b", Value: []string{"1"}},
-					{Key: "a", Value: []string{"2"}},
-				},
-			},
+			name:  "a bare question mark yields one empty parameter",
+			input: "/foo?",
+			expect: &QueryStrings{Prefix: "/foo", Params: []Param{
+				{Name: ""},
+			}},
 		},
 		{
-			name:  "a valueless parameter does not collide with a valued one",
-			input: "/?b=1&b&a=2",
-			expect: &QueryStrings{
-				Prefix: "/",
-				Items: []*QueryString{
-					{Key: "b", Value: []string{"1"}},
-					{Key: "b", Value: nil},
-					{Key: "a", Value: []string{"2"}},
-				},
-			},
+			name:  "distinguishes empty value from no value",
+			input: "/?a=&b",
+			expect: &QueryStrings{Prefix: "/", Params: []Param{
+				{Name: "a", Value: "", HasValue: true},
+				{Name: "b"},
+			}},
 		},
 		{
-			name:  "repeated valueless parameters collapse to one",
-			input: "/?b&b&a=2",
-			expect: &QueryStrings{
-				Prefix: "/",
-				Items: []*QueryString{
-					{Key: "b", Value: nil},
-					{Key: "a", Value: []string{"2"}},
-				},
-			},
+			name:  "keeps duplicates in place",
+			input: "/?b=1&a=2&b=3",
+			expect: &QueryStrings{Prefix: "/", Params: []Param{
+				{Name: "b", Value: "1", HasValue: true},
+				{Name: "a", Value: "2", HasValue: true},
+				{Name: "b", Value: "3", HasValue: true},
+			}},
 		},
 		{
-			name:  "the empty key is deduplicated too",
-			input: "/?=1&=2&a=3",
-			expect: &QueryStrings{
-				Prefix: "/",
-				Items: []*QueryString{
-					{Key: "", Value: []string{"1"}},
-					{Key: "a", Value: []string{"3"}},
-				},
-			},
+			name:  "never decodes",
+			input: "/?a%20b=x%20y&c=p/q",
+			expect: &QueryStrings{Prefix: "/", Params: []Param{
+				{Name: "a%20b", Value: "x%20y", HasValue: true},
+				{Name: "c", Value: "p/q", HasValue: true},
+			}},
 		},
 		{
-			name:  "deduplication is case sensitive",
-			input: "/?A=1&a=2",
-			expect: &QueryStrings{
-				Prefix: "/",
-				Items: []*QueryString{
-					{Key: "A", Value: []string{"1"}},
-					{Key: "a", Value: []string{"2"}},
-				},
-			},
+			name:  "keeps a valueless duplicate distinct from a valued one",
+			input: "/?b&b=1",
+			expect: &QueryStrings{Prefix: "/", Params: []Param{
+				{Name: "b"},
+				{Name: "b", Value: "1", HasValue: true},
+			}},
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			q, err := ParseQuery(tt.input)
-			if err != nil {
-				t.Fatalf("Unexpected parse query error: %s", err.Error())
-			}
-			q.Unique()
-			if diff := cmp.Diff(tt.expect, q); diff != "" {
-				t.Errorf("Result unmatch: diff=: %s", diff)
+			if diff := cmp.Diff(tt.expect, ParseQuery(tt.input)); diff != "" {
+				t.Errorf("unmatch: %s", diff)
 			}
 		})
 	}
 }
 
-func TestQueryStringsSort(t *testing.T) {
+func TestQueryStringsString(t *testing.T) {
 	tests := []struct {
+		name   string
 		input  string
-		mode   SortMode
-		expect *QueryStrings
+		expect string
+	}{
+		{name: "round trips encoding", input: "/?a=%41&b=x%20y", expect: "/?a=%41&b=x%20y"},
+		{name: "round trips duplicate order", input: "/?b=1&a=2&b=3", expect: "/?b=1&a=2&b=3"},
+		{name: "round trips a valueless parameter", input: "/?a&b=1", expect: "/?a&b=1"},
+		{name: "round trips a bare question mark", input: "/foo?", expect: "/foo?"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ParseQuery(tt.input).String(); got != tt.expect {
+				t.Errorf("expected %q, got %q", tt.expect, got)
+			}
+		})
+	}
+}
+
+func TestQueryStringsAdd(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		key, value string
+		expect     string
+	}{
+		{name: "escapes a space as %20", input: "/q?x=1", key: "y", value: "a b", expect: "/q?x=1&y=a%20b"},
+		{name: "escapes the name too", input: "/q?x=1", key: "a b", value: "v", expect: "/q?x=1&a%20b=v"},
+		{name: "escapes a slash", input: "/q?x=1", key: "y", value: "a/b", expect: "/q?x=1&y=a%2Fb"},
+		{name: "double encodes a percent", input: "/q?x=1", key: "y", value: "%41", expect: "/q?x=1&y=%2541"},
+		{name: "is a no-op for an empty value", input: "/q?x=1", key: "y", value: "", expect: "/q?x=1"},
+		{name: "is a no-op for an empty name", input: "/q?x=1", key: "", value: "v", expect: "/q?x=1"},
+		{name: "never deduplicates", input: "/q?x=1", key: "x", value: "2", expect: "/q?x=1&x=2"},
+		{name: "appends after a bare question mark", input: "/q?", key: "y", value: "v", expect: "/q?&y=v"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := ParseQuery(tt.input)
+			q.Add(tt.key, tt.value)
+			if got := q.String(); got != tt.expect {
+				t.Errorf("expected %q, got %q", tt.expect, got)
+			}
+		})
+	}
+}
+
+func TestQueryStringsSet(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		key, value string
+		expect     string
+	}{
+		{name: "replaces in place and drops later duplicates", input: "/q?a=1&b=2&a=3", key: "a", value: "9", expect: "/q?a=9&b=2"},
+		{name: "appends when absent", input: "/q?b=2", key: "a", value: "9", expect: "/q?b=2&a=9"},
+		{name: "escapes a space as %20", input: "/q?x=1", key: "x", value: "a b", expect: "/q?x=a%20b"},
+		{name: "escapes the name too", input: "/q?x=1", key: "a b", value: "v", expect: "/q?x=1&a%20b=v"},
+		{name: "is a no-op for an empty value", input: "/q?x=1", key: "x", value: "", expect: "/q?x=1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := ParseQuery(tt.input)
+			q.Set(tt.key, tt.value)
+			if got := q.String(); got != tt.expect {
+				t.Errorf("expected %q, got %q", tt.expect, got)
+			}
+		})
+	}
+}
+
+func TestQueryStringsClean(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect string
+	}{
+		{name: "removes empty-named parameters", input: "/q?a=1&&b=2&=v", expect: "/q?a=1&b=2"},
+		{name: "keeps valueless parameters", input: "/q?a&b=1", expect: "/q?a&b=1"},
+		{name: "keeps duplicates in place", input: "/q?b=1&a=2&b=3", expect: "/q?b=1&a=2&b=3"},
+		{name: "preserves encoding", input: "/q?a=%41&b=x%20y&c=p/q", expect: "/q?a=%41&b=x%20y&c=p/q"},
+		{name: "a bare question mark yields no query string", input: "/foo?", expect: "/foo"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := ParseQuery(tt.input)
+			q.Clean()
+			if got := q.String(); got != tt.expect {
+				t.Errorf("expected %q, got %q", tt.expect, got)
+			}
+		})
+	}
+}
+
+func TestQueryStringsFilter(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		keep   func(string) bool
+		expect string
 	}{
 		{
-			input: "/?a=b&c=d",
-			mode:  SortDesc,
-			expect: &QueryStrings{
-				Prefix: "/",
-				Items: []*QueryString{
-					{
-						Key:   "c",
-						Value: []string{"d"},
-					},
-					{
-						Key:   "a",
-						Value: []string{"b"},
-					},
-				},
-			},
+			name:   "keeps duplicates in place",
+			input:  "/q?b=1&a=2&b=3",
+			keep:   func(n string) bool { return n != "a" },
+			expect: "/q?b=1&b=3",
 		},
 		{
-			input: "/?c=d&a=b",
-			mode:  SortAsc,
-			expect: &QueryStrings{
-				Prefix: "/",
-				Items: []*QueryString{
-					{
-						Key:   "a",
-						Value: []string{"b"},
-					},
-					{
-						Key:   "c",
-						Value: []string{"d"},
-					},
-				},
-			},
+			name:   "preserves encoding",
+			input:  "/q?a=%41&b=2",
+			keep:   func(n string) bool { return n != "b" },
+			expect: "/q?a=%41",
+		},
+		{
+			name:   "matches the raw encoded name",
+			input:  "/q?a%20b=1&c=2",
+			keep:   func(n string) bool { return n == "a%20b" },
+			expect: "/q?a%20b=1",
+		},
+		{
+			name:   "drops empty-named parameters regardless of the predicate",
+			input:  "/q?=v&a=1",
+			keep:   func(n string) bool { return true },
+			expect: "/q?a=1",
 		},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := ParseQuery(tt.input)
+			q.Filter(tt.keep)
+			if got := q.String(); got != tt.expect {
+				t.Errorf("expected %q, got %q", tt.expect, got)
+			}
+		})
+	}
+}
 
-	for i, tt := range tests {
-		q, err := ParseQuery(tt.input)
-		if err != nil {
-			t.Errorf("[%d] Unexpected parse query error: %s", i, err.Error())
-		}
-		q.Sort(tt.mode)
-		if diff := cmp.Diff(tt.expect, q); diff != "" {
-			t.Errorf("[%d] Result unmatch: diff=: %s", i, diff)
-		}
+func TestEscape(t *testing.T) {
+	tests := []struct {
+		name     string
+		in, want string
+	}{
+		{name: "space becomes %20 not plus", in: "a b", want: "a%20b"},
+		{name: "slash is escaped", in: "a/b", want: "a%2Fb"},
+		{name: "percent is escaped", in: "%41", want: "%2541"},
+		{name: "unreserved characters pass through", in: "aZ0-._~", want: "aZ0-._~"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Escape(tt.in); got != tt.want {
+				t.Errorf("expected %q, got %q", tt.want, got)
+			}
+		})
 	}
 }

--- a/linter/context/builtin.go
+++ b/linter/context/builtin.go
@@ -1304,6 +1304,7 @@ func builtinFunctions() Functions {
 					Value: &BuiltinFunction{
 						Return: types.StringType,
 						Arguments: [][]types.Type{
+							[]types.Type{types.StringType, types.BoolType},
 							[]types.Type{types.StringType},
 						},
 						Scopes:    RECV | HASH | HIT | MISS | PASS | FETCH | ERROR | DELIVER | LOG,


### PR DESCRIPTION
- add support for `querystring.sort(..., only_unique_keys)`
- preserve raw encoding, parameter order, duplicates, and valueless parameters
- align sorting, filtering, cleaning, add, and set behavior
- enforce the 32-parameter processing limit
- add regression coverage for query string edge cases
- semantics verified against Fastly Fiddle