### PR TITLE
fix: parse IPv4 and IPv6 addresses for client.ip correctly

### DIFF
--- a/interpreter/variable/all.go
+++ b/interpreter/variable/all.go
@@ -535,11 +535,11 @@ func (v *AllScopeVariables) Get(s context.Scope, name string) (value.Value, erro
 		}
 		if v.ctx.ClientIdentity == nil {
 			// default as client.ip
-			idx := strings.LastIndex(req.RemoteAddr, ":")
-			if idx == -1 {
+			host, _, err := net.SplitHostPort(req.RemoteAddr)
+			if err != nil {
 				return &value.String{Value: req.RemoteAddr}, nil
 			}
-			return &value.String{Value: req.RemoteAddr[:idx]}, nil
+			return &value.String{Value: host}, nil
 		}
 		return v.ctx.ClientIdentity, nil
 
@@ -547,11 +547,11 @@ func (v *AllScopeVariables) Get(s context.Scope, name string) (value.Value, erro
 		if v := lookupOverrideAsIP(v.ctx, name); v != nil {
 			return v, nil
 		}
-		idx := strings.LastIndex(req.RemoteAddr, ":")
-		if idx == -1 {
+		host, _, err := net.SplitHostPort(req.RemoteAddr)
+		if err != nil {
 			return &value.IP{Value: net.ParseIP(req.RemoteAddr)}, nil
 		}
-		return &value.IP{Value: net.ParseIP(req.RemoteAddr[:idx])}, nil
+		return &value.IP{Value: net.ParseIP(host)}, nil
 
 	case CLIENT_OS_NAME:
 		if v := lookupOverride(v.ctx, name); v != nil {

--- a/interpreter/variable/all_test.go
+++ b/interpreter/variable/all_test.go
@@ -1,6 +1,7 @@
 package variable
 
 import (
+	"net"
 	ghttp "net/http"
 	"net/url"
 	"sync/atomic"
@@ -538,6 +539,64 @@ func TestGetFromRegex(t *testing.T) {
 			}
 			if diff := cmp.Diff(val, tt.expect); diff != "" {
 				t.Errorf("Return value unmatch, diff: %s", diff)
+			}
+		})
+	}
+}
+
+func TestClientIPFromRemoteAddr(t *testing.T) {
+	tests := []struct {
+		input  string
+		expect net.IP
+	}{
+		{input: "192.0.2.1:12345", expect: net.ParseIP("192.0.2.1")},
+		{input: "[2001:db8::1]:12345", expect: net.ParseIP("2001:db8::1")},
+		{input: "192.0.2.1", expect: net.ParseIP("192.0.2.1")},
+		{input: "2001:db8::1", expect: net.ParseIP("2001:db8::1")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			vars := NewAllScopeVariables(&context.Context{
+				Request: http.WrapRequest(&ghttp.Request{
+					RemoteAddr: tt.input,
+				}),
+			})
+			result, err := vars.Get(context.RecvScope, CLIENT_IP)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			ip := value.Unwrap[*value.IP](result)
+			if !ip.Value.Equal(tt.expect) {
+				t.Fatalf("expected %v, got %v", tt.expect, ip.Value)
+			}
+		})
+	}
+}
+
+func TestClientIdentityFromRemoteAddr(t *testing.T) {
+	tests := []struct {
+		input  string
+		expect string
+	}{
+		{input: "192.0.2.1:12345", expect: "192.0.2.1"},
+		{input: "[2001:db8::1]:12345", expect: "2001:db8::1"},
+		{input: "192.0.2.1", expect: "192.0.2.1"},
+		{input: "2001:db8::1", expect: "2001:db8::1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			vars := NewAllScopeVariables(&context.Context{
+				Request: http.WrapRequest(&ghttp.Request{
+					RemoteAddr: tt.input,
+				}),
+			})
+			result, err := vars.Get(context.RecvScope, CLIENT_IDENTITY)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			identity := value.Unwrap[*value.String](result)
+			if identity.Value != tt.expect {
+				t.Fatalf("expected %q, got %q", tt.expect, identity.Value)
 			}
 		})
 	}


### PR DESCRIPTION
# Summary

Fix an issue where `client.ip` returned `nil` when the simulator received a request from an IPv6 client.

# Background

In the simulator, `client.ip` is determined from the client address in `RemoteAddr`.
For IPv6 connections, `RemoteAddr` uses a bracketed format such as `[2001:db8::1]:12345`.

The previous implementation split the address at the last `:`, so it could not correctly parse IPv6 addresses.

# Changes

- Use `net.SplitHostPort` to extract the host portion from `RemoteAddr`
- Support IPv4 and IPv6 values for `client.ip`
- Apply the same parsing logic to `client.identity`
- Add regression tests covering IPv4, IPv6, and addresses with and without ports

# Tests

The following test command passes:

```text
go test ./interpreter/variable
```

# Scope of Impact

Only the way `client.ip` and `client.identity` are resolved in the simulator is changed.
The default values in testing and console modes are not affected.
