### PR TITLE
Add fmt error-on-unformatted option

### DIFF
--- a/cmd/falco/help.go
+++ b/cmd/falco/help.go
@@ -215,8 +215,9 @@ Usage:
     falco fmt [flags] ...files
 
 Flags:
-    -h, --help         : Show this help
-    -w, --write        : Overwrite format result
+    -h, --help                 : Show this help
+    -x, --error-on-unformatted : Return a non zero exit code if formatting is required
+    -w, --write                : Overwrite format result
 
 files argument accepts glob file patterns
 

--- a/cmd/falco/runner.go
+++ b/cmd/falco/runner.go
@@ -561,6 +561,18 @@ func (r *Runner) Format(rslv resolver.Resolver) error {
 
 	formatted := formatter.New(r.config.Format).Format(vcl)
 	var w io.Writer
+	if r.config.Format.ErrorOnUnformatted {
+		formatted_buf := new(strings.Builder)
+		_, err := io.Copy(formatted_buf, formatted)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		formatted_string := formatted_buf.String()
+		if main.Data != formatted_string {
+			return errors.WithStack(fmt.Errorf("%s requires formatting", main.Name))
+		}
+		formatted = strings.NewReader(formatted_string)
+	}
 	if r.config.Format.Overwrite {
 		writeln(cyan, "Formatted %s.", main.Name)
 		fp, err := os.OpenFile(main.Name, os.O_TRUNC|os.O_WRONLY, 0o644)

--- a/config/config.go
+++ b/config/config.go
@@ -99,7 +99,8 @@ type ConsoleConfig struct {
 // Format configuration
 type FormatConfig struct {
 	// CLI options
-	Overwrite bool `cli:"w,write" default:"false"`
+	Overwrite          bool `cli:"w,write" default:"false"`
+	ErrorOnUnformatted bool `cli:"x,error-on-unformatted" default:"false"`
 
 	// Formatter options
 	IndentWidth                int    `yaml:"indent_width" default:"2"`

--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -18,8 +18,9 @@ Usage:
     falco fmt [flags] ...files
 
 Flags:
-    -h, --help         : Show this help
-    -w, --write        : Overwrite format result
+    -h, --help                 : Show this help
+    -x, --error-on-unformatted : Return a non zero exit code if formatting is required
+    -w, --write                : Overwrite format result
 
 files argument accepts glob file patterns
 


### PR DESCRIPTION
Closes https://github.com/ysugimoto/falco/issues/647

This makes falco easier to use in CI scripts, where you're interested if the changed code meets the conventions.